### PR TITLE
Move Fava to beancount/fava

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ gh-pages:
 	touch .nojekyll
 	git add -A
 	git commit -m 'Update gh-pages'
-	git push --force git@github.com:aumayr/fava.git gh-pages:gh-pages
+	git push --force git@github.com:beancount/fava.git gh-pages:gh-pages
 	git checkout master
 	git branch -D gh-pages
 

--- a/README.rst
+++ b/README.rst
@@ -1,21 +1,21 @@
-.. image:: https://badges.gitter.im/aumayr/fava.svg
-   :alt: Join the chat at https://gitter.im/aumayr/fava
-   :target: https://gitter.im/aumayr/fava
+.. image:: https://badges.gitter.im/beancount/fava.svg
+   :alt: Join the chat at https://gitter.im/beancount/fava
+   :target: https://gitter.im/beancount/fava
 .. image:: https://img.shields.io/pypi/l/beancount-fava.svg
    :target: https://pypi.python.org/pypi/beancount-fava
 .. image:: https://img.shields.io/pypi/v/beancount-fava.svg
    :target: https://pypi.python.org/pypi/beancount-fava
-.. image:: https://img.shields.io/travis/aumayr/fava.svg
-   :target: https://travis-ci.org/aumayr/fava?branch=master
+.. image:: https://img.shields.io/travis/beancount/fava.svg
+   :target: https://travis-ci.org/beancount/fava?branch=master
 
 Fava is a web interface for the double-entry bookkeeping software `beancount
 <http://furius.ca/beancount/>`__ with a focus on features and usability.
 
 Check out the online `demo <http://fava.pythonanywhere.com>`__ and learn more
-about Fava on the `Web Site <https://aumayr.github.io/fava/>`__.
+about Fava on the `Web Site <https://beancount.github.io/fava/>`__.
 
 The `Getting Started
-<https://aumayr.github.io/fava/usage.html>`__ guide details the installation
+<https://beancount.github.io/fava/usage.html>`__ guide details the installation
 and how to get started with beancount.  If you are already familiar with
 beancount, you can get started with Fava::
 
@@ -26,5 +26,5 @@ and visit the web interface at `http://localhost:5000
 <http://localhost:5000>`__.
 
 If you want to hack on Fava or run a development version, see the
-`Development <https://aumayr.github.io/fava/development.html>`__ page on the
+`Development <https://beancount.github.io/fava/development.html>`__ page on the
 website for details. Contributions are very welcome!

--- a/contrib/creating_a_release.md
+++ b/contrib/creating_a_release.md
@@ -1,7 +1,7 @@
 # Steps to create a release
 
 1. Compare changes to last release, eg.
-   https://github.com/aumayr/fava/compare/v0.2.2...master
+   https://github.com/beancount/fava/compare/v0.2.2...master
 3. Update `CHANGES`
 4. Update `README.rst` (search and replace old version number)
 5. Update `AUTHORS`

--- a/contrib/pythonanywhere/README.md
+++ b/contrib/pythonanywhere/README.md
@@ -7,7 +7,7 @@
   current version available on PyPI (`pip3 install beancount-fava`)
 - [favadev.pythonanywhere.com](http://favadev.pythonanywhere.com), which
   tracks the HEAD of the Github repo
-  ([github.com/aumayr/fava](http://github.com/aumayr/fava))
+  ([github.com/beancount/fava](http://github.com/beancount/fava))
 
 There are four parts to both instances:
 1. '/home/$USER/update.sh' does install `fava` and all dependencies and

--- a/contrib/pythonanywhere/favadev/update.sh
+++ b/contrib/pythonanywhere/favadev/update.sh
@@ -24,7 +24,7 @@ cp ~/fava/fava/default-settings.conf /home/favadev/
 
 # Generate fresh example
 date=`date +%Y-%m-%d`
-site='github.com/aumayr/fava'
+site='github.com/beancount/fava'
 name="option \"title\" \"Example beancount-fava @ $version ($date) [$site]\""
 bean-example | sed "7s#.*#$name#" > test.bean
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,7 +14,7 @@ exclude_patterns = ['_build']
 pygments_style = 'sphinx'
 
 extlinks = {
-    'bug': ('https://github.com/aumayr/fava/issues/%s', '#'),
+    'bug': ('https://github.com/beancount/fava/issues/%s', '#'),
     'user': ('https://github.com/%s', '@'),
 }
 
@@ -27,13 +27,13 @@ html_theme_options = {
     'logo_text_align': 'center',
     'description': """Web interface for <a href=\"http://furius.ca/beancount/\"
 title=\"Double-entry bookkeeping software Beancount\">Beancount</a>""",
-    'github_user': 'aumayr',
+    'github_user': 'beancount',
     'github_repo': 'fava',
     'github_button': 'false',
     'show_powered_by': 'false',
     'extra_nav_links': {
-        "fava @ Github": 'https://github.com/aumayr/fava',
-        "Issue Tracker": 'https://github.com/aumayr/fava/issues',
+        "fava @ Github": 'https://github.com/beancount/fava',
+        "Issue Tracker": 'https://github.com/beancount/fava/issues',
     },
     'link': '#3572b0',
     'link_hover': '#1A2F59',

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -6,7 +6,7 @@ get you up and running:
 
 .. code:: bash
 
-    git clone https://github.com/aumayr/fava.git
+    git clone https://github.com/beancount/fava.git
     cd fava
     # using a virtual environment is optional, but recommended
     virtualenv -p python3 venv
@@ -33,7 +33,7 @@ run from source like so (more details `here <http://furius.ca/beancount/doc/inst
     pip install --editable .
 
 Contributions are very welcome, just open a PR on `Github
-<https://github.com/aumayr/fava/pulls>`__.
+<https://github.com/beancount/fava/pulls>`__.
 
 Fava is released under the `MIT License
-<https://github.com/aumayr/fava/blob/master/LICENSE>`__.
+<https://github.com/beancount/fava/blob/master/LICENSE>`__.

--- a/fava/docs/_index.md
+++ b/fava/docs/_index.md
@@ -6,12 +6,12 @@ Welcome to the help pages for Fava:
 - [Running Fava]({{ url_for('help_page', page_slug='running_fava') }}) - available command-line options.
 
 If you discover bug in Fava, or have some ideas for improvement, please open a
-[bug report](https://github.com/aumayr/fava/issues).
+[bug report](https://github.com/beancount/fava/issues).
 
 ### Related websites
 
-- Fava [Website](https://aumayr.github.io/fava/),
-- Fava [Bug Tracker](https://github.com/aumayr/fava/issues),
+- Fava [Website](https://beancount.github.io/fava/),
+- Fava [Bug Tracker](https://github.com/beancount/fava/issues),
 - Beancount [Documentation](http://furius.ca/beancount/doc/index),
 - Beancount [Mailing list](https://groups.google.com/forum/#!forum/beancount),
 - Beancount [Bug Tracker](https://bitbucket.org/blais/beancount/issues?status=new&status=open),

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     version=version,
     description=('A rich web interface for the CL-accounting tool beancount.'),
     long_description=_read('README.rst'),
-    url='https://aumayr.github.io/fava/',
+    url='https://beancount.github.io/fava/',
     author='Dominik Aumayr',
     author_email='dominik@aumayr.name',
     license='MIT',


### PR DESCRIPTION
This PR tracks all changes neccessary before moving to https://github.com/beancount/fava (see #383)

Before moving, I want to collect the things that have to be changed:

- [X] https://aumayr.github.io/fava => https://beancount.github.io/fava
- [X] Update scripts for pythonanywhere.com
- [X] Help and docs
- [x] Move over the repo (https://help.github.com/articles/about-repository-transfers/)

Please comment if I missed something.