### PR TITLE
Document upload: Invoices

### DIFF
--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -1,0 +1,31 @@
+FROM python:3.5.1-alpine
+
+ENV BEANCOUNT_INPUT_FILE ""
+ENV FAVA_OPTIONS "-H 0.0.0.0"
+ENV FINGERPRINT "3f:d3:c5:17:23:3c:cd:f5:2d:17:76:06:93:7e:ee:97:42:21:14:aa"
+ENV BUILDDEPS "libxml2-dev libxslt-dev gcc musl-dev mercurial git nodejs make g++"
+ENV RUNDEPS "libxml2 libxslt"
+
+RUN cd /root \
+        && apk add --update $BUILDDEPS $RUNDEPS \
+        && hg clone --config hostfingerprints.bitbucket.org=$FINGERPRINT https://bitbucket.org/blais/beancount \
+        && (cd beancount && hg log -l1) \
+        && python3 -mpip install ./beancount \
+        && git clone https://github.com/aumayr/fava.git \
+        && (cd fava && git log -1) \
+        && make -C fava \
+        && make -C fava clean \
+        && rm fava/CHANGES \
+        && python3 -mpip install ./fava \
+        && python3 -mpip uninstall --yes pip \
+        && find /usr/local/lib/python3.5/site-packages -name *.so -print0|xargs -0 strip -v \
+        && apk del $BUILDDEPS \
+        && rm -rf /var/cache/apk /tmp /root \
+        && find /usr/local/lib/python3.5 -name __pycache__ -print0|xargs -0 rm -rf \
+        && find /usr/local/lib/python3.5 -name *.pyc -print0|xargs -0 rm -f
+
+
+# Default fava port number
+EXPOSE 5000
+
+CMD fava $FAVA_OPTIONS $BEANCOUNT_INPUT_FILE

--- a/fava/api/__init__.py
+++ b/fava/api/__init__.py
@@ -428,5 +428,5 @@ class BeancountReportAPI():
     def entries_for_link(self, link):
         """Entries with the specified link."""
         return [entry for entry in self.entries
-                if isinstance(entry, (Transaction, Document)) and \
+                if isinstance(entry, (Transaction, Document)) and
                 entry.links and link in entry.links]

--- a/fava/api/__init__.py
+++ b/fava/api/__init__.py
@@ -424,3 +424,9 @@ class BeancountReportAPI():
             if isinstance(posting, Open):
                 return posting.meta
         return {}
+
+    def entries_for_link(self, link):
+        """Entries with the specified link."""
+        return [entry for entry in self.entries
+                if isinstance(entry, (Transaction, Document)) and \
+                entry.links and link in entry.links]

--- a/fava/application.py
+++ b/fava/application.py
@@ -226,6 +226,7 @@ def query():
 def journal_link(link):
     return render_template('journal.html', link=link)
 
+
 @app.route('/<bfile>/<report_name>/')
 def report(report_name):
     if report_name in REPORTS:

--- a/fava/application.py
+++ b/fava/application.py
@@ -222,6 +222,10 @@ def query():
     return render_template('query.html', result_types=types, result_rows=rows)
 
 
+@app.route('/<bfile>/journal/<link>/')
+def journal_link(link):
+    return render_template('journal.html', link=link)
+
 @app.route('/<bfile>/<report_name>/')
 def report(report_name):
     if report_name in REPORTS:

--- a/fava/plugins/statements_from_metadata.py
+++ b/fava/plugins/statements_from_metadata.py
@@ -10,62 +10,69 @@ import collections
 from os.path import join, dirname, isfile
 from beancount.core import data
 
-StatementDocumentError = collections.namedtuple('StatementDocumentError', 'source message entry')
+StatementDocumentError = collections.namedtuple('StatementDocumentError',
+                                                'source message entry')
 
 __plugins__ = ['statements_from_metadata']
+
 
 def statements_from_metadata(entries, options_map):
     errors = []
     key = 'statement'
 
-    if not 'documents' in options_map or len(options_map['documents']) == 0:
+    if 'documents' not in options_map or len(options_map['documents']) == 0:
         return entries, errors
 
     def filenames(date, name):
-        return [name, '{} {}'.format(date, name), '{}.{}'.format(date, name)]
+        d_str = date.strftime("%Y-%m-%d")
+        return [name, '{} {}'.format(d_str, name), '{}.{}'.format(d_str, name)]
 
     for entry in entries:
         type = entry.__class__.__name__.lower()
-        if type == 'transaction':
-            possible_paths = []  # set of tuples (account, path)
-            date = entry.date.strftime("%Y-%m-%d")
 
-            for documents_root in options_map['documents']:
-                # If the `statement` metadata key is set on the transaction, assume it belongs to the first posting
-                if key in entry.meta:
-                    posting = entry.postings[0]
-                    account = posting.account.replace(':', '/')
-                    for filename in filenames(date, entry.meta[key]):
-                        possible_paths.append((posting.account, join(dirname(options_map['filename']), filename)))
-                        possible_paths.append((posting.account, join(dirname(options_map['filename']), documents_root, filename)))
-                        possible_paths.append((posting.account, join(dirname(options_map['filename']), documents_root, account, filename)))
+        if type != 'transaction':
+            continue
 
-                # Check if the `statement` metadata key is set on one of the postings
-                for posting in entry.postings:
-                    if posting.meta and key in posting.meta:
-                        account = posting.account.replace(':', '/')
-                        for filename in filenames(date, posting.meta[key]):
-                            possible_paths.append((posting.account, join(dirname(options_map['filename']), filename)))
-                            possible_paths.append((posting.account, join(dirname(options_map['filename']), documents_root, filename)))
-                            possible_paths.append((posting.account, join(dirname(options_map['filename']), documents_root, account, filename)))
+        paths = []  # set of tuples (account, path)
+        b_dir = dirname(options_map['filename'])
 
-            if len(possible_paths) == 0:
-                continue
+        for documents in options_map['documents']:
+            statements = []
 
-            found = False
-            for account, path in possible_paths:
-                if isfile(path):
-                    # TODO link the Document entry with the Transaction
-                    meta = data.new_metadata('<fava_statements_plugin>', 0)
-                    entries.append(data.Document(meta, entry.date, account, path))
-                    found = True
+            # If the `statement` metadata key is set on the transaction, assume
+            # it belongs to the first posting
+            if key in entry.meta:
+                statements.append((entry.meta[key], entry.postings[0].account))
 
-            if not found:
-                errors.append(
-                    StatementDocumentError(
-                        entry.meta,
-                        "Statement document not found. Search paths: {}".format(
-                            ', '.join([path for _, path in possible_paths])),
-                        entry))
+            for posting in entry.postings:
+                if posting.meta and key in posting.meta:
+                    statements.append((posting.meta[key], posting.account))
+
+            for path, account in statements:
+                account_path = account.replace(':', '/')
+                for filename in filenames(entry.date, path):
+                    paths.append((account, join(b_dir, filename)))
+                    paths.append((account, join(b_dir, documents, filename)))
+                    paths.append((account, join(b_dir, documents,
+                                                account_path, filename)))
+
+        if len(paths) == 0:
+            continue
+
+        found = False
+        for account, path in paths:
+            if isfile(path):
+                # TODO link the Document entry with the Transaction
+                meta = data.new_metadata('<fava_statements_plugin>', 0)
+                entries.append(data.Document(meta, entry.date, account, path))
+                found = True
+
+        if not found:
+            errors.append(
+                StatementDocumentError(
+                    entry.meta,
+                    "Document not found. Search paths: {}".format(
+                        ', '.join([path for _, path in paths])),
+                    entry))
 
     return entries, errors

--- a/fava/plugins/statements_from_metadata.py
+++ b/fava/plugins/statements_from_metadata.py
@@ -1,0 +1,71 @@
+"""Plugin that looks through all transactions and their postings for the
+`statement`-metadata-key, and if found and present in the filesystem, adds a
+corresponding Document-directive.
+
+The file specified in the `statement`-metadata-value will be searched
+"intelligently", based on the suggestions by @corani
+(https://github.com/beancount/fava/issues/386#issuecomment-256267212).
+"""
+import collections
+from os.path import join, dirname, isfile
+from beancount.core import data
+
+StatementDocumentError = collections.namedtuple('StatementDocumentError', 'source message entry')
+
+__plugins__ = ['statements_from_metadata']
+
+def statements_from_metadata(entries, options_map):
+    errors = []
+    key = 'statement'
+
+    if not 'documents' in options_map or len(options_map['documents']) == 0:
+        return entries, errors
+
+    def filenames(date, name):
+        return [name, '{} {}'.format(date, name), '{}.{}'.format(date, name)]
+
+    for entry in entries:
+        type = entry.__class__.__name__.lower()
+        if type == 'transaction':
+            possible_paths = []  # set of tuples (account, path)
+            date = entry.date.strftime("%Y-%m-%d")
+
+            for documents_root in options_map['documents']:
+                # If the `statement` metadata key is set on the transaction, assume it belongs to the first posting
+                if key in entry.meta:
+                    posting = entry.postings[0]
+                    account = posting.account.replace(':', '/')
+                    for filename in filenames(date, entry.meta[key]):
+                        possible_paths.append((posting.account, join(dirname(options_map['filename']), filename)))
+                        possible_paths.append((posting.account, join(dirname(options_map['filename']), documents_root, filename)))
+                        possible_paths.append((posting.account, join(dirname(options_map['filename']), documents_root, account, filename)))
+
+                # Check if the `statement` metadata key is set on one of the postings
+                for posting in entry.postings:
+                    if posting.meta and key in posting.meta:
+                        account = posting.account.replace(':', '/')
+                        for filename in filenames(date, posting.meta[key]):
+                            possible_paths.append((posting.account, join(dirname(options_map['filename']), filename)))
+                            possible_paths.append((posting.account, join(dirname(options_map['filename']), documents_root, filename)))
+                            possible_paths.append((posting.account, join(dirname(options_map['filename']), documents_root, account, filename)))
+
+            if len(possible_paths) == 0:
+                continue
+
+            found = False
+            for account, path in possible_paths:
+                if isfile(path):
+                    # TODO link the Document entry with the Transaction
+                    meta = data.new_metadata('<fava_statements_plugin>', 0)
+                    entries.append(data.Document(meta, entry.date, account, path))
+                    found = True
+
+            if not found:
+                errors.append(
+                    StatementDocumentError(
+                        entry.meta,
+                        "Statement document not found. Search paths: {}".format(
+                            ', '.join([path for _, path in possible_paths])),
+                        entry))
+
+    return entries, errors

--- a/fava/plugins/statements_from_metadata.py
+++ b/fava/plugins/statements_from_metadata.py
@@ -44,14 +44,14 @@ def statements_from_metadata(entries, options_map):
             for key in entry.meta.keys():
                 if key.startswith('statement'):
                     statements.append(
-                        (entry.meta['statement'], entry.postings[0].account))
+                        (entry.meta[key], entry.postings[0].account))
 
             for posting in entry.postings:
                 if posting.meta:
                     for key in posting.meta.keys():
                         if key.startswith('statement'):
                             statements.append(
-                                (posting.meta['statement'], posting.account))
+                                (posting.meta[key], posting.account))
 
             for path, account in statements:
                 account_path = account.replace(':', '/')

--- a/fava/plugins/statements_from_metadata.py
+++ b/fava/plugins/statements_from_metadata.py
@@ -18,7 +18,6 @@ __plugins__ = ['statements_from_metadata']
 
 def statements_from_metadata(entries, options_map):
     errors = []
-    key = 'statement'
 
     if 'documents' not in options_map or len(options_map['documents']) == 0:
         return entries, errors
@@ -41,12 +40,17 @@ def statements_from_metadata(entries, options_map):
 
             # If the `statement` metadata key is set on the transaction, assume
             # it belongs to the first posting
-            if key in entry.meta:
-                statements.append((entry.meta[key], entry.postings[0].account))
+            for key in entry.meta.keys():
+                if key.startswith('statement'):
+                    statements.append(
+                        (entry.meta['statement'], entry.postings[0].account))
 
             for posting in entry.postings:
-                if posting.meta and key in posting.meta:
-                    statements.append((posting.meta[key], posting.account))
+                if posting.meta:
+                    for key in posting.meta.keys():
+                        if key.startswith('statement'):
+                            statements.append(
+                                (posting.meta['statement'], posting.account))
 
             for path, account in statements:
                 account_path = account.replace(':', '/')

--- a/fava/plugins/statements_from_metadata.py
+++ b/fava/plugins/statements_from_metadata.py
@@ -72,7 +72,8 @@ def statements_from_metadata(entries, options_map):
                 links.add(_hash)
                 entries[i] = entry._replace(links=links)
                 meta = data.new_metadata('<fava_statements_plugin>', 0)
-                entries.append(data.Document(meta, entry.date, account, path, None, set([_hash])))
+                entries.append(data.Document(meta, entry.date, account, path,
+                                             set(['test']), set([_hash])))
                 found = True
 
         if not found:

--- a/fava/static/sass/_journal-table.scss
+++ b/fava/static/sass/_journal-table.scss
@@ -1,5 +1,12 @@
 // Journal table
 
+h3.link-title {
+  float: left;
+  padding: 0 10px 0 0;
+  line-height: 32px;
+  margin: 0;
+}
+
 .journal-entry-filters {
   .inactive {
     background: $color-background-darker;

--- a/fava/static/sass/_journal-table.scss
+++ b/fava/static/sass/_journal-table.scss
@@ -167,13 +167,7 @@
   .description {
     flex: 1;
 
-    .links {
-      margin-left: 1em;
-      margin-right: 1em;
-      text-decoration: none;
-    }
-
-    .tag {
+    .tag, .link {
       color: $color-journaltable-tag;
       display: inline-block;
       margin-right: 8px;
@@ -182,6 +176,26 @@
         color: darken($color-journaltable-tag, 30%);
         text-decoration: underline;
       }
+    }
+
+    .link {
+      color: $color-journaltable-link;
+
+      &:hover { color: darken($color-journaltable-link, 30%); }
+    }
+  }
+
+  .document .description {
+    .tag {
+      color: $color-journaltable-tag-document;
+
+      &:hover { color: darken($color-journaltable-tag-document, 30%); }
+    }
+
+    .link {
+      color: $color-journaltable-link-document;
+
+      &:hover { color: darken($color-journaltable-link-document, 30%); }
     }
   }
 

--- a/fava/static/sass/style.scss
+++ b/fava/static/sass/style.scss
@@ -92,6 +92,9 @@ $color-journaltable-header: #888;
 $color-journaltable-border: #f5f5f5;
 $color-journaltable-metadata: #85aacf;
 $color-journaltable-tag: #6aa2db;
+$color-journaltable-tag-document: #bb7ebb;
+$color-journaltable-link: #cbdde8;
+$color-journaltable-link-document: #c79cc7;
 $color-journal-leg-indicator: #c1d0d9;
 
 $color-treetable-header-bg: darken($color-background, 15);

--- a/fava/templates/_journal_table.html
+++ b/fava/templates/_journal_table.html
@@ -94,6 +94,11 @@
 {% endif %}
 {%- endmacro %}
 
+{% macro render_tags_links(entry) -%}
+{% for tag in entry.tags or [] %}<a class="tag" href="{{ tag_url.replace('REPLACEME', tag) }}" title="Filter for tag #{{ tag }}"><span>#</span>{{ tag }}</a>{% endfor %}
+{% for link in entry.links or [] %}<a class="link"><span>^</span>{{ link }}</a>{% endfor %}
+{%- endmacro %}
+
 <ol id="journal-table" class="journal-table">
     <li class="head">
         <p>
@@ -156,6 +161,7 @@
         {% elif type == 'budget' %}
         {% elif type == 'document' %}
             Document for {{ account_link(entry.account) }}: <a href="{{ url_for('document', file_path=entry.filename) }}">{{ entry.filename|basename }}</a>
+            {{ render_tags_links(entry) }}
         {% elif type == 'balance' %}
             Balance {{ account_link(entry.account) }}
             {% if entry.diff_amount %} fails;
@@ -167,7 +173,7 @@
             {% endif %}
         {% elif type == 'transaction' %}
             <strong>{{ entry.payee or '' }}</strong>{% if entry.payee and entry.narration %} | {% endif %}{{ entry.narration or '' }}
-            {% for tag in entry.tags or [] %}<a class="tag" href="{{ tag_url.replace('REPLACEME', tag) }}" title="Filter for tag #{{ tag }}"><span>#</span>{{ tag }}</a>{% endfor %}
+            {{ render_tags_links(entry) }}
         {% endif %}
         </span>
         {% if type == 'transaction' %}

--- a/fava/templates/_journal_table.html
+++ b/fava/templates/_journal_table.html
@@ -85,9 +85,9 @@
         {% for key, value in metadata.items() %}
             <dt>{{ key }}</dt>
             <dd>
-                {%- if key == 'statement' %}<a href="{{ url_for('document', file_path=value)  }}">{% endif -%}
+                {%- if key.startswith('statement') %}<a href="{{ url_for('document', file_path=value)  }}">{% endif -%}
                 {{ value }}
-                {%- if key == 'statement' %}</a>{% endif -%}
+                {%- if key.startswith('statement') %}</a>{% endif -%}
             </dd>
         {% endfor %}
     </dl>

--- a/fava/templates/_journal_table.html
+++ b/fava/templates/_journal_table.html
@@ -212,7 +212,7 @@
                 <span class="num"></span>
                 {% endif %}
             </p>
-            {{ render_metadata(posting.meta|remove_keys(['lineno', 'filename']), show_type['metadata']) }}
+            {{ render_metadata(posting.meta|remove_keys(['__automatic__', 'lineno', 'filename']), show_type['metadata']) }}
         </li>
         {% endfor %}
         </ul>

--- a/fava/templates/_journal_table.html
+++ b/fava/templates/_journal_table.html
@@ -1,4 +1,9 @@
-{% set entry_types = ['open', 'close', 'transaction', 'balance', 'note', 'document', 'pad', 'query', 'custom', 'budget'] %}
+{% if link %}
+    {% set entry_types = ['transaction', 'document'] %}
+    <h3 class="link-title">Link ^{{ link }}</h3>
+{% else %}
+    {% set entry_types = ['open', 'close', 'transaction', 'balance', 'note', 'document', 'pad', 'query', 'custom', 'budget'] %}
+{% endif %}
 {% set transaction_types = ['cleared', 'pending', 'other'] %}
 {% set flags_to_types = {'*': 'cleared', '!': 'pending'} %}
 {% set default_show_type = {
@@ -96,7 +101,7 @@
 
 {% macro render_tags_links(entry) -%}
 {% for tag in entry.tags or [] %}<a class="tag" href="{{ tag_url.replace('REPLACEME', tag) }}" title="Filter for tag #{{ tag }}"><span>#</span>{{ tag }}</a>{% endfor %}
-{% for link in entry.links or [] %}<a class="link"><span>^</span>{{ link }}</a>{% endfor %}
+{% for link_ in entry.links or [] %}<a class="link" href="{{ url_for('journal_link', link=link_) }}"><span>^</span>{{ link_ }}</a>{% endfor %}
 {%- endmacro %}
 
 <ol id="journal-table" class="journal-table">

--- a/fava/templates/journal.html
+++ b/fava/templates/journal.html
@@ -2,7 +2,11 @@
 {% set active_page = 'journal' %}
 
 {% block content %}
-    {% with journal = api.entries %}
-        {% include "_journal_table.html" %}
-    {% endwith %}
+    {% if link %}
+        {% set journal=api.entries_for_link(link) %}
+    {% else %}
+        {% set journal=api.entries %}
+    {% endif %}
+
+    {% include "_journal_table.html" %}
 {% endblock %}


### PR DESCRIPTION
Related issue with discussion: #386

To try out the plugin add this to your beancount file:

```ruby
plugin "fava.plugins.statements_from_metadata"

2016-10-30 * "" "Test"
  statement: "2016-10-30 test.pdf"
  Expenses:Other                                             10.00 EUR
  Assets:Cash
    statement: "2016-10-30 test 2.pdf"
```

Things to do related to the plugin:

- [ ] Link the transaction and the generated Document entry
- [x] Support multiple statements per transaction (currently metadata is a dict), like
  `statements `, `statements-2`, `statements-3`, ...
- [ ] Add description of the feature to help pages, including which paths are searched
- [ ] Testcases

General things to do:

- [ ] Support "relative" paths suggested by @corani (https://github.com/beancount/fava/issues/386#issuecomment-256267212) when downloading files (in the Journal)
- [ ] Drag'n'drop: Add support for multiple `document_root`
- [ ] Drag'n'drop: Add support for dropping on a Journal transaction or posting (upload; add the corresponding metadata entry)
