### PR TITLE
Show budgets in bar charts

### DIFF
--- a/fava/api/charts.py
+++ b/fava/api/charts.py
@@ -8,6 +8,7 @@ from beancount.core import inventory, realization
 from beancount.core.data import iter_entry_dates
 from flask.json import JSONEncoder
 
+from fava.api.budgets import calculate_budget
 from fava.api.helpers import net_worth_at_dates
 
 
@@ -96,6 +97,8 @@ class Charts(object):
             'totals': self._total_balance(
                 names,
                 begin_date, end_date),
+            'budgets': calculate_budget(self.api.budgets, names[0],
+                                        begin_date, end_date),
         } for begin_date, end_date in interval_tuples]
 
     def linechart(self, account_name):

--- a/fava/static/javascript/charts.js
+++ b/fava/static/javascript/charts.js
@@ -384,6 +384,12 @@ class BarChart extends BaseChart {
         .attr('class', 'bar')
         .style('fill', d => currencyColorScale(d.name));
 
+    this.selections.budgets = this.selections.groups.selectAll('.budget')
+        .data(d => d.values)
+        .enter()
+      .append('rect')
+        .attr('class', 'budget');
+
     this.update();
     return this;
   }
@@ -414,6 +420,12 @@ class BarChart extends BaseChart {
     this.selections.groupboxes
       .attr('width', this.x0.bandwidth())
       .attr('height', this.height);
+
+    this.selections.budgets
+      .attr('width', this.x1.bandwidth())
+      .attr('x', d => this.x1(d.name))
+      .attr('y', d => this.y(Math.max(0, d.budget)))
+      .attr('height', d => Math.abs(this.y(d.budget) - this.y(0)));
 
     this.selections.bars
       .attr('width', this.x1.bandwidth())
@@ -800,6 +812,7 @@ export default function initCharts() {
           values: window.favaAPI.operating_currencies.map(name => ({
             name,
             value: +d.totals[name] || 0,
+            budget: +d.budgets[name] || 0,
           })),
           date: new Date(d.begin_date),
           label: dateFormat[$('#chart-interval').value](new Date(d.begin_date)),

--- a/fava/static/sass/_charts.scss
+++ b/fava/static/sass/_charts.scss
@@ -165,6 +165,9 @@ svg {
     opacity: 0;
   }
 
+  .budget {
+    opacity: .3;
+  }
 }
 
 .tooltip {


### PR DESCRIPTION
If budgets exist, they will be shown as a grey bar overlaying the account changes/balances.

Fix #299 