### PR TITLE
Journal: Show checkmark for transactions that have a statement attached to them

### DIFF
--- a/fava/static/sass/_journal-table.scss
+++ b/fava/static/sass/_journal-table.scss
@@ -241,13 +241,27 @@
     display: inline-block;
     height: 6px;
     margin-right: 4px;
-    margin-top: 8px;
+    margin-top: 10px;
     padding: 0;
     width: 6px;
 
     &:last-child { margin-right: 10px; }
 
     &.leg-pending { background-color: $color-journalentry-postingwarning; }
+  }
+
+  .metadata-indicator {
+    font-size: 10px;
+    background: $color-journal-leg-indicator;
+    margin-right: 4px;
+    margin-top: 5px;
+    border-radius: 20px;
+    height: 16px;
+    line-height: 16px;
+    padding: 0 8px;
+    color: darken($color-journal-leg-indicator, 35%); // #617079;
+
+    &:last-child { margin-right: 10px; }
   }
 
   .budget-value {

--- a/fava/static/sass/_journal-table.scss
+++ b/fava/static/sass/_journal-table.scss
@@ -251,15 +251,16 @@
   }
 
   .metadata-indicator {
-    font-size: 10px;
     background: $color-journal-leg-indicator;
-    margin-right: 4px;
-    margin-top: 5px;
     border-radius: 20px;
+    color: darken($color-journal-leg-indicator, 35%);
+    font-size: 10px;
     height: 16px;
     line-height: 16px;
+    margin-right: 4px;
+    margin-top: 5px;
     padding: 0 8px;
-    color: darken($color-journal-leg-indicator, 35%); // #617079;
+    text-transform: lowercase;
 
     &:last-child { margin-right: 10px; }
   }

--- a/fava/static/sass/style.scss
+++ b/fava/static/sass/style.scss
@@ -96,6 +96,7 @@ $color-journaltable-tag-document: #bb7ebb;
 $color-journaltable-link: #cbdde8;
 $color-journaltable-link-document: #c79cc7;
 $color-journal-leg-indicator: #c1d0d9;
+$color-journal-metadata-indicator: #c1d0d9;
 
 $color-treetable-header-bg: darken($color-background, 15);
 $color-treetable-expander: #afc1d3;

--- a/fava/templates/_journal_table.html
+++ b/fava/templates/_journal_table.html
@@ -155,6 +155,7 @@
         {% set entry, _, change, balance = entry %}
     {% endif %}
     {% set type = entry.__class__.__name__.lower() %}
+    {% set metadata = entry.meta|remove_keys(['__tolerances__', '__automatic__', 'filename', 'lineno']) %}
     <li class="{{ type }}
     {%- if entry.flag %} {{ flags_to_types.get(entry.flag, 'other') }}
         {%- if not show_type[flags_to_types.get(entry.flag, 'other')] %} hidden{% endif -%}
@@ -214,6 +215,9 @@
             {{ render_tags_links(entry) }}
         {% endif %}
         </span>
+        {% for key, _ in metadata.items() %}
+            <span class="metadata-indicator">{{ key[:2] }}</span>
+        {% endfor %}
         {% if type == 'transaction' %}
             {% for posting in entry.postings %}
                 <span class="leg-indicator{% if posting.flag %} leg-{{ flags_to_types.get(posting.flag, 'other') }}{% endif %}"></span>
@@ -224,7 +228,7 @@
             <span class="num">{{ render_inventory(balance) }}</span>
         </p>
         {% endif %}
-        {{ render_metadata(entry.meta|remove_keys(['__tolerances__', '__automatic__', 'filename', 'lineno']), show_type['metadata'], entry) }}
+        {{ render_metadata(metadata, show_type['metadata'], entry) }}
         {% if entry.postings %}
         <ul class="postings{% if not show_type['postings'] %} hidden{% endif %}">
         {% for posting in entry.postings %}


### PR DESCRIPTION
implements #413

Shows the first two characters of metadata keys as little bubbles.

Looks like this:

![screenshot](https://cloud.githubusercontent.com/assets/5135450/20619874/08c9677a-b2f7-11e6-9005-b7ab0608b632.png)
