### PR TITLE
Editor: Keyboard shortcut for commenting out a line/selection

### DIFF
--- a/fava/static/javascript/editor.js
+++ b/fava/static/javascript/editor.js
@@ -23,6 +23,9 @@ import 'codemirror/addon/fold/foldgutter';
 // auto-complete
 import 'codemirror/addon/hint/show-hint';
 
+// commenting
+import 'codemirror/addon/comment/comment';
+
 import './codemirror-fold-beancount';
 import './codemirror-hint-beancount';
 import './codemirror-mode-beancount';
@@ -87,6 +90,13 @@ function formatEditorContent(cm) {
     });
 }
 
+function toggleComment(cm) {
+  const args = { from: cm.getCursor(true), to: cm.getCursor(false), options: { lineComment: ';' } };
+  if (!cm.uncomment(args.from, args.to, args.options)) {
+    cm.lineComment(args.from, args.to, args.options);
+  }
+}
+
 function centerCursor(cm) {
   const top = cm.cursorCoords(true, 'local').top;
   const height = cm.getScrollInfo().clientHeight;
@@ -140,6 +150,12 @@ export default function initEditor() {
       },
       'Cmd-D': (cm) => {
         formatEditorContent(cm);
+      },
+      'Ctrl-Y': (cm) => {
+        toggleComment(cm);
+      },
+      'Cmd-Y': (cm) => {
+        toggleComment(cm);
       },
       Tab: (cm) => {
         if (cm.somethingSelected()) {

--- a/fava/templates/overlays/_keyboard_shortcuts.html
+++ b/fava/templates/overlays/_keyboard_shortcuts.html
@@ -63,6 +63,8 @@
                 <dd>Save</dd>
                 <dt><kbd>Ctrl</kbd>/<kbd>Cmd</kbd>+<kbd>d</kbd></dt>
                 <dd>Format</dd>
+                <dt><kbd>Ctrl</kbd>/<kbd>Cmd</kbd>+<kbd>y</kbd></dt>
+                <dd>Toggle comment</dd>
             </dl>
             <h3>Query</h3>
             <dl>


### PR DESCRIPTION
Implementation of #407 

`Cmd`+`/` does not work for me on a Mac (Chrome/Safari), as it opens the help menu of the browser. Mapped it to `Cmd`+`y` for now. Any suggestions about that?