### PR TITLE
Collapse inventories into units when displaying journal balances and changes

### DIFF
--- a/fava/templates/_journal_table.html
+++ b/fava/templates/_journal_table.html
@@ -102,7 +102,7 @@
 {%- endmacro %}
 
 {% macro render_inventory(inv) -%}
-    {% for pos in inv %}
+    {% for pos in inv.units() %}
         {{ pos.units|format_amount }}<br>
     {% endfor %}
 {%- endmacro %}


### PR DESCRIPTION
If you make many transactions containing different commodities within a journal
screen (e.g. parent investment account), each journal line becomes dominated by
the list of individual positions.  This will reduce all of the amounts of a
single commodity into a single commodity into a single line.