### PR TITLE
Transaction form: Support metadata

### DIFF
--- a/fava/core/file.py
+++ b/fava/core/file.py
@@ -153,6 +153,10 @@ def _render_transaction(transaction):
         transaction.date, transaction.flag, transaction.payee,
         transaction.narration)]
 
+    if transaction.meta and len(transaction.meta.keys()) > 0:
+        for key, value in transaction.meta.items():
+            lines.append('    {}: "{}"'.format(key, value))
+
     for posting in transaction.postings:
         line = '    {}'.format(posting.account)
         if posting.units.number or posting.units.currency:

--- a/fava/json_api.py
+++ b/fava/json_api.py
@@ -115,7 +115,7 @@ def add_transaction():
 
     date = util.date.parse_date(json['date'])[0]
     transaction = Transaction(
-        None, date, json['flag'], json['payee'],
+        json['metadata'], date, json['flag'], json['payee'],
         json['narration'], None, None, postings)
 
     g.ledger.file.insert_transaction(transaction)

--- a/fava/static/javascript/transaction-form.js
+++ b/fava/static/javascript/transaction-form.js
@@ -34,14 +34,34 @@ function addPostingRow() {
   return newPosting;
 }
 
+function addMetadataRow() {
+  const newMetadata = $('#metadata-template').cloneNode(true);
+  newMetadata.querySelectorAll('input').forEach((input) => {
+    initInput(input);
+  });
+  $('#transaction-form .metadatas').appendChild(newMetadata);
+  newMetadata.setAttribute('id', '');
+  return newMetadata;
+}
+
 function submitTransactionForm(successCallback) {
   const jsonData = {
     date: $('#transaction-form input[name=date]').value,
     flag: $('#transaction-form input[name=flag]').value,
     payee: $('#transaction-form input[name=payee]').value,
     narration: $('#transaction-form input[name=narration]').value,
+    metadata: {},
     postings: [],
   };
+
+  $$('#transaction-form .metadata').forEach((metadata) => {
+    const key = metadata.querySelector('input[name=metadata-key]').value;
+    const value = metadata.querySelector('input[name=metadata-value]').value;
+
+    if (key) {
+      jsonData.metadata[key] = value;
+    }
+  });
 
   $$('#transaction-form .posting').forEach((posting) => {
     const account = posting.querySelector('input[name=account]').value;
@@ -65,6 +85,9 @@ function submitTransactionForm(successCallback) {
   })
     .then(handleJSON)
     .then((data) => {
+      $$('#transaction-form .metadata').forEach((el) => {
+        el.remove();
+      });
       $$('#transaction-form .posting').forEach((el) => {
         el.remove();
       });
@@ -113,5 +136,17 @@ export default function initTransactionForm() {
     event.preventDefault();
     const newPosting = addPostingRow();
     newPosting.querySelector('.account').focus();
+  });
+
+  $('#add-metadata').addEventListener('click', (event) => {
+    event.preventDefault();
+    const newMetadata = addMetadataRow();
+    newMetadata.querySelector('.metadata-key').focus();
+  });
+
+  $.delegate($('#transaction-form'), 'click', '.add-metadata', (event) => {
+    event.preventDefault();
+    const newMetadata = addMetadataRow();
+    newMetadata.querySelector('.metadata-key').focus();
   });
 }

--- a/fava/static/sass/_base.scss
+++ b/fava/static/sass/_base.scss
@@ -240,6 +240,19 @@ button {
       box-shadow: 0 0 5px darken($color-header-text, 20);
     }
   }
+
+  &.link {
+    background: none;
+    color: $color-links;
+
+    &:focus,
+    &:active,
+    &:hover {
+      box-shadow: none;
+      color: darken($color-links, 10);
+      text-decoration: underline;
+    }
+  }
 }
 
 .hidden {

--- a/fava/static/sass/_overlay.scss
+++ b/fava/static/sass/_overlay.scss
@@ -211,10 +211,10 @@ $overlay-wrapper-background: rgba(0, 0, 0, .5);
   }
 
   .add-metadata-link {
+    bottom: 20px;
+    font-size: .9em;
     position: absolute;
     right: 20px;
-    bottom: 20px;
-    font-size: 0.9em;
   }
 }
 

--- a/fava/static/sass/_overlay.scss
+++ b/fava/static/sass/_overlay.scss
@@ -165,16 +165,61 @@ $overlay-wrapper-background: rgba(0, 0, 0, .5);
   .add-posting {
     border-radius: 15px;
     display: none;
-    height: 1.5em;;
+    height: 1.5em;
     line-height: 1.5em;
-    margin: 7px 0 0 12px;
+    margin: 7px 0 0 10px;
     padding: 0;
     text-align: center;
     width: 1.5em;
   }
+
+  .metadatas {
+    padding-left: 4em;
+
+    input {
+      font-size: .8em;
+    }
+
+    .metadata-key {
+      width: 10em;
+    }
+
+    .metadata-value {
+      flex-grow: 1;
+    }
+
+    .fieldset {
+      width: 50%;
+
+      &:last-child {
+        .add-metadata {
+          display: inline-block;
+        }
+      }
+    }
+  }
+
+  .add-metadata {
+    border-radius: 3px;
+    display: none;
+    height: 1em;
+    line-height: 1em;
+    margin: 7px 0 0 12px;
+    padding: 0;
+    text-align: center;
+    width: 1em;
+  }
+
+  .add-metadata-link {
+    position: absolute;
+    right: 20px;
+    bottom: 20px;
+    font-size: 0.9em;
+  }
 }
 
-[id='posting-template'] {
+[id='posting-template'],
+[id='metadata-template'] {
   display: none;
 }
 

--- a/fava/templates/overlays/_transaction_form.html
+++ b/fava/templates/overlays/_transaction_form.html
@@ -12,19 +12,30 @@
                 <label for="payee">{{ _('Narration') }}:</label>
                 <input type="text" name="narration" placeholder="{{ _('Narration') }}" />
             </div>
+            <div class="metadatas">
+            </div>
             <div class="postings">
             </div>
             <div class="fieldset">
                 <button type="submit" id="transaction-form-submit" data-url="{{ url_for('json_api.add_document') }}">{{ _('Save') }}</button>
                 <button type="submit" class="muted" id="transaction-form-submit-and-new" data-url="{{ url_for('json_api.add_document') }}">{{ _('Save and add new') }}</button>
+                <button id="add-metadata" class="link add-metadata-link">{{ _('Add Metadata') }}</a>
             </div>
         </form>
     </div>
 </div>
-<div id="posting-template" class="fieldset posting">
-    <label for="account">{{ _('Account') }}:</label>
-    <input type="text" class="account" name="account" placeholder="{{ _('Account') }}" list="accounts" />
-    <input type="number" step="0.01" class="number" name="number" placeholder="{{ _('Number') }}" />
-    <input type="text" class="currency" name="currency" placeholder="{{ _('Currency') }}" list="currencies" />
-    <button class="muted add-posting" title="{{ _('Add posting') }}">+</button>
+<div id="posting-template" class=" posting">
+    <div class="fieldset">
+        <label for="account">{{ _('Account') }}:</label>
+        <input type="text" class="account" name="account" placeholder="{{ _('Account') }}" list="accounts" />
+        <input type="number" step="0.01" class="number" name="number" placeholder="{{ _('Number') }}" />
+        <input type="text" class="currency" name="currency" placeholder="{{ _('Currency') }}" list="currencies" />
+        <button class="muted add-posting" title="{{ _('Add posting') }}">+</button>
+    </div>
+</div>
+<div id="metadata-template" class="fieldset metadata">
+    <label for="account">{{ _('Metadata') }}:</label>
+    <input type="text" class="metadata-key" name="metadata-key" placeholder="{{ _('Key') }}" />
+    <input type="text" class="metadata-value" name="metadata-value" placeholder="{{ _('Value') }}" />
+    <button class="muted add-metadata" title="{{ _('Add metadata') }}">+</button>
 </div>

--- a/tests/test_api_file.py
+++ b/tests/test_api_file.py
@@ -170,8 +170,17 @@ def test__render_transaction():
         None, datetime.date(2016, 1, 1), '*',
         'new payee', 'narr', None, None, postings)
 
-    print(_render_transaction(transaction))
     assert '\n' + _render_transaction(transaction) == dedent("""
     2016-01-01 * "new payee" "narr"
+        Liabilities:US:Chase:Slate                    -10.00 USD
+        Expenses:Food                                  10.00 USD""")
+
+    transaction = data.Transaction(
+        {'foo': 'bar'}, datetime.date(2016, 1, 1), '*',
+        'new payee', 'narr', None, None, postings)
+
+    assert '\n' + _render_transaction(transaction) == dedent("""
+    2016-01-01 * "new payee" "narr"
+        foo: "bar"
         Liabilities:US:Chase:Slate                    -10.00 USD
         Expenses:Food                                  10.00 USD""")


### PR DESCRIPTION
This PR implements input fields in the transaction form to enable the entering of metadata. 

The key and value are inserted into the file unchecked, so the rules in the Beancount Language Specification (keys should start with a lowercase character from a-z, etc.) are not checked or enforced.

(The next goal is to enable the upload of statements when adding a new transaction with the form.)