### PR TITLE
Conversion

### DIFF
--- a/fava/application.py
+++ b/fava/application.py
@@ -186,6 +186,8 @@ def _inject_filters(endpoint, values):
         return
     if 'interval' not in values:
         values['interval'] = request.args.get('interval')
+    if 'conversion' not in values:
+        values['conversion'] = request.args.get('conversion')
     for filter_name in ['account', 'from', 'payee', 'tag', 'time']:
         if filter_name not in values:
             values[filter_name] = g.filters[filter_name]
@@ -199,6 +201,7 @@ def _pull_beancount_file(_, values):
     if g.beancount_file_slug not in app.config['FILE_SLUGS']:
         abort(404)
     g.ledger = app.config['LEDGERS'][g.beancount_file_slug]
+    g.at_value = request.args.get('conversion') == 'at_value'
 
 
 @app.errorhandler(FavaAPIException)

--- a/fava/static/javascript/router.js
+++ b/fava/static/javascript/router.js
@@ -43,6 +43,13 @@ function updateURL(url) {
       newURL.removeSearch('interval');
     }
   }
+  const conversion = document.getElementById('conversion');
+  if (conversion) {
+    newURL.setSearch('conversion', conversion.value);
+    if (conversion.value === 'at_cost') {
+      newURL.removeSearch('conversion');
+    }
+  }
   return newURL.toString();
 }
 
@@ -127,6 +134,12 @@ export default function initRouter() {
 
     if ($('#chart-interval')) {
       $('#chart-interval').addEventListener('change', () => {
+        loadURL(updateURL(window.location.href));
+      });
+    }
+
+    if ($('#conversion')) {
+      $('#conversion').addEventListener('change', () => {
         loadURL(updateURL(window.location.href));
       });
     }

--- a/fava/template_filters.py
+++ b/fava/template_filters.py
@@ -31,6 +31,13 @@ def cost(inventory):
     return inventory.reduce(convert.get_cost)
 
 
+def cost_or_value(inventory, date=None):
+    """Get the cost or value of an inventory."""
+    if g.at_value:
+        return inventory.reduce(convert.get_value, g.ledger.price_map, date)
+    return inventory.reduce(convert.get_cost)
+
+
 def format_currency(value, currency=None, show_if_zero=False):
     """Format a value using the derived precision for a specified currency."""
     if not value and not show_if_zero:

--- a/fava/templates/_charts.html
+++ b/fava/templates/_charts.html
@@ -72,6 +72,10 @@
             <input name="mode" type="radio" value="treemap" id="mode-treemap" checked> <label for="mode-treemap">{{ _('Treemap') }}</label>
             <input name="mode" type="radio" value="sunburst" id="mode-sunburst"> <label for="mode-sunburst">{{ _('Sunburst') }}</label>
         </span>
+        <select name="conversion" id="conversion">
+          <option value="at_cost"{{ ' selected' if request.args.get('conversion') == 'at_cost' }} >At Cost</option>
+          <option value="at_value"{{ ' selected' if request.args.get('conversion') == 'at_value' }}>At Market Value</option>
+        </select>
         {% if not hide_interval_filter %}
             <select name="chart-interval" id="chart-interval" data-default="{{ ledger.fava_options['interval'] }}">
                 {% for interval_ in ['day', 'week', 'month', 'quarter', 'year'] %}

--- a/fava/templates/_tree_table.html
+++ b/fava/templates/_tree_table.html
@@ -1,5 +1,5 @@
 {% import 'macros/_account_macros.html' as account_macros with context %}
-{% set show_other_column = (operating_currencies|sort != ledger.options['commodities']|list|sort) %}
+{% set show_other_column = (operating_currencies|length < ledger.options['commodities']|length) %}
 
 {% macro tree(real_account, totals=True) %}
     <ol class="tree-table{{ ' two-currencies' if operating_currencies|length > 1 else '' }}" title="{{ _('Hold Shift while clicking to expand all children \nHold Ctrl or Cmd while clicking to expand one level') }}">
@@ -16,8 +16,8 @@
     </li>
 {% for account in ([real_account] if real_account.account else real_account.values()) recursive %}
     {% if account|should_show %}
-    {% set balance = account.balance|cost %}
-    {% set balance_children = (account|balance_children)|cost %}
+    {% set balance = account.balance|cost_or_value %}
+    {% set balance_children = account|balance_children|cost_or_value %}
     <li{% if account.account|should_collapse_account %} class="toggled"{% endif %}>
         <p{% if not balance.is_empty() %} class='has-balance'{% endif %}>
         <span class="account-cell depth-{{ loop.depth0 }} droptarget
@@ -33,17 +33,13 @@
     {% if show_other_column %}
         <span class="num other">
             <span class="balance">
-                {% for currency in ledger.options['commodities'] if currency not in operating_currencies %}
-                    {% if currency in balance.currencies() %}
-                        {{ balance.get_currency_units(currency).number|format_currency(currency) }} {{ currency }}<br>
-                    {% endif %}
+                {% for pos in balance|sort(attribute='units.currency') if pos.units.currency not in operating_currencies %}
+                    {{ pos.units|format_amount }}<br>
                 {% endfor %}
             </span>
             <span class="balance-children">
-                {% for currency in ledger.options['commodities'] if currency not in operating_currencies %}
-                    {% if currency in balance_children.currencies() %}
-                        {{ balance_children.get_currency_units(currency).number|format_currency(currency) }} {{ currency }}<br>
-                    {% endif %}
+                {% for pos in balance_children|sort(attribute='units.currency') if pos.units.currency not in operating_currencies %}
+                    {{ pos.units|format_amount }}<br>
                 {% endfor %}
             </span>
         </span>
@@ -58,7 +54,7 @@
     {% endif %}
 {% endfor %}
 {% if totals %}
-    {% set balance = (real_account|balance_children)|cost %}
+    {% set balance = real_account|balance_children|cost_or_value %}
         <li class="totals">
             <p>
             <span class="account-cell">&nbsp;</span>
@@ -67,10 +63,8 @@
         {% endfor %}
         {% if show_other_column %}
             <span class="num other">
-                {% for currency in ledger.options['commodities'] if currency not in operating_currencies%}
-                    {% if currency in balance.currencies() %}
-                        {{ balance.get_currency_units(currency).number|format_currency(currency) }} {{ currency }}<br>
-                    {% endif %}
+                {% for pos in balance|sort(attribute='units.currency') if pos.units.currency not in operating_currencies %}
+                    {{ pos.units|format_amount }}<br>
                 {% endfor %}
             </span>
         {% endif %}
@@ -121,8 +115,8 @@
         {% if accumulate %}{% set begin_date = dates[-1][0] %}{% endif %}
         {% set budget = ledger.budgets.calculate(account.account, begin_date, end_date) %}
         {% set current_account = interval_balances[loop.index0]|get_or_create(account.account) %}
-        {% set balance = current_account.balance|cost %}
-        {% set balance_children = (current_account|balance_children)|cost %}
+        {% set balance = current_account.balance|cost_or_value(end_date) %}
+        {% set balance_children = current_account|balance_children|cost_or_value(end_date) %}
         <span class="num other{{ ' has-balance' if not balance.is_empty() else '' }}">
             <a href="{{ url_for('account', name=account.account, time=begin_date|string + ' - ' + end_date|string) }}">
             {% for pos in balance %}
@@ -155,7 +149,7 @@
         <span class="account-cell">&nbsp;</span>
     {% for begin_date, end_date in dates %}
         {% set current_account = interval_balances[loop.index0]|get_or_create(account_name) %}
-        {% set balance_children = (current_account|balance_children)|cost %}
+        {% set balance_children = current_account|balance_children|cost_or_value(end_date) %}
         <span class="num other">
             {% for pos in balance_children %}
                 {{ pos.units|format_amount }}<br>


### PR DESCRIPTION
[The first commit updates our code to use the new shiny conversion utilities in `beancount.core.convert`. @blais, could we get a new release of Beancount so that we can depend on this?, edit: this has been cherry-picked into master]

More importantly, this allows us to offer a toggle to show market values instead of cost values (ref #464).

This should also allow us to convert everything to a single currency (later, ref #242).