### PR TITLE
Option to invert balance sheet numbers

### DIFF
--- a/fava/core/fava_options.py
+++ b/fava/core/fava_options.py
@@ -30,7 +30,8 @@ DEFAULTS = {
     'journal-show-document': ['discovered', 'statement'],
     'language': None,
     'interval': 'month',
-    'incognito': False
+    'incognito': False,
+    'invert-balance-sheet': False,
 }
 
 BOOL_OPTS = [
@@ -42,6 +43,7 @@ BOOL_OPTS = [
     'show-accounts-with-zero-transactions',
     'show-closed-accounts',
     'use-external-editor',
+    'invert-balance-sheet',
 ]
 
 INT_OPTS = [

--- a/fava/docs/options.md
+++ b/fava/docs/options.md
@@ -184,3 +184,11 @@ entry, then the grey uptodate-indicator is shown.
 Default: `false`
  
 If set to `true` all digits will be replaced with "X".
+
+---
+ 
+## `invert-balance-sheet`
+ 
+Default: `false`
+ 
+If set to `true` all numbers on the balance sheet screen will be inverted.

--- a/fava/static/css/base.css
+++ b/fava/static/css/base.css
@@ -454,6 +454,13 @@ kbd {
 
   & h3 {
     text-align: center;
+
+    & .byline {
+        color: var(--color-background-darkest);
+        font-size: .9em;
+        font-weight: normal;
+        margin-left: .2em;
+    }
   }
 }
 

--- a/fava/static/css/base.css
+++ b/fava/static/css/base.css
@@ -456,10 +456,10 @@ kbd {
     text-align: center;
 
     & .byline {
-        color: var(--color-background-darkest);
-        font-size: .9em;
-        font-weight: normal;
-        margin-left: .2em;
+      color: var(--color-background-darkest);
+      font-size: .9em;
+      font-weight: normal;
+      margin-left: .2em;
     }
   }
 }

--- a/fava/template_filters.py
+++ b/fava/template_filters.py
@@ -38,21 +38,24 @@ def cost_or_value(inventory, date=None):
     return inventory.reduce(convert.get_cost)
 
 
-def format_currency(value, currency=None, show_if_zero=False):
+def format_currency(value, currency=None, show_if_zero=False, invert=False):
     """Format a value using the derived precision for a specified currency."""
     if not value and not show_if_zero:
         return ''
     if value == 0.0:
         return g.ledger.quantize(Decimal(0.0), currency)
+    if invert:
+        value = value * -1
     return g.ledger.quantize(value, currency)
 
 
-def format_amount(amount):
+def format_amount(amount, invert=False):
     """Format an amount to string using the DisplayContext."""
     if not amount:
         return ''
-    return "{} {}".format(format_currency(amount.number, amount.currency),
-                          amount.currency)
+    return "{} {}".format(
+        format_currency(amount.number, amount.currency, invert=invert),
+        amount.currency)
 
 
 def hash_entry(entry):

--- a/fava/templates/_tree_table.html
+++ b/fava/templates/_tree_table.html
@@ -1,7 +1,7 @@
 {% import 'macros/_account_macros.html' as account_macros with context %}
 {% set show_other_column = (operating_currencies|length < ledger.options['commodities']|length) %}
 
-{% macro tree(real_account, totals=True) %}
+{% macro tree(real_account, totals=True, invert=False) %}
     <ol class="tree-table{{ ' two-currencies' if operating_currencies|length > 1 else '' }}" title="{{ _('Hold Shift while clicking to expand all children \nHold Ctrl or Cmd while clicking to expand one level') }}">
     <li class="head">
         <p>
@@ -26,20 +26,20 @@
         {{ account_macros.account_name(account.account, last_segment=True) }}</span>
     {% for currency in operating_currencies %}
         <span class="num">
-            <span class="balance">{{ balance.get_currency_units(currency).number|format_currency(currency) }}</span>
-            <span class="balance-children">{{ balance_children.get_currency_units(currency).number|format_currency(currency) }}</span>
+            <span class="balance">{{ balance.get_currency_units(currency).number|format_currency(currency, invert=invert) }}</span>
+            <span class="balance-children">{{ balance_children.get_currency_units(currency).number|format_currency(currency, invert=invert) }}</span>
         </span>
     {% endfor %}
     {% if show_other_column %}
         <span class="num other">
             <span class="balance">
                 {% for pos in balance|sort(attribute='units.currency') if pos.units.currency not in operating_currencies %}
-                    {{ pos.units|format_amount }}<br>
+                    {{ pos.units|format_amount(invert=invert) }}<br>
                 {% endfor %}
             </span>
             <span class="balance-children">
                 {% for pos in balance_children|sort(attribute='units.currency') if pos.units.currency not in operating_currencies %}
-                    {{ pos.units|format_amount }}<br>
+                    {{ pos.units|format_amount(invert=invert) }}<br>
                 {% endfor %}
             </span>
         </span>
@@ -59,12 +59,12 @@
             <p>
             <span class="account-cell">&nbsp;</span>
         {% for currency in operating_currencies %}
-            <span class="num">{{ balance.get_currency_units(currency).number|format_currency(currency) }}</span>
+            <span class="num">{{ balance.get_currency_units(currency).number|format_currency(currency, invert=invert) }}</span>
         {% endfor %}
         {% if show_other_column %}
             <span class="num other">
                 {% for pos in balance|sort(attribute='units.currency') if pos.units.currency not in operating_currencies %}
-                    {{ pos.units|format_amount }}<br>
+                    {{ pos.units|format_amount(invert=invert) }}<br>
                 {% endfor %}
             </span>
         {% endif %}

--- a/fava/templates/balance_sheet.html
+++ b/fava/templates/balance_sheet.html
@@ -10,17 +10,18 @@
     {{ charts.hierarchy(ledger.options['name_equity']) }}
 
     {% set root_account_closed = ledger.root_account_closed %}
+    {% set invert = ledger.fava_options['invert-balance-sheet'] %}
 
     <div class="row">
         <div class="column">
-            <h3>{{ ledger.options['name_assets'] }}</h3>
-            {{ tree_table.tree(root_account_closed|get_or_create(ledger.options['name_assets'])) }}
+            <h3>{{ ledger.options['name_assets'] }}{% if invert %} <span class="byline">{{ _('inverted') }}</span>{% endif %}</h3>
+            {{ tree_table.tree(root_account_closed|get_or_create(ledger.options['name_assets']), invert=invert) }}
         </div>
         <div class="column">
-            <h3>{{ ledger.options['name_liabilities'] }}</h3>
-            {{ tree_table.tree(root_account_closed|get_or_create(ledger.options['name_liabilities'])) }}
-            <h3>{{ ledger.options['name_equity'] }}</h3>
-            {{ tree_table.tree(root_account_closed|get_or_create(ledger.options['name_equity'])) }}
+            <h3>{{ ledger.options['name_liabilities'] }}{% if invert %} <span class="byline">{{ _('inverted') }}</span>{% endif %}</h3>
+            {{ tree_table.tree(root_account_closed|get_or_create(ledger.options['name_liabilities']), invert=invert) }}
+            <h3>{{ ledger.options['name_equity'] }}{% if invert %} <span class="byline">{{ _('inverted') }}</span>{% endif %}</h3>
+            {{ tree_table.tree(root_account_closed|get_or_create(ledger.options['name_equity']), invert=invert) }}
         </div>
     </div>
 {% endblock %}


### PR DESCRIPTION
This PR implements #448:

A new option named `invert-balance-sheet` was added to invert all numbers on the balance sheet ;-) 

```ruby
2017-04-12 custom "fava-option" "invert-balance-sheet" "true"
```

With this option enabled, the balance sheet looks like this:

![screenshot](https://cloud.githubusercontent.com/assets/5135450/24946166/465d15d2-1f62-11e7-853a-802329add5c8.png)

\cc @knoxx093 @blais