### PR TITLE
Filter text changed in help docs

### DIFF
--- a/fava/docs/features.md
+++ b/fava/docs/features.md
@@ -131,7 +131,7 @@ found in the journal:
 
 There's a special URL handler `/jump` which can be used to jump to current page
 with given params. This is useful to limit the scope of current viewing page.
-E.g. `/jump?time=last+month+-+next+month` will show current page but limit to
+E.g. `/jump?time=month-1+-+month%2B1` will show current page but limit to
 the last month, this month and the next month.
 
 ## Language


### PR DESCRIPTION
The last month/next month filtering isn't valid. Should be month±x