### PR TITLE
Tag-filter: Exclude tags and links by filtering for `-#tag`

### DIFF
--- a/fava/core/filters.py
+++ b/fava/core/filters.py
@@ -149,12 +149,12 @@ class TagFilter(EntryFilter):
             (entry.links & self.links)
         ) if self.tags else True
 
-        include = hasattr(entry, 'tags') and (
-            not (entry.tags & self.exclude_tags) and
-            not (entry.links & self.exclude_links)
-        ) if self.exclude_tags else include
+        exclude = hasattr(entry, 'tags') and (
+            (entry.tags & self.exclude_tags) or
+            (entry.links & self.exclude_links)
+        )
 
-        return include
+        return include and not exclude
 
 
 def _match(search, string):

--- a/fava/docs/features.md
+++ b/fava/docs/features.md
@@ -25,8 +25,10 @@ There are four filters available in Fava:
   current year. To prevent subtraction, use parentheses: `(month)-10` refers to
   the 10th of this month, whereas `month-10` would be 10 months ago.
 - **Tags**: Filter entries to the ones having the tags or links selected. This
-  filter is inclusive, meaning that if you select multiple tags entries with
-  any of those tags will be filtered.
+  filter is inclusive, meaning that if you select multiple tags entries with any
+  of those tags will be filtered. This filter also allows for negative filtering
+  (eg. `-#tag` or `-^link`) for excluding certain tags or links from the
+  results.
 - **Account**: Filter entries by account, matching any entry this account is
   part of. The filter can simply be an account name or a regular expression,
   e.g. `.*:Company:.*` to filter for all that contain `Company` as a component

--- a/fava/docs/features.md
+++ b/fava/docs/features.md
@@ -27,8 +27,8 @@ There are four filters available in Fava:
 - **Tags**: Filter entries to the ones having the tags or links selected. This
   filter is inclusive, meaning that if you select multiple tags entries with any
   of those tags will be filtered. This filter also allows for negative filtering
-  (eg. `-#tag` or `-^link`) for excluding certain tags or links from the
-  results.
+  by prepending a `-`, e.g. `-#tag` or `-^link`, to exclude entries with the
+  given tag or link.
 - **Account**: Filter entries by account, matching any entry this account is
   part of. The filter can simply be an account name or a regular expression,
   e.g. `.*:Company:.*` to filter for all that contain `Company` as a component
@@ -37,7 +37,7 @@ There are four filters available in Fava:
 - **Payee**: Filter entries by payee. Like the account filter, this can either
   be a full payee name or a regular expression.
 
-If you select multiple filters (like *Tags* and *Time*), the subset of entries
+If you use multiple filters (like *Tags* and *Time*), the subset of entries
 matching both filters will be selected.
 
 ## Editor

--- a/tests/test_core_filters.py
+++ b/tests/test_core_filters.py
@@ -78,6 +78,9 @@ def test_time_filter(example_ledger):
 
 
 def test_tag_filter(example_ledger):
+    len_all_transactions = sum(map(
+        lambda x: isinstance(x, Transaction),
+        example_ledger.all_entries))
     tag_filter = TagFilter()
 
     tag_filter.set('#nomatch, ,')
@@ -108,6 +111,19 @@ def test_tag_filter(example_ledger):
     filtered_entries = tag_filter.apply(
         example_ledger.all_entries, example_ledger.options)
     assert len(filtered_entries) == len(example_ledger.all_entries)
+
+    assert tag_filter.set('-#nomatch')
+    filtered_entries = tag_filter.apply(
+        example_ledger.all_entries, example_ledger.options)
+    assert len(filtered_entries) == len_all_transactions
+
+    tag_filter.set('-#test')
+    filtered_entries = tag_filter.apply(
+        example_ledger.all_entries, example_ledger.options)
+    assert all(map(
+        lambda x: isinstance(x, Transaction),
+        filtered_entries))
+    assert len(filtered_entries) == len_all_transactions - 2
 
 
 def test_payee_filter(example_ledger):

--- a/tests/test_core_filters.py
+++ b/tests/test_core_filters.py
@@ -78,9 +78,6 @@ def test_time_filter(example_ledger):
 
 
 def test_tag_filter(example_ledger):
-    len_all_transactions = sum(map(
-        lambda x: isinstance(x, Transaction),
-        example_ledger.all_entries))
     tag_filter = TagFilter()
 
     tag_filter.set('#nomatch, ,')
@@ -115,15 +112,12 @@ def test_tag_filter(example_ledger):
     assert tag_filter.set('-#nomatch')
     filtered_entries = tag_filter.apply(
         example_ledger.all_entries, example_ledger.options)
-    assert len(filtered_entries) == len_all_transactions
+    assert len(filtered_entries) == len(example_ledger.all_entries)
 
     tag_filter.set('-#test')
     filtered_entries = tag_filter.apply(
         example_ledger.all_entries, example_ledger.options)
-    assert all(map(
-        lambda x: isinstance(x, Transaction),
-        filtered_entries))
-    assert len(filtered_entries) == len_all_transactions - 2
+    assert len(filtered_entries) == len(example_ledger.all_entries) - 2
 
 
 def test_payee_filter(example_ledger):


### PR DESCRIPTION
Adds the ability to exclude certain tags for filtering for `-#tag` and certain links by filtering for `-#link`.