### PR TITLE
Faster balance sheets

### DIFF
--- a/fava/core/charts.py
+++ b/fava/core/charts.py
@@ -3,7 +3,7 @@ import datetime
 
 from beancount.core import flags, convert, realization
 from beancount.core.amount import Amount
-from beancount.core.data import Transaction
+from beancount.core.data import Transaction, Cost
 from beancount.core.display_context import DisplayContext
 from beancount.core.number import Decimal, MISSING
 from beancount.core.position import Position
@@ -165,11 +165,16 @@ class ChartModule(FavaModule):
         txn = next(transactions, None)
         inventory = Inventory()
 
+        today = datetime.datetime.today().replace(
+            hour=0, minute=0, second=0, microsecond=0)
         for date in self.ledger.interval_ends(interval):
             while txn and txn.date < date:
                 for posting in filter(lambda p: p.account.startswith(types),
                                       txn.postings):
-                    inventory.add_position(posting)
+                    inventory.add_amount(
+                        posting.units,
+                        Cost(0, posting.cost.currency, today, None)
+                        if posting.cost else None)
                 txn = next(transactions, None)
             yield {
                 'date': date,

--- a/tests/test_core_charts.py
+++ b/tests/test_core_charts.py
@@ -2,6 +2,8 @@ import datetime
 
 from beancount.core.number import D
 
+from fava.application import app
+
 
 def test_linechart_data(example_ledger):
     data = example_ledger.charts.linechart(
@@ -16,3 +18,17 @@ def test_net_worth(example_ledger):
     assert data[-18]['balance']['USD'] == D('39125.34004')
     assert data[-1]['date'] == datetime.date(2016, 5, 10)
     assert data[-1]['balance']['USD'] == D('102327.53144')
+
+
+def test_hierarchy(example_ledger):
+    with app.test_request_context('/'):
+        app.preprocess_request()
+        data = example_ledger.charts.hierarchy('Assets')
+        assert data['balance_children'] == {'IRAUSD': D('7200.00'),
+                                            'USD': D('94320.27840'),
+                                            'VACHR': D('-82')}
+        assert data['balance'] == {}
+        # Assets:US:ETrade
+        etrade = data['children'][1]['children'][2]
+        assert etrade['children'][1]['balance'] == {'USD': D('4899.98')}
+        assert etrade['balance_children'] == {'USD': D('23137.54')}


### PR DESCRIPTION
Two improvements, when mixed with https://bitbucket.org/blais/beancount/issues/191/beancountcoreinventory-should-be-a-dict, reduce my balance sheet computation time from over 3 seconds to around 1 second.