### PR TITLE
Tree table optimizations; show unrealized gain

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -95,6 +95,31 @@ fava.core.helpers
 
 .. automodule:: fava.core.helpers
 
+fava.core.ingest
+~~~~~~~~~~~~~~~~
+
+.. automodule:: fava.core.ingest
+
+fava.core.inventory
+~~~~~~~~~~~~~~~~~~~
+
+.. automodule:: fava.core.inventory
+
+fava.core.misc
+~~~~~~~~~~~~~~
+
+.. automodule:: fava.core.misc
+
+fava.core.query_shell
+~~~~~~~~~~~~~~~~~~~~~
+
+.. automodule:: fava.core.query_shell
+
+fava.core.tree
+~~~~~~~~~~~~~~
+
+.. automodule:: fava.core.tree
+
 fava.core.watcher
 ~~~~~~~~~~~~~~~~~
 

--- a/fava/core/__init__.py
+++ b/fava/core/__init__.py
@@ -274,7 +274,7 @@ class FavaLedger():
     def root_tree_closed(self):
         """A root tree for the balance sheet."""
         tree = Tree(self.entries)
-        tree.cap(self.options, 'Unrealized')
+        tree.cap(self.options, self.fava_options['unrealized'])
         return tree
 
     def interval_balances(self, interval, account_name, accumulate=False):

--- a/fava/core/fava_options.py
+++ b/fava/core/fava_options.py
@@ -14,28 +14,28 @@ OptionError = namedtuple('OptionError', 'source message entry')
 InsertEntryOption = namedtuple('InsertEntryOption', 'date re filename lineno')
 
 DEFAULTS = {
-    'default-file': None,
     'account-journal-include-children': True,
     'auto-reload': False,
     'charts': True,
-    'use-external-editor': False,
-    'show-closed-accounts': False,
-    'show-accounts-with-zero-balance': True,
-    'show-accounts-with-zero-transactions': True,
-    'uptodate-indicator-grey-lookback-days': 60,
-    'upcoming-events': 7,
-    'sidebar-show-queries': 5,
+    'default-file': None,
     'editor-print-margin-column': 60,
     'extensions': [],
-    'journal-show':
-    ['transaction', 'balance', 'note', 'document', 'custom', 'budget'],
-    'journal-show-transaction': ['cleared', 'pending'],
-    'journal-show-document': ['discovered', 'statement'],
-    'language': None,
-    'interval': 'month',
-    'insert-entry': [],
     'import-config': None,
     'import-dirs': [],
+    'insert-entry': [],
+    'interval': 'month',
+    'journal-show': ['transaction', 'balance', 'note', 'document', 'custom',
+                     'budget'],
+    'journal-show-document': ['discovered', 'statement'],
+    'journal-show-transaction': ['cleared', 'pending'],
+    'language': None,
+    'show-accounts-with-zero-balance': True,
+    'show-accounts-with-zero-transactions': True,
+    'show-closed-accounts': False,
+    'sidebar-show-queries': 5,
+    'upcoming-events': 7,
+    'uptodate-indicator-grey-lookback-days': 60,
+    'use-external-editor': False,
 }
 
 BOOL_OPTS = [
@@ -50,23 +50,23 @@ BOOL_OPTS = [
 
 INT_OPTS = [
     'editor-print-margin-column',
-    'sidebar-show-queries',
-    'uptodate-indicator-grey-lookback-days',
     'upcoming-events',
+    'uptodate-indicator-grey-lookback-days',
+    'sidebar-show-queries',
 ]
 
 LIST_OPTS = [
     'extensions',
+    'import-dirs',
     'journal-show',
     'journal-show-document',
     'journal-show-transaction',
-    'import-dirs',
 ]
 
 STR_OPTS = [
-    'language',
-    'interval',
     'import-config',
+    'interval',
+    'language',
 ]
 
 

--- a/fava/core/fava_options.py
+++ b/fava/core/fava_options.py
@@ -33,6 +33,7 @@ DEFAULTS = {
     'show-accounts-with-zero-transactions': True,
     'show-closed-accounts': False,
     'sidebar-show-queries': 5,
+    'unrealized': 'Unrealized',
     'upcoming-events': 7,
     'uptodate-indicator-grey-lookback-days': 60,
     'use-external-editor': False,
@@ -67,6 +68,7 @@ STR_OPTS = [
     'import-config',
     'interval',
     'language',
+    'unrealized',
 ]
 
 

--- a/fava/core/inventory.py
+++ b/fava/core/inventory.py
@@ -1,0 +1,67 @@
+"""Alternative implementation of Beancount's Inventory."""
+
+from beancount.core.amount import Amount
+from beancount.core.number import ZERO
+from beancount.core.position import Position
+
+
+# pylint: disable=abstract-method
+class CounterInventory(dict):
+    """A lightweight inventory.
+
+    This is intended as a faster alternative to Beancount's Inventory class.
+    Due to not using a list, for inventories with a lot of different positions,
+    inserting is much faster.
+
+    The keys should be tuples ``(currency, cost)``.
+    """
+
+    def is_empty(self):
+        """Check if the inventory is empty."""
+        return not bool(self)
+
+    def add(self, key, number):
+        """Add a number to key."""
+        new_num = number + self.get(key, ZERO)
+        if new_num == ZERO:
+            self.pop(key, None)
+        else:
+            self[key] = new_num
+
+    def reduce(self, reducer, *args):
+        """Reduce inventory.
+
+        Note that this returns a simple :class:`CounterInventory` with just
+        currencies as keys.
+        """
+        counter = CounterInventory()
+        for (currency, cost), number in self.items():
+            pos = Position(Amount(number, currency), cost)
+            amount = reducer(pos, *args)
+            counter.add(amount.currency, amount.number)
+        return counter
+
+    def add_amount(self, amount, cost=None):
+        """Add an Amount to the inventory."""
+        key = (amount.currency, cost)
+        self.add(key, amount.number)
+
+    def add_position(self, pos):
+        """Add a Position or Posting to the inventory."""
+        self.add_amount(pos.units, pos.cost)
+
+    def __neg__(self):
+        return CounterInventory({key: -num for key, num in self.items()})
+
+    def add_inventory(self, counter):
+        """Add another :class:`CounterInventory`."""
+        if not self:
+            self.update(counter)
+        else:
+            self_get = self.get
+            for key, num in counter.items():
+                new_num = num + self_get(key, ZERO)
+                if new_num == ZERO:
+                    self.pop(key, None)
+                else:
+                    self[key] = new_num

--- a/fava/core/tree.py
+++ b/fava/core/tree.py
@@ -1,0 +1,124 @@
+"""Account balance trees."""
+
+import collections
+
+from beancount.core import account, convert
+
+from fava.core.inventory import CounterInventory
+
+
+# pylint: disable=too-few-public-methods
+class TreeNode(object):
+    """A node in the account tree."""
+    __slots__ = ('name', 'children', 'balance', 'balance_children', 'has_txns')
+
+    def __init__(self, name):
+        #: str: Account name.
+        self.name = name
+        #: A list of :class:`.TreeNode`, its children.
+        self.children = []
+        #: :class:`.CounterInventory`: The cumulative account balance.
+        self.balance_children = CounterInventory()
+        #: :class:`.CounterInventory`: The account balance.
+        self.balance = CounterInventory()
+        #: bool: True if the account has any transactions.
+        self.has_txns = False
+
+
+class Tree(dict):
+    """Account tree.
+
+    Args:
+        entries: A list of entries to compute balances from.
+    """
+    def __init__(self, entries=None):
+        dict.__init__(self)
+        self.get('', insert=True)
+        if entries:
+            account_balances = collections.defaultdict(CounterInventory)
+            for entry in entries:
+                for posting in getattr(entry, 'postings', []):
+                    account_balances[posting.account].add_position(posting)
+
+            for name, balance in sorted(account_balances.items()):
+                self.insert(name, balance)
+
+    def ancestors(self, name):
+        """Ancestors of an account.
+
+        Args:
+            name: An account name.
+        Yields:
+            The ancestors of the given account from the bottom up.
+        """
+        while name:
+            name = account.parent(name)
+            yield self.get(name)
+
+    def insert(self, name, balance):
+        """Insert account with a balance.
+
+        Insert account and update its balance and the balances of its
+        ancestors.
+
+        Args:
+            name: An account name.
+            balance: The balance of the account.
+        """
+        node = self.get(name, insert=True)
+        node.balance.add_inventory(balance)
+        node.balance_children.add_inventory(balance)
+        node.has_txns = True
+        for parent_node in self.ancestors(name):
+            parent_node.balance_children.add_inventory(balance)
+
+    def get(self, name, insert=False):
+        """Get an account.
+
+        Args:
+            name: An account name.
+            insert: If True, insert the name into the tree if it does not
+                exist.
+        Returns:
+            TreeNode: The account of that name or an empty account if the
+            account is not in the tree.
+        """
+        try:
+            return self[name]
+        except KeyError:
+            node = TreeNode(name)
+            if insert:
+                if name:
+                    parent = self.get(account.parent(name), insert=True)
+                    parent.children.append(node)
+                self[name] = node
+            return node
+
+    def cap(self, options, unrealized_account):
+        """Transfer Income and Expenses, add conversions and unrealized gains.
+
+        Args:
+            options: The Beancount options.
+            unrealized_account: The name of the account to post unrealized
+                gains to (as a subaccount of Equity).
+        """
+        equity = options['name_equity']
+        conversions = CounterInventory({
+            (currency, None): -number
+            for currency, number
+            in self.get('').balance_children.reduce(convert.get_cost).items()
+        })
+
+        # Add conversions
+        self.insert(equity + ':' + options['account_current_conversions'],
+                    conversions)
+
+        # Insert unrealized gains.
+        self.insert(equity + ':' + unrealized_account,
+                    -self.get('').balance_children)
+
+        # Transfer Income and Expenses
+        self.insert(equity + ':' + options['account_current_earnings'],
+                    self.get(options['name_income']).balance_children)
+        self.insert(equity + ':' + options['account_current_earnings'],
+                    self.get(options['name_expenses']).balance_children)

--- a/fava/docs/options.md
+++ b/fava/docs/options.md
@@ -91,6 +91,15 @@ automatically.
 
 ---
 
+## `unrealized`
+
+Default: `Unrealized`
+
+The subaccount of the Equity account to post unrealized gains to if the account
+trees are shown at market value.
+
+---
+
 ## `journal-show`
 
 Default: `transaction balance note document custom budget`

--- a/fava/static/css/tree-table.css
+++ b/fava/static/css/tree-table.css
@@ -154,9 +154,10 @@
     opacity: .5;
   }
 
-  & .budget {
+  & .diff {
     color: var(--color-budget-zero);
-    margin-right: 4px;
+    font-size: .9em;
+    margin-right: 3px;
 
     &.negative { color: var(--color-budget-negative); }
     &.positive { color: var(--color-budget-positive); }

--- a/fava/templates/_entry_filters.html
+++ b/fava/templates/_entry_filters.html
@@ -30,7 +30,7 @@
     {% set placeholder = placeholders[name] %}
     {% set list = 'list={}'.format(lists[name]) if name in lists else '' %}
     <span{% if not filter_value %} class="empty"{% endif %}>
-      <input id="{{ name }}-filter" data-key="{{ keys[name] }}" name="{{ name }}" type="text"{{ list }} value="{{ filter_value or '' }}" placeholder="{{ placeholder }}" size="{{ (filter_value or placeholder)|length+2 }}">
+      <input id="{{ name }}-filter" data-key="{{ keys[name] }}" name="{{ name }}" type="text" {{ list }} value="{{ filter_value or '' }}" placeholder="{{ placeholder }}" size="{{ (filter_value or placeholder)|length+2 }}">
         <button type="button" tabindex="-1" class="close">&times;</button>
     </span>
 {% endmacro %}

--- a/fava/templates/_tree_table.html
+++ b/fava/templates/_tree_table.html
@@ -1,86 +1,101 @@
 {% import 'macros/_account_macros.html' as account_macros with context %}
 {% set show_other_column = (operating_currencies|length < ledger.options['commodities']|length) %}
+{% set table_hover_text = _('Hold Shift while clicking to expand all children.
+Hold Ctrl or Cmd while clicking to expand one level.') %}
 
-{% macro tree(real_account, totals=True) %}
-    <ol class="tree-table{{ ' two-currencies' if operating_currencies|length > 1 else '' }}" title="{{ _('Hold Shift while clicking to expand all children \nHold Ctrl or Cmd while clicking to expand one level') }}">
-    <li class="head">
-        <p>
-        <span class="account-cell"><span>{{ _('Account') }}</span><button type="button" class="link expand-all hidden" title="{{ _('Expand all accounts') }}">{{ _('Expand all') }}</button></span>
-        {% for currency in operating_currencies %}
-            <span class="num">{{ currency }}</span>
-        {% endfor %}
-        {% if show_other_column %}
-            <span class="other">{{ _('Other') }}</span>
-        {% endif %}
-        </p>
-    </li>
-{% for account in ([real_account] if real_account.account else real_account.values()) recursive %}
-    {% if account|should_show %}
-    {% set balance = account.balance|cost_or_value %}
-    {% set balance_children = account|balance_children|cost_or_value %}
-    <li{% if account.account|should_collapse_account %} class="toggled"{% endif %}>
-        <p{% if not balance.is_empty() %} class='has-balance'{% endif %}>
-        <span class="account-cell depth-{{ loop.depth0 }} droptarget
-        {{- '' if not account|length else ' has-children'}}
-        " data-account-name="{{ account.account }}">
-        {{ account_macros.account_name(account.account, last_segment=True) }}</span>
+{% macro render_diff_and_number(balance, cost, currency) %}
+  {% set num = balance.pop(currency, 0) %}
+  {% if currency in cost %}
+    {% set cost_num = cost.pop(currency, 0) %}
+    {% set diff = num - cost_num %}
+    {% if diff %}
+    <span class="diff{{ ' positive' if diff > 0 else ' negative' }}" title="{{ cost_num|format_currency(currency) }} {{ currency }}">
+      ({{ diff|format_currency(currency) }})
+    </span>
+    {% endif %}
+  {% endif %}
+  <span class="number">{{ num|format_currency(currency) }}</span>
+{% endmacro %}
+
+{% macro tree(account_node, totals=True) %}
+<ol class="tree-table{{ ' two-currencies' if operating_currencies|length > 1 else '' }}" title="{{ table_hover_text }}">
+  <li class="head">
+    <p>
+      <span class="account-cell"><span>{{ _('Account') }}</span><button type="button" class="link expand-all hidden" title="{{ _('Expand all accounts') }}">{{ _('Expand all') }}</button></span>
+      {% for currency in operating_currencies %}
+      <span class="num">{{ currency }}</span>
+      {% endfor %}
+      {% if show_other_column %}
+      <span class="other">{{ _('Other') }}</span>
+      {% endif %}
+    </p>
+  </li>
+  {% for account in ([account_node] if account_node.name else account_node.children) if account|should_show recursive %}
+  {% set balance = account.balance|cost_or_value %}
+  {% set balance_children = account.balance_children|cost_or_value %}
+  {% set cost = account.balance|cost if g.conversion == 'at_value' else {} %}
+  {% set cost_children = account.balance_children|cost if g.conversion == 'at_value' else {} %}
+  <li{{ ' class=toggled' if account.name|should_collapse_account else '' }}>
+    <p{{ ' class=has-balance' if not balance.is_empty() else '' }}>
+    <span class="account-cell depth-{{ loop.depth0 }} droptarget{{ ' has-children' if account.children else '' }}" data-account-name="{{ account.name }}">
+      {{ account_macros.account_name(account.name, last_segment=True) }}
+    </span>
     {% for currency in operating_currencies %}
-        <span class="num">
-            <span class="balance">{{ balance.get_currency_units(currency).number|format_currency(currency) }}</span>
-            <span class="balance-children">{{ balance_children.get_currency_units(currency).number|format_currency(currency) }}</span>
-        </span>
+    <span class="num">
+      <span class="balance">{{ render_diff_and_number(balance, cost, currency) }}</span>
+      <span class="balance-children">{{ render_diff_and_number(balance_children, cost_children, currency) }}</span>
+    </span>
     {% endfor %}
     {% if show_other_column %}
-        <span class="num other">
-            <span class="balance">
-                {% for pos in balance|sort(attribute='units.currency') if pos.units.currency not in operating_currencies %}
-                    {{ pos.units|format_amount }}<br>
-                {% endfor %}
-            </span>
-            <span class="balance-children">
-                {% for pos in balance_children|sort(attribute='units.currency') if pos.units.currency not in operating_currencies %}
-                    {{ pos.units|format_amount }}<br>
-                {% endfor %}
-            </span>
-        </span>
+    <span class="num other">
+      <span class="balance">
+        {% for currency in balance.keys()|sort %}
+        {{ render_diff_and_number(balance, cost, currency) }} {{ currency }}<br>
+        {% endfor %}
+      </span>
+      <span class="balance-children">
+        {% for currency in balance_children.keys()|sort %}
+        {{ render_diff_and_number(balance_children, cost_children, currency) }} {{ currency }}<br>
+        {% endfor %}
+      </span>
+    </span>
     {% endif %}
     </p>
-    {% if account|length %}
+    {% if account.children %}
     <ol>
-    {{ loop(account.values()|sort(attribute='account')) }}
+      {{ loop(account.children|sort(attribute='name')) }}
     </ol>
     {% endif %}
-    </li>
+  </li>
+  {% endfor %}
+  {% if totals %}
+  {% set balance = account_node.balance_children|cost_or_value %}
+  <li class="totals">
+    <p>
+    <span class="account-cell">&nbsp;</span>
+    {% for currency in operating_currencies %}
+    <span class="num">{{ balance.pop(currency, 0)|format_currency(currency) }}</span>
+    {% endfor %}
+    {% if show_other_column %}
+    <span class="num other">
+      {% for currency, number in balance.items()|sort if number %}
+      {{ (number, currency)|format_amount }}<br>
+      {% endfor %}
+    </span>
     {% endif %}
-{% endfor %}
-{% if totals %}
-    {% set balance = real_account|balance_children|cost_or_value %}
-        <li class="totals">
-            <p>
-            <span class="account-cell">&nbsp;</span>
-        {% for currency in operating_currencies %}
-            <span class="num">{{ balance.get_currency_units(currency).number|format_currency(currency) }}</span>
-        {% endfor %}
-        {% if show_other_column %}
-            <span class="num other">
-                {% for pos in balance|sort(attribute='units.currency') if pos.units.currency not in operating_currencies %}
-                    {{ pos.units|format_amount }}<br>
-                {% endfor %}
-            </span>
-        {% endif %}
-            </p>
-        </li>
-{% endif %}
+    </p>
+  </li>
+  {% endif %}
 </ol>
 {% endmacro %}
 
 {% macro render_budget(budget, currency, number=0) %}
-  {% if currency in budget %}
-    {% set diff = budget[currency] - number %}
-    <span class="budget {% if diff > 0 %}positive{% elif diff < 0 %}negative{% endif %}" title="{{ budget[currency]|format_currency(currency) }} {{ currency }}">
-      ({{ diff|format_currency(currency, show_if_zero=True) }}{{ ' '+currency if not number else '' }})
-    </span>
-  {% endif %}
+{% if currency in budget %}
+{% set diff = budget[currency] - number %}
+<span class="diff {% if diff > 0 %}positive{% elif diff < 0 %}negative{% endif %}" title="{{ budget[currency]|format_currency(currency) }} {{ currency }}">
+  ({{ diff|format_currency(currency, show_if_zero=True) }}{{ ' '+currency if not number else '' }})
+</span>
+{% endif %}
 {% endmacro %}
 
 {% macro account_tree(account_name, interval_balances, dates, accumulate) %}
@@ -105,7 +120,7 @@
         <span class="account-cell depth-{{ loop.depth0 }} droptarget
         {{- '' if not account|length else ' has-children'}}
         " data-account-name="{{ account.account }}">
-            {% if account|length %}<span class="expander" title="{{ _('Hold the Shift-key while clicking to expand all children') }}"></span>{% endif %}
+            {% if account|length %}<span class="expander"></span>{% endif %}
         {{ account_macros.account_name(account.account, last_segment=True) }}</span>
     {% for begin_date, end_date in dates %}
         {% if accumulate %}{% set begin_date = dates[-1][0] %}{% endif %}

--- a/fava/templates/balance_sheet.html
+++ b/fava/templates/balance_sheet.html
@@ -9,18 +9,18 @@
     {{ charts.hierarchy(ledger.options['name_liabilities']) }}
     {{ charts.hierarchy(ledger.options['name_equity']) }}
 
-    {% set root_account_closed = ledger.root_account_closed %}
+    {% set root_tree_closed = ledger.root_tree_closed %}
 
     <div class="row">
         <div class="column">
             <h3>{{ ledger.options['name_assets'] }}</h3>
-            {{ tree_table.tree(root_account_closed|get_or_create(ledger.options['name_assets'])) }}
+            {{ tree_table.tree(root_tree_closed.get(ledger.options['name_assets'])) }}
         </div>
         <div class="column">
             <h3>{{ ledger.options['name_liabilities'] }}</h3>
-            {{ tree_table.tree(root_account_closed|get_or_create(ledger.options['name_liabilities'])) }}
+            {{ tree_table.tree(root_tree_closed.get(ledger.options['name_liabilities'])) }}
             <h3>{{ ledger.options['name_equity'] }}</h3>
-            {{ tree_table.tree(root_account_closed|get_or_create(ledger.options['name_equity'])) }}
+            {{ tree_table.tree(root_tree_closed.get(ledger.options['name_equity'])) }}
         </div>
     </div>
 {% endblock %}

--- a/fava/templates/income_statement.html
+++ b/fava/templates/income_statement.html
@@ -15,11 +15,11 @@
     <div class="row">
         <div class="column">
             <h3>{{ ledger.options['name_income'] }}</h3>
-            {{ tree_table.tree(ledger.root_account|get_or_create(ledger.options['name_income'])) }}
+            {{ tree_table.tree(ledger.root_tree.get(ledger.options['name_income'])) }}
         </div>
         <div class="column">
             <h3>{{ ledger.options['name_expenses'] }}</h3>
-            {{ tree_table.tree(ledger.root_account|get_or_create(ledger.options['name_expenses'])) }}
+            {{ tree_table.tree(ledger.root_tree.get(ledger.options['name_expenses'])) }}
         </div>
     </div>
 {% endblock %}

--- a/fava/templates/trial_balance.html
+++ b/fava/templates/trial_balance.html
@@ -9,5 +9,5 @@
         {{ charts.hierarchy(ledger.options['name_{}'.format(base_account)]) }}
     {% endfor %}
 
-    {{ tree_table.tree(ledger.root_account, totals=False) }}
+    {{ tree_table.tree(ledger.root_tree.get(''), totals=False) }}
 {% endblock %}

--- a/tests/test_core_inventory.py
+++ b/tests/test_core_inventory.py
@@ -1,0 +1,44 @@
+from beancount.core.amount import A
+
+from fava.core.inventory import CounterInventory
+
+
+def test_CounterInventory_add():
+    inv = CounterInventory()
+    key = 'KEY'
+    inv.add(key, 10)
+    assert len(inv) == 1
+    inv.add(key, -10)
+    assert inv.is_empty()
+
+
+def test_CounterInventory_add_amount():
+    inv = CounterInventory()
+    inv.add_amount(A('10 USD'))
+    inv.add_amount(A('30 USD'))
+    assert len(inv) == 1
+    inv.add_amount(A('-40 USD'))
+    assert inv.is_empty()
+
+    inv.add_amount(A('10 USD'))
+    inv.add_amount(A('20 CAD'))
+    inv.add_amount(A('10 USD'))
+    assert len(inv) == 2
+    inv.add_amount(A('-20 CAD'))
+    assert len(inv) == 1
+
+
+def test_CounterInventory_add_inventory():
+    inv = CounterInventory()
+    inv2 = CounterInventory()
+    inv3 = CounterInventory()
+    inv.add_amount(A('10 USD'))
+    inv2.add_amount(A('30 USD'))
+    inv3.add_amount(A('-40 USD'))
+    inv.add_inventory(inv2)
+    assert len(inv) == 1
+    inv.add_inventory(inv3)
+    assert inv.is_empty()
+    inv = CounterInventory()
+    inv.add_inventory(inv2)
+    assert len(inv) == 1

--- a/tests/test_core_tree.py
+++ b/tests/test_core_tree.py
@@ -1,0 +1,63 @@
+from beancount.core import realization
+from beancount.ops import summarize
+
+from fava.core.tree import Tree
+
+
+def test_Tree():
+    tree = Tree()
+    assert len(tree) == 1
+    tree.get('account:name:a:b:c')
+    assert len(tree) == 1
+    node = tree.get('account:name:a:b:c', insert=True)
+    assert len(tree) == 6
+    tree.get('account:name', insert=True)
+    assert len(tree) == 6
+    assert node is tree.get('account:name:a:b:c', insert=True)
+
+    assert list(tree.ancestors('account:name:a:b:c')) == [
+        tree.get('account:name:a:b'),
+        tree.get('account:name:a'),
+        tree.get('account:name'),
+        tree.get('account'),
+        tree.get(''),
+    ]
+
+    assert len(list(tree.ancestors('not:account:name:a:b:c'))) == 6
+
+
+def _compare_inv_and_counter(inv, counter):
+    for pos in inv:
+        assert pos.units.number == counter[(pos.units.currency, pos.cost)]
+    if counter:
+        assert len(inv) == len(counter)
+
+
+def test_Tree_from_entries(example_ledger):
+    tree = Tree(example_ledger.entries)
+    real_account = realization.realize(example_ledger.entries)
+
+    for account in realization.iter_children(real_account):
+        name = account.account
+        node = tree[name]
+        _compare_inv_and_counter(account.balance, node.balance)
+        _compare_inv_and_counter(
+            realization.compute_balance(account), node.balance_children)
+
+
+def test_Tree_cap(example_ledger):
+    closing_entries = summarize.cap_opt(
+        example_ledger.entries, example_ledger.options)
+    real_account = realization.realize(closing_entries)
+
+    tree = Tree(example_ledger.entries)
+    tree.cap(example_ledger.options, 'Unrealized')
+
+    for account in realization.iter_children(real_account):
+        name = account.account
+        node = tree[name]
+        if not name:
+            continue
+        if name.startswith('Expenses') or name.startswith('Income'):
+            continue
+        _compare_inv_and_counter(account.balance, node.balance)


### PR DESCRIPTION
First, this contains some improvements to the balance trees are calculated. Since Beancount's inventories are currently based on lists, this helps in particular for balances containing lots of holdings at cost.

Secondly, if "At Value" is selected, the unrealized gains will be shown next to the market value (similar to how budgets are displayed). This looks as follows (I guess the cell widths should be increased):

![screenshot-2017-10-6 balance sheet - huge example file](https://user-images.githubusercontent.com/2482259/31294621-dff6df16-aadb-11e7-885c-b408bf5ff310.png)

Ref #589 