### PR TITLE
Reinstate removal of symlink

### DIFF
--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -16,7 +16,7 @@ RUN cd /root \
         && (cd fava && git log -1) \
         && make -C fava \
         && make -C fava mostlyclean \
-        && rm fava/CHANGES \
+        && rm fava/docs/changelog.rst \
         && python3 -mpip install ./fava \
         && python3 -mpip uninstall --yes pip \
         && find /usr/local/lib/python3.6/site-packages -name *.so -print0|xargs -0 strip -v \


### PR DESCRIPTION
Was broken in the changelog move: https://github.com/beancount/fava/commit/433d5bcd512f4079505c64ebcc933dd45a8c98a2