### PR TITLE
When dropping a document on a transaction, use tx date in filename suggestion

### DIFF
--- a/fava/static/javascript/documents-upload.js
+++ b/fava/static/javascript/documents-upload.js
@@ -49,7 +49,7 @@ e.on('page-loaded', () => {
       const folders = $$('#document-upload-folder option');
       const { files } = event.dataTransfer;
       let entryDate = new Date();
-      let entryDateString = target.getAttribute('data-entry-date');
+      const entryDateString = target.getAttribute('data-entry-date');
       if (entryDateString) {
         entryDate = new Date(entryDateString);
       }

--- a/fava/static/javascript/documents-upload.js
+++ b/fava/static/javascript/documents-upload.js
@@ -48,8 +48,8 @@ e.on('page-loaded', () => {
 
       const folders = $$('#document-upload-folder option');
       const { files } = event.dataTransfer;
-      var entryDate = new Date();
-      var entryDateString = target.getAttribute('data-entry-date');
+      let entryDate = new Date();
+      let entryDateString = target.getAttribute('data-entry-date');
       if (entryDateString) {
         entryDate = new Date(entryDateString);
       }

--- a/fava/static/javascript/documents-upload.js
+++ b/fava/static/javascript/documents-upload.js
@@ -48,6 +48,11 @@ e.on('page-loaded', () => {
 
       const folders = $$('#document-upload-folder option');
       const { files } = event.dataTransfer;
+      var entryDate = new Date();
+      var entryDateString = target.getAttribute('data-entry-date');
+      if (entryDateString) {
+        entryDate = new Date(entryDateString);
+      }
       let changedFilename = false;
 
       if (!folders.length) {
@@ -61,7 +66,7 @@ e.on('page-loaded', () => {
         let filename = files[i].name;
 
         if (filename.length < 11 || filenameRegex.test(filename.substring(0, 10)) === false) {
-          filename = `${new Date().toISOString().substring(0, 10)} ${filename}`;
+          filename = `${entryDate.toISOString().substring(0, 10)} ${filename}`;
           changedFilename = true;
         }
 

--- a/fava/templates/_journal_table.html
+++ b/fava/templates/_journal_table.html
@@ -118,7 +118,7 @@
         <p>
         <span class="datecell" data-sort-value=-{{ loop.index }}><a href="#context-{{ entry_hash }}">{{ entry.date }}</a></span>
         <span class="flag">{{ entry.flag }}</span>
-    <span class="description{% if type != 'transaction' %}"{% else %} droptarget" data-entry="{{ entry_hash }}" data-account-name="{{ entry.postings[0].account if entry.postings else "" }}"{% endif %}>
+        <span class="description{% if type != 'transaction' %}"{% else %} droptarget" data-entry="{{ entry_hash }}" data-entry-date="{{ entry.date }}" data-account-name="{{ entry.postings[0].account if entry.postings else "" }}"{% endif %}>
         {% if type == 'open' %}
             Open {{ account_link(entry.account) }}
         {% elif type == 'close' %}
@@ -178,7 +178,7 @@
             <p>
                 <span class="datecell"></span>
                 <span class="flag"> </span>
-                <span class="description droptarget" data-entry="{{ entry_hash }}" data-account-name="{{ posting.account }}">{{ account_link(posting.account) }}</span>
+                <span class="description droptarget" data-entry="{{ entry_hash }}" data-account-name="{{ posting.account }}" data-entry-date="{{ entry.date }}">{{ account_link(posting.account) }}</span>
                 {# We want the output these amounts with the same precision as in the input file.
                    For computed values this might give a lot of digits, so format the price using the DisplayContext for now.#}
                 <span class="num">{{ posting.units or '' }}</span>


### PR DESCRIPTION
When I want to add a document to a transaction (e.g. a trade confirmation for that tx), fava prepends the current date in its suggested filename. It would make more sense to suggest the date of the transaction by default.