### PR TITLE
Enable filtering on a link only

### DIFF
--- a/fava/core/filters.py
+++ b/fava/core/filters.py
@@ -147,7 +147,7 @@ class TagFilter(EntryFilter):
         include = hasattr(entry, 'tags') and (
             (entry.tags & self.tags) or
             (entry.links & self.links)
-        ) if self.tags else True
+        ) if self.tags or self.links else True
 
         exclude = hasattr(entry, 'tags') and (
             (entry.tags & self.exclude_tags) or

--- a/tests/example.beancount
+++ b/tests/example.beancount
@@ -2744,17 +2744,17 @@ option "operating_currency" "USD"
   Assets:US:ETrade:Cash                              0.00 USD
   Income:US:ETrade:Dividends                         0.00 USD
 
-2014-09-25 * "Buy shares of GLD" #test
+2014-09-25 * "Buy shares of GLD" #test ^test-link
   Assets:US:ETrade:Cash                          -4908.79 USD
   Assets:US:ETrade:GLD                                 44 GLD {111.36 USD}
   Expenses:Financial:Commissions                     8.95 USD
 
-2014-11-15 * "Buy shares of ITOT"
+2014-11-15 * "Buy shares of ITOT" ^test-link
   Assets:US:ETrade:Cash                           -757.39 USD
   Assets:US:ETrade:ITOT                                 9 ITOT {83.16 USD}
   Expenses:Financial:Commissions                     8.95 USD
 
-2014-11-15 * "Buy shares of GLD"
+2014-11-15 * "Buy shares of GLD" ^test-link
   Assets:US:ETrade:Cash                           -779.37 USD
   Assets:US:ETrade:GLD                                  7 GLD {110.06 USD}
   Expenses:Financial:Commissions                     8.95 USD

--- a/tests/test_core_filters.py
+++ b/tests/test_core_filters.py
@@ -119,6 +119,21 @@ def test_tag_filter(example_ledger):
         example_ledger.all_entries, example_ledger.options)
     assert len(filtered_entries) == len(example_ledger.all_entries) - 2
 
+    tag_filter.set('^test-link')
+    filtered_entries = tag_filter.apply(
+        example_ledger.all_entries, example_ledger.options)
+    assert len(filtered_entries) == 3
+
+    tag_filter.set('^test-link,#test')
+    filtered_entries = tag_filter.apply(
+        example_ledger.all_entries, example_ledger.options)
+    assert len(filtered_entries) == 4
+
+    tag_filter.set('^test-link,-#test')
+    filtered_entries = tag_filter.apply(
+        example_ledger.all_entries, example_ledger.options)
+    assert len(filtered_entries) == 2
+
 
 def test_payee_filter(example_ledger):
     payee_filter = PayeeFilter()


### PR DESCRIPTION
Fixes #611.

Previously, filtering on a link only worked if you also filtered on a tag at the same time.