### PR TITLE
Add todo_as_error plugin

### DIFF
--- a/fava/help/features.md
+++ b/fava/help/features.md
@@ -189,3 +189,15 @@ corresponding transaction and can be filtered in the Journal:
 
 When displaying a Journal, including a filtered Journal, the entries displayed
 can be downloaded in Beancount format by clicking the `Export` button.
+
+### Display 'todo'-metadata-entries as errors
+
+When enabling the `todo_as_error`-plugin, transactions with the `todo`-metadata-key will be added as Beancount errors, displaying the value of the `todo`-metadata-entry as the error description.
+
+    plugin "fava.plugins.link_statements"
+
+    2017-12-27 * "" "Groceries"
+      todo: "Put the milk into the fridge"
+      Expenses:Groceries   150.00 USD
+      Assets:Cash
+

--- a/fava/plugins/todo_as_error.py
+++ b/fava/plugins/todo_as_error.py
@@ -1,0 +1,22 @@
+"""Beancount plugin that creates errors from 'todo'-metadata-entries.
+
+It looks through all Transaction entries that have the 'todo'-metadata-entry
+and creates errors from these entries.
+"""
+import collections
+
+from beancount.core.data import Transaction
+
+__plugins__ = ['todo_as_error', ]
+
+TodoError = collections.namedtuple('TodoError', 'source message entry')
+
+
+def todo_as_error(entries, _):
+    errors = []
+
+    for entry in entries:
+        if isinstance(entry, Transaction) and 'todo' in entry.meta:
+            errors.append(TodoError(entry.meta, entry.meta['todo'], entry))
+
+    return entries, errors

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,6 +1,7 @@
 from textwrap import dedent
 from beancount.loader import load_file, load_string
 from fava.plugins.link_statements import StatementDocumentError
+from fava.plugins.todo_as_error import TodoError
 
 
 def test_plugins(tmpdir):
@@ -103,3 +104,20 @@ def test_link_statements_missing(tmpdir):
     assert len(errors) == 1
     assert isinstance(errors[0], StatementDocumentError)
     assert len(entries) == 3
+
+
+def test_todo_as_error(load_doc):
+    """
+    plugin "fava.plugins.todo_as_error"
+    plugin "beancount.plugins.auto_accounts"
+
+    2016-11-01 * "Foo" "Bar"
+        todo: "This will become an error"
+        Expenses:Foo                100 EUR
+        Assets:Cash
+    """
+    entries, errors, _ = load_doc
+
+    assert len(errors) == 1
+    assert isinstance(errors[0], TodoError)
+    assert errors[0].message == 'This will become an error'


### PR DESCRIPTION
## Display 'todo'-metadata-entries as errors

When enabling the `todo_as_error`-plugin, transactions with the `todo`-metadata-key will be added as Beancount errors, displaying the value of the `todo`-metadata-entry as the error description.

```ruby
    plugin "fava.plugins.link_statements"

    2017-12-27 * "" "Groceries"
      todo: "Put the milk into the fridge"
      Expenses:Groceries   150.00 USD
      Assets:Cash
```