### PR TITLE
Entry form: /-key does divide the number by 2

### DIFF
--- a/fava/json_api.py
+++ b/fava/json_api.py
@@ -122,6 +122,15 @@ def add_document():
     return _api_success(message='Uploaded to {}'.format(filepath))
 
 
+def _parse_number(num):
+    if not num:
+        return None
+    if '/' in num:
+        left, right = num.split('/')
+        return D(left) / D(right)
+    return D(num)
+
+
 def json_to_entry(json_entry, valid_accounts):
     """Parse JSON to a Beancount entry."""
     # pylint: disable=not-callable
@@ -140,7 +149,7 @@ def json_to_entry(json_entry, valid_accounts):
                 raise FavaAPIException('Unknown account: {}.'
                                        .format(posting['account']))
             data.create_simple_posting(txn, posting['account'],
-                                       posting.get('number') or None,
+                                       _parse_number(posting.get('number')),
                                        posting.get('currency'))
 
         return txn
@@ -148,7 +157,7 @@ def json_to_entry(json_entry, valid_accounts):
         if json_entry['account'] not in valid_accounts:
             raise FavaAPIException(
                 'Unknown account: {}.'.format(json_entry['account']))
-        number = D(json_entry['number'])
+        number = _parse_number(json_entry['number'])
         amount = Amount(number, json_entry.get('currency'))
 
         return data.Balance(json_entry['metadata'], date,

--- a/fava/static/css/base.css
+++ b/fava/static/css/base.css
@@ -78,7 +78,7 @@ h4,
 h5 {
   color: var(--color-headings);
   font-weight: 500;
-  margin: 0 0 1rem;
+  margin: 0 .5rem 1rem 0;
   padding: 0;
 }
 

--- a/fava/static/css/ingest.css
+++ b/fava/static/css/ingest.css
@@ -41,6 +41,7 @@
 
     & label {
       display: inline-block;
+      margin: 0;
     }
   }
 

--- a/fava/templates/_entry_forms.html
+++ b/fava/templates/_entry_forms.html
@@ -1,20 +1,18 @@
 {% macro posting(posting=None) %}
 <div class="fieldset posting">
-  <label for="account">{{ _('Posting') }}:</label>
   <button class="muted round remove-fieldset" data-event="remove-fieldset" type="button" tabindex="-1">×</button>
-  <input type="text" class="account" placeholder="{{ _('Account') }}" list="accounts" value="{{ posting.account or '' }}"/>
-  <input type="number" step="0.01" class="number" placeholder="{{ _('Number') }}" value="{{ posting.units.number if posting else '' }}"/>
-  <input type="text" class="currency" placeholder="{{ _('Currency') }}" list="currencies" value="{{ posting.units.currency if posting else '' }}"/>
+  <input type="text" class="account" placeholder="{{ _('Account') }}" list="accounts" value="{{ posting.account or '' }}">
+  <input type="tel" class="number" placeholder="{{ _('Number') }}" value="{{ posting.units.number if posting else '' }}">
+  <input type="text" class="currency" placeholder="{{ _('Currency') }}" list="currencies" value="{{ posting.units.currency if posting else '' }}">
   <button class="muted round add-row" type="button" data-event="add-posting" title="{{ _('Add posting') }}">+</button>
 </div>
 {% endmacro %}
 
 {% macro metadata(key=None, value=None) %}
 <div class="fieldset metadata-row">
-  <label for="account">{{ _('Metadata') }}:</label>
   <button class="muted round remove-fieldset" data-event="remove-fieldset" type="button" tabindex="-1">×</button>
-  <input type="text" class="metadata-key" placeholder="{{ _('Key') }}" value="{{ key or '' }}"/>
-  <input type="text" class="metadata-value" placeholder="{{ _('Value') }}" value="{{ value or '' }}"/>
+  <input type="text" class="metadata-key" placeholder="{{ _('Key') }}" value="{{ key or '' }}">
+  <input type="text" class="metadata-value" placeholder="{{ _('Value') }}" value="{{ value or '' }}">
   <button class="muted round add-row" type="button" data-event="add-metadata" title="{{ _('Add metadata') }}">+</button>
 </div>
 {% endmacro %}
@@ -22,13 +20,12 @@
 {% macro transaction(entry=None) %}
 <div class="entry-form transaction" data-type="transaction">
   <div class="fieldset">
-    <label for="date">{{ _('Date') }}:</label>
-    <input type="date" name="date" value="{{ entry.date or today() }}" />
+    <input type="date" name="date" value="{{ entry.date or today() }}">
     <input type="text" name="flag" value="{{ entry.flag or '*' }}">
     <label for="payee">{{ _('Payee') }}:</label>
-    <input type="text" name="payee" placeholder="{{ _('Payee') }}" list="payees" value="{{ entry.payee or '' }}"/>
+    <input type="text" name="payee" placeholder="{{ _('Payee') }}" list="payees" value="{{ entry.payee or '' }}">
     <label for="payee">{{ _('Narration') }}:</label>
-    <input type="text" name="narration" placeholder="{{ _('Narration') }}" value="{{ entry.narration or '' }}"/>
+    <input type="text" name="narration" placeholder="{{ _('Narration') }}" value="{{ entry.narration or '' }}">
     <button class="muted round" type="button" data-event="add-metadata" title="{{ _('Add metadata') }}">m</button>
     <button class="muted round" type="button" data-event="add-posting" title="{{ _('Add posting') }}">p</button>
   </div>
@@ -47,14 +44,12 @@
 
 {% macro balance(entry=None) %}
 <div class="entry-form balance" data-type="balance">
-  <h4>{{ _('Balance') }}</h4>
   <div class="fieldset">
-    <label for="date">{{ _('Date') }}:</label>
-    <input type="date" name="date" value="{{ entry.date or today() }}" />
-    <label for="account">{{ _('Account') }}:</label>
-    <input type="text" class="account" name="account" placeholder="{{ _('Account') }}" list="accounts" value="{{ entry.account or '' }}"/>
-    <input type="number" step="0.01" class="number" name="number" placeholder="{{ _('Number') }}" value="{{ entry.amount.number if entry.amount else '' }}"/>
-    <input type="text" class="currency" name="currency" placeholder="{{ _('Currency') }}" list="currencies" value="{{ entry.amount.currency if entry.amount else '' }}"/>
+    <input type="date" name="date" value="{{ entry.date or today() }}" >
+    <h4>{{ _('Balance') }}</h4>
+    <input type="text" class="account" name="account" placeholder="{{ _('Account') }}" list="accounts" value="{{ entry.account or '' }}">
+    <input type="tel" class="number" name="number" placeholder="{{ _('Number') }}" value="{{ entry.amount.number if entry.amount else '' }}">
+    <input type="text" class="currency" name="currency" placeholder="{{ _('Currency') }}" list="currencies" value="{{ entry.amount.currency if entry.amount else '' }}">
     <button class="muted round" type="button" data-event="add-metadata" title="{{ _('Add metadata') }}">m</button>
   </div>
   <div class="metadata">
@@ -67,12 +62,10 @@
 
 {% macro note(entry=None) %}
 <div class="entry-form note" data-type="note">
-  <h4>{{ _('Note') }}</h4>
   <div class="fieldset">
-    <label for="date">{{ _('Date') }}:</label>
-    <input type="date" name="date" value="{{ entry.date or today() }}" />
-    <input type="text" class="account" name="account" placeholder="{{ _('Account') }}" list="accounts" value="{{ entry.account or '' }}"/>
-    <label for="comment">{{ _('Comment') }}:</label>
+    <input type="date" name="date" value="{{ entry.date or today() }}">
+    <h4>{{ _('Note') }}</h4>
+    <input type="text" class="account" name="account" placeholder="{{ _('Account') }}" list="accounts" value="{{ entry.account or '' }}">
     <button class="muted round" type="button" data-event="add-metadata" title="{{ _('Add metadata') }}">m</button>
   </div>
   <div class="fieldset">


### PR DESCRIPTION
This implements a special requirement I have, and this PR is here to show what the change would implement, and a point of discussion if we merge this into `master` or not. 

Here is the feature: As I split many expenses with my girlfriend, I often have to divide amounts by 2, say an expense on my credit card for example, where half goes to my Expense-account and half to her Liabilities-account. With this change, when the focus is in the `number`-input field, whenever the user presses the `/`-key, the number get's divided by 2. This makes this kind of entries very quick to do.

This change should not really "interrupt" anyone who does not know or need this feature, as it is not very common to enter `/` in the number-input-field. 

@yagebu What do you think of this? Are you OK with merging this into `master`?