### PR TITLE
Fix Editor focus

### DIFF
--- a/fava/static/javascript/editor.js
+++ b/fava/static/javascript/editor.js
@@ -146,8 +146,8 @@ function initQueryEditor() {
   const editor = CodeMirror.fromTextArea(queryForm.elements.query_string, queryOptions);
 
   editor.on('keyup', (cm, event) => {
-    if (!cm.state.completionActive && event.keyCode !== 13 &&
-        event.keyCode !== 27 && (event.keyCode < 33 || event.keyCode > 40)) {
+    const key = event.keyCode;
+    if (!cm.state.completionActive && key !== 13 && key !== 27 && (key < 33 || key > 40)) {
       CodeMirror.commands.autocomplete(cm, null, { completeSingle: false });
     }
   });
@@ -221,8 +221,8 @@ export default function initSourceEditor(name) {
   });
 
   editor.on('keyup', (cm, event) => {
-    if (!cm.state.completionActive && event.keyCode !== 13 &&
-        event.keyCode !== 27 && (event.keyCode < 33 || event.keyCode > 40)) {
+    const key = event.keyCode;
+    if (!cm.state.completionActive && key !== 13 && key !== 27 && (key < 33 || key > 40)) {
       CodeMirror.commands.autocomplete(cm, null, { completeSingle: false });
     }
   });

--- a/fava/static/javascript/editor.js
+++ b/fava/static/javascript/editor.js
@@ -146,7 +146,8 @@ function initQueryEditor() {
   const editor = CodeMirror.fromTextArea(queryForm.elements.query_string, queryOptions);
 
   editor.on('keyup', (cm, event) => {
-    if (!cm.state.completionActive && event.keyCode !== 13) {
+    if (!cm.state.completionActive && event.keyCode !== 13 &&
+        (event.keyCode < 33 || event.keyCode > 40)) {
       CodeMirror.commands.autocomplete(cm, null, { completeSingle: false });
     }
   });
@@ -220,7 +221,8 @@ export default function initSourceEditor(name) {
   });
 
   editor.on('keyup', (cm, event) => {
-    if (!cm.state.completionActive && event.keyCode !== 13) {
+    if (!cm.state.completionActive && event.keyCode !== 13 &&
+        (event.keyCode < 33 || event.keyCode > 40)) {
       CodeMirror.commands.autocomplete(cm, null, { completeSingle: false });
     }
   });

--- a/fava/static/javascript/editor.js
+++ b/fava/static/javascript/editor.js
@@ -147,7 +147,7 @@ function initQueryEditor() {
 
   editor.on('keyup', (cm, event) => {
     if (!cm.state.completionActive && event.keyCode !== 13 &&
-        (event.keyCode < 33 || event.keyCode > 40)) {
+        event.keyCode !== 27 && (event.keyCode < 33 || event.keyCode > 40)) {
       CodeMirror.commands.autocomplete(cm, null, { completeSingle: false });
     }
   });
@@ -222,7 +222,7 @@ export default function initSourceEditor(name) {
 
   editor.on('keyup', (cm, event) => {
     if (!cm.state.completionActive && event.keyCode !== 13 &&
-        (event.keyCode < 33 || event.keyCode > 40)) {
+        event.keyCode !== 27 && (event.keyCode < 33 || event.keyCode > 40)) {
       CodeMirror.commands.autocomplete(cm, null, { completeSingle: false });
     }
   });


### PR DESCRIPTION
This PR regards the autocomplete popup and how it reacts to different keystrokes. 

- Don't open the popup when navigating the editor with arrow keys (see #606)
- When the popup is shown and the user presses `Esc`, close the popup.

Fixes #606