### PR TITLE
Confirmaton to save changes in editor

### DIFF
--- a/fava/static/javascript/editor.js
+++ b/fava/static/javascript/editor.js
@@ -222,6 +222,7 @@ const sourceEditorOptions = {
   },
 };
 
+let activeEditor = null;
 // Init source editor.
 export default function initSourceEditor(name) {
   sourceEditorOptions.rulers = [];
@@ -236,6 +237,9 @@ export default function initSourceEditor(name) {
   if (!sourceEditorTextarea) { return; }
 
   const editor = CodeMirror.fromTextArea(sourceEditorTextarea, sourceEditorOptions);
+  if (name === '#source-editor') {
+    activeEditor = editor;
+  }
   const saveButton = $(`${name}-submit`);
   editor.setOption('favaSaveButton', saveButton);
 
@@ -284,4 +288,27 @@ e.on('page-loaded', () => {
   initQueryEditor();
   initReadOnlyEditors();
   initSourceEditor('#source-editor');
+});
+
+const leaveMessage = 'There are unsaved changes. Are you sure you want to leave?';
+
+e.on('navigate', (state) => {
+  if (activeEditor) {
+    if (!activeEditor.isClean()) {
+      const leave = window.confirm(leaveMessage); // eslint-disable-line no-alert
+      if (!leave) {
+        state.interrupt = true; // eslint-disable-line no-param-reassign
+      } else {
+        activeEditor = null;
+      }
+    } else {
+      activeEditor = null;
+    }
+  }
+});
+
+window.addEventListener('beforeunload', (event) => {
+  if (activeEditor && !activeEditor.isClean()) {
+    event.returnValue = leaveMessage; // eslint-disable-line no-param-reassign
+  }
 });

--- a/fava/static/javascript/router.js
+++ b/fava/static/javascript/router.js
@@ -72,6 +72,10 @@ class Router {
   // Replace <article> contents with the page at `url`. If `historyState` is
   // false, do not create a history state.
   loadURL(url, historyState = true) {
+    const state = { interrupt: false };
+    e.trigger('navigate', state);
+    if (state.interrupt) { return; }
+
     const getUrl = new URL(url);
     getUrl.searchParams.set('partial', true);
 


### PR DESCRIPTION
This tries to implement the first part of #605: Adding a confirmation dialog when navigation away from the Editor when there are unsaved changes.

Ref #605