### PR TITLE
Fix dockerfile cleanup

### DIFF
--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -21,7 +21,7 @@ RUN cd /root \
         && python3 -mpip uninstall --yes pip \
         && find /usr/local/lib/python3.6/site-packages -name *.so -print0|xargs -0 strip -v \
         && apk del $BUILDDEPS \
-        && rm -rf /var/cache/apk/{*,.[!.]*} /tmp/{*,.[!.]*} /root/{*,.[!.]*} \
+        && rm -rf /var/cache/apk/* /var/cache/apk/.[!.]* /tmp/* /tmp/.[!.]* /root/* /root/.[!.]* \
         && find /usr/local/lib/python3.6 -name __pycache__ -print0|xargs -0 rm -rf \
         && find /usr/local/lib/python3.6 -name *.pyc -print0|xargs -0 rm -f
 


### PR DESCRIPTION
The previous implementation used a bashism, which isn't available in the
sh that Docker's RUN uses so no cleanup was actually happening - npm caches etc were left behind. Fixing removes ~80MB from the image size.