### PR TITLE
Fix minor cosmetic issues in documentation

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -40,7 +40,7 @@ import transactions from your bank for example.
 Fava can now show your balances at market value or convert them to a single
 currency if your file contains the necessary price information.
 
-We now also provide a compiled GUI version of Fava for Linux and MacOS. This
+We now also provide a compiled GUI version of Fava for Linux and macOS. This
 version might still be a bit buggy so any feedback/help on it is very welcome.
 
 Other changes:
@@ -322,7 +322,7 @@ v0.2.0 (February 11th, 2016 - first release of `fava`)
 - 2016-01-07 - Added setting ``collapse-accounts`` to specify a list of
   accounts to collapse in the account hierarchy. :bug:`91`
 - 2016-01-07 - Added a ``beancount-urlscheme``-command to register the
-  ``beancount://``-URL -scheme on a Mac (other platforms still missing, but in
+  ``beancount://``-URL -scheme on macOS (other platforms still missing, but in
   development). There is a new setting called ``use-external-editor`` that
   will, if set to ``True``, render all links to the Source Editor as
   ``beancount://``-URLs to open the files directly in the editor specified by

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ before-release: translations-push translations-fetch
 
 # Before making a release, CHANGES needs to be updated and version number in
 # fava/__init__.py should be set to the release version.
-# A tag and Github release should be created too.
+# A tag and GitHub release should be created too.
 #
 # After the release, the version number should be bumped in fava/__init__.py
 # (with '-dev') and gui/src/main.js and fava.pythonanywhere.com should be

--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,7 @@ Beancount, you can get started with Fava::
 
 and visit the web interface at `http://localhost:5000
 <http://localhost:5000>`__.  Alternatively, for the GUI version of Fava, head
-to the `Releases <https://github.com/beancount/fava/releases>`__ page on Github
+to the `Releases <https://github.com/beancount/fava/releases>`__ page on GitHub
 to download the latest release for your platform.
 
 If you want to hack on Fava or run a development version, see the

--- a/contrib/pythonanywhere/README.md
+++ b/contrib/pythonanywhere/README.md
@@ -4,7 +4,7 @@ Fava has two example pages hosted on
 - [fava.pythonanywhere.com](https://fava.pythonanywhere.com), which runs the
   latest released version.
 - [favadev.pythonanywhere.com](https://favadev.pythonanywhere.com), which
-  tracks the HEAD of the Github repo
+  tracks the HEAD of the GitHub repo
   ([github.com/beancount/fava](https://github.com/beancount/fava))
 
 There are four parts to both instances:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,7 +40,7 @@ title=\"Double-entry bookkeeping software Beancount\">Beancount</a>""",
     'github_button': 'false',
     'show_powered_by': 'false',
     'extra_nav_links': {
-        "fava @ Github": 'https://github.com/beancount/fava',
+        "fava @ GitHub": 'https://github.com/beancount/fava',
         "Issue Tracker": 'https://github.com/beancount/fava/issues',
     },
     'link': '#3572b0',

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -39,7 +39,7 @@ install from source like so (more details `here
 
     pip install hg+https://bitbucket.org/blais/beancount#egg=beancount
 
-Contributions are very welcome, just open a PR on `Github
+Contributions are very welcome, just open a PR on `GitHub
 <https://github.com/beancount/fava/pulls>`__.
 
 Fava is released under the `MIT License

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,5 +25,5 @@ If you are already familiar with Beancount, this is enough to get you up and run
 
 and visit the web interface at `http://localhost:5000
 <http://localhost:5000>`__ (alternatively, for the GUI version of Fava, head to
-the `Releases <https://github.com/beancount/fava/releases>`__ page on Github to
+the `Releases <https://github.com/beancount/fava/releases>`__ page on GitHub to
 download the latest version for your platform).

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -22,12 +22,12 @@ and access it with you default web browser. Alternatively there is a GUI
 version which bundles Fava with a browser basically.  If you know your way
 around the terminal, installation via ``pip`` (see below) is recommended,
 otherwise, head to the `Releases
-<https://github.com/beancount/fava/releases>`__ page on Github and download the
+<https://github.com/beancount/fava/releases>`__ page on GitHub and download the
 latest GUI version for your platform: ``AppImage`` on Linux (the file needs to
-be made executable after downloading) or ``dmg`` for MacOS. There is currently no
+be made executable after downloading) or ``dmg`` for macOS. There is currently no
 build of the GUI for Windows.
 
-Fava is known to run on MacOS, Linux, and Windows (with Cygwin).  You will need
+Fava is known to run on macOS, Linux, and Windows (with Cygwin).  You will need
 `Python 3 <https://www.python.org/downloads/>`__ (at least version 3.4).  Then
 you can use ``pip`` to install Fava by running::
 

--- a/fava/help/extensions.md
+++ b/fava/help/extensions.md
@@ -1,7 +1,7 @@
 Fava supports extensions. Currently they can only register hooks for some events.
 
 If you use this extension system and need it to do more or need other hooks,
-please open an issue on [Github](https://github.com/beancount/fava/issues).
+please open an issue on [GitHub](https://github.com/beancount/fava/issues).
 
 A Fava extension is simply a Python module which contains a class that inherits
 from `FavaExtensionBase` from `fava.ext`. Check out `fava.ext.auto_commit` for an

--- a/fava/help/features.md
+++ b/fava/help/features.md
@@ -66,7 +66,7 @@ Fava can open up your source file in your favorite editor directly from the web
 interface using the `use-external-editor` configuration variable through the
 `beancount://` URL handler. See the [Beancount
 urlscheme](https://github.com/aumayr/beancount_urlscheme) project for
-pre-configured URL handlers for OS X and Cygwin.
+pre-configured URL handlers for macOS and Cygwin.
 
 ## Multiple Beancount files
 

--- a/fava/help/options.md
+++ b/fava/help/options.md
@@ -81,7 +81,7 @@ file.
 
 ## `auto-reload`
 
-Default: `false`.
+Default: `false`
 
 Set this to `true` to make Fava automatically reload the page whenever a file
 changes is detected. By default only a notification is shown which you can


### PR DESCRIPTION
Use "macOS" consistently, capitalize "GitHub" correctly and fix a minor
cosmetic issue in a help option.