### PR TITLE
charts

### DIFF
--- a/fava/core/fava_options.py
+++ b/fava/core/fava_options.py
@@ -16,7 +16,6 @@ InsertEntryOption = namedtuple('InsertEntryOption', 'date re filename lineno')
 DEFAULTS = {
     'account-journal-include-children': True,
     'auto-reload': False,
-    'charts': True,
     'default-file': None,
     'editor-print-margin-column': 60,
     'extensions': [],
@@ -42,7 +41,6 @@ DEFAULTS = {
 BOOL_OPTS = [
     'account-journal-include-children',
     'auto-reload',
-    'charts',
     'show-accounts-with-zero-balance',
     'show-accounts-with-zero-transactions',
     'show-closed-accounts',

--- a/fava/help/options.md
+++ b/fava/help/options.md
@@ -4,7 +4,7 @@ following to your Beancount file.
 <pre><textarea class="editor-readonly">
 2016-06-14 custom "fava-option" "default-file"
 2016-06-14 custom "fava-option" "interval" "week"
-2016-04-14 custom "fava-option" "charts" "false"
+2016-04-14 custom "fava-option" "auto-reload" "true"
 2016-04-14 custom "fava-option" "journal-show" "transaction open"
 2016-04-14 custom "fava-option" "editor-print-margin-column" "10" </textarea></pre>
 
@@ -37,15 +37,6 @@ Default: `month`
 
 The default interval that charts and the account reports by interval use.
 The possible options are `day`, `week`, `month`, `quarter`, and `year`.
-
----
-
-## `charts`
-
-Default: `true`
-
-Set this to `false` to hide the charts. In any case, they can be hidden/shown
-using the "Toggle Charts" button.
 
 ---
 

--- a/fava/static/css/base.css
+++ b/fava/static/css/base.css
@@ -192,7 +192,7 @@ label {
 
 select {
   font-size: inherit;
-  margin: 0 .5em .5em 0;
+  margin: 0 .5em 0 0;
 }
 
 input {
@@ -418,6 +418,7 @@ article {
 }
 
 .wide-form {
+  align-items: center;
   display: flex;
   flex-wrap: wrap;
   margin-bottom: .5em;
@@ -425,6 +426,10 @@ article {
 
   & .small {
     margin-left: -3px;
+  }
+
+  & > span {
+    margin-right: .5em;
   }
 }
 

--- a/fava/static/css/charts.css
+++ b/fava/static/css/charts.css
@@ -18,11 +18,9 @@
 }
 
 .toggle-chart {
+  height: 22px;
   margin: 0;
-  padding: 4px 6px;
-  position: absolute;
-  right: 1.5em;
-  top: 1.5em;
+  padding: 2px 6px;
 
   & span {
     border: 0;
@@ -31,24 +29,21 @@
     border-top: 13px solid var(--color-background);
     display: block;
   }
-
-  &.hide-charts span {
-    border: 0;
-    border-bottom: 13px solid var(--color-background);
-    border-left: 9px solid transparent;
-    border-right: 9px solid transparent;
-  }
 }
 
-.charts form {
-  display: flex;
-  margin-bottom: 10px;
-  padding-left: 10px;
-  padding-right: 35px;
+.hide-charts .toggle-chart span {
+  border: 0;
+  border-bottom: 13px solid var(--color-background);
+  border-left: 9px solid transparent;
+  border-right: 9px solid transparent;
+}
 
-  & > span {
-    margin-right: .5em;
-  }
+.hide-charts .chart-container,
+.hide-charts .chart-legend,
+.hide-charts .chart-currency,
+.hide-charts .chart-mode,
+.hide-charts .chart-labels {
+  display: none;
 }
 
 .chart-container {

--- a/fava/static/css/charts.css
+++ b/fava/static/css/charts.css
@@ -96,10 +96,8 @@ svg {
       stroke-dasharray: 2, 2;
     }
   }
-}
 
-.voronoi {
-  & path {
+  & .voronoi {
     fill: none;
     pointer-events: all;
   }
@@ -121,13 +119,11 @@ svg {
 .sunburst {
   & .account {
     cursor: pointer;
-    font-size: 13px;
-    font-weight: 700;
+    fill: var(--color-text);
   }
 
   & .balance {
     font-family: var(--font-family-monospaced);
-    font-size: 14px;
   }
 
   & path {

--- a/fava/static/javascript/charts.js
+++ b/fava/static/javascript/charts.js
@@ -642,9 +642,7 @@ class LineChart extends BaseChart {
 class SunburstChartContainer extends BaseChart {
   constructor(svg) {
     super();
-    this.svg = svg;
-    this.svg.attr('class', 'sunburst');
-
+    this.svg = svg.attr('class', 'sunburst');
     this.sunbursts = [];
     this.canvases = [];
   }

--- a/fava/static/javascript/charts.js
+++ b/fava/static/javascript/charts.js
@@ -12,6 +12,7 @@ import 'd3-transition';
 
 import { $, $$ } from './helpers';
 import e from './events';
+import router from './router';
 
 const treemapColorScale = scaleOrdinal(schemeSet3);
 const sunburstColorScale = scaleOrdinal(schemeCategory10);
@@ -934,6 +935,13 @@ e.on('page-loaded', () => {
 });
 
 e.on('button-click-toggle-chart', () => {
-  $('#charts').classList.toggle('hide-charts');
+  const hideCharts = $('#charts').classList.toggle('hide-charts');
+  const url = new URL(window.location.href);
+  if (hideCharts) {
+    url.searchParams.set('charts', false);
+  } else {
+    url.searchParams.delete('charts');
+  }
+  router.navigate(url.toString(), false);
   updateChart();
 });

--- a/fava/static/javascript/charts.js
+++ b/fava/static/javascript/charts.js
@@ -754,7 +754,7 @@ class HierarchyContainer extends BaseChart {
 
 let currentChart;
 function updateChart() {
-  if (!$('#charts').classList.contains('hidden')) {
+  if (!$('#charts').classList.contains('hide-charts')) {
     currentChart.update();
   }
 }
@@ -935,8 +935,7 @@ e.on('page-loaded', () => {
   }
 });
 
-e.on('button-click-toggle-chart', (button) => {
-  button.classList.toggle('hide-charts');
-  $('#charts').classList.toggle('hidden', button.classList.contains('hide-charts'));
+e.on('button-click-toggle-chart', () => {
+  $('#charts').classList.toggle('hide-charts');
   updateChart();
 });

--- a/fava/static/javascript/filters.js
+++ b/fava/static/javascript/filters.js
@@ -1,5 +1,6 @@
-import { $, $$ } from './helpers';
 import e from './events';
+import { timeFilterDateFormat } from './format';
+import { $, $$ } from './helpers';
 
 // Adjust the size of the input element.
 function updateInput(input) {
@@ -8,6 +9,14 @@ function updateInput(input) {
 
   const isEmpty = !input.value;
   input.closest('span').classList.toggle('empty', isEmpty);
+}
+
+export default function setTimeFilter(date) {
+  const interval = $('#chart-interval').value;
+  const input = $('#time-filter');
+  input.value = timeFilterDateFormat[interval](date);
+  updateInput(input);
+  e.trigger('form-submit-filters', input.form);
 }
 
 e.on('page-loaded', () => {

--- a/fava/static/javascript/format.js
+++ b/fava/static/javascript/format.js
@@ -1,0 +1,48 @@
+// Helper functions to format numbers and dates.
+
+import { format } from 'd3-format';
+import { utcFormat } from 'd3-time-format';
+
+const formatCurrencyWithComma = format(',.2f');
+const formatCurrencyWithoutComma = format('.2f');
+export function formatCurrency(number) {
+  let str = '';
+  if (window.favaAPI.options.render_commas) {
+    str = formatCurrencyWithComma(number);
+  } else {
+    str = formatCurrencyWithoutComma(number);
+  }
+  if (window.favaAPI.incognito) {
+    str = str.replace(/[0-9]/g, 'X');
+  }
+  return str;
+}
+
+const formatCurrencyShortDefault = format('.2s');
+export function formatCurrencyShort(number) {
+  let str = formatCurrencyShortDefault(number);
+  if (window.favaAPI.incognito) {
+    str = str.replace(/[0-9]/g, 'X');
+  }
+  return str;
+}
+
+export const dateFormat = {
+  year: utcFormat('%Y'),
+  quarter(date) {
+    return `${date.getUTCFullYear()}Q${Math.floor(date.getUTCMonth() / 3) + 1}`;
+  },
+  month: utcFormat('%b %Y'),
+  week: utcFormat('%YW%W'),
+  day: utcFormat('%Y-%m-%d'),
+};
+
+export const timeFilterDateFormat = {
+  year: utcFormat('%Y'),
+  quarter(date) {
+    return `${date.getUTCFullYear()}Q${Math.floor(date.getUTCMonth() / 3) + 1}`;
+  },
+  month: utcFormat('%Y-%m'),
+  week: utcFormat('%Y-W%W'),
+  day: utcFormat('%Y-%m-%d'),
+};

--- a/fava/static/javascript/router.js
+++ b/fava/static/javascript/router.js
@@ -12,6 +12,7 @@ import { handleHash } from './overlays';
 // conversion <select>'s.
 function updateURL(url) {
   const newURL = new URL(url);
+  const currentURL = new URL(window.location.href);
   ['account', 'filter', 'time'].forEach((filter) => {
     newURL.searchParams.delete(filter);
     const el = $(`#${filter}-filter`);
@@ -19,20 +20,15 @@ function updateURL(url) {
       newURL.searchParams.set(filter, el.value);
     }
   });
-  const interval = $('#chart-interval');
-  if (interval) {
-    newURL.searchParams.set('interval', interval.value);
-    if (interval.value === interval.getAttribute('data-default')) {
-      newURL.searchParams.delete('interval');
+
+  ['interval', 'charts', 'conversion'].forEach((setting) => {
+    if (currentURL.searchParams.has(setting)) {
+      newURL.searchParams.set(setting, currentURL.searchParams.get(setting));
+    } else {
+      newURL.searchParams.delete(setting);
     }
-  }
-  const conversion = $('#conversion');
-  if (conversion) {
-    newURL.searchParams.set('conversion', conversion.value);
-    if (conversion.value === 'at_cost') {
-      newURL.searchParams.delete('conversion');
-    }
-  }
+  });
+
   return newURL.toString();
 }
 
@@ -181,15 +177,27 @@ e.on('form-submit-query', (form) => {
 
 // These elements might be added asynchronously, so rebind them on page-load.
 e.on('page-loaded', () => {
-  if ($('#chart-interval')) {
-    $('#chart-interval').addEventListener('change', () => {
-      router.navigate(updateURL(window.location.href));
+  const interval = $('#chart-interval');
+  if (interval) {
+    interval.addEventListener('change', () => {
+      const newURL = new URL(window.location.href);
+      newURL.searchParams.set('interval', interval.value);
+      if (interval.value === interval.getAttribute('data-default')) {
+        newURL.searchParams.delete('interval');
+      }
+      router.navigate(newURL.toString());
     });
   }
 
-  if ($('#conversion')) {
-    $('#conversion').addEventListener('change', () => {
-      router.navigate(updateURL(window.location.href));
+  const conversion = $('#conversion');
+  if (conversion) {
+    conversion.addEventListener('change', () => {
+      const newURL = new URL(window.location.href);
+      newURL.searchParams.set('conversion', conversion.value);
+      if (conversion.value === 'at_cost') {
+        newURL.searchParams.delete('conversion');
+      }
+      router.navigate(newURL.toString());
     });
   }
 });

--- a/fava/templates/_charts.html
+++ b/fava/templates/_charts.html
@@ -56,8 +56,7 @@
 {% endmacro %}
 
 {% macro skeleton(hide_interval_filter=False) %}
-{% set show_charts = ledger.fava_options['charts'] %}
-<div id="charts" class="charts{% if not show_charts %} hide-charts{% endif %}">
+<div id="charts" class="charts{% if request.args.get('charts') == 'false' %} hide-charts{% endif %}">
     <form id="chart-form" class="wide-form">
         <span id="chart-legend" class="chart-legend"></span>
         <span class="spacer"></span>
@@ -87,7 +86,7 @@
                 {% endfor %}
             </select>
             {% endif %}
-            <button type="button" data-event="toggle-chart" data-key="ctrl+c" class="toggle-chart{% if not show_charts %} hide-charts{% endif %}">
+            <button type="button" data-event="toggle-chart" data-key="ctrl+c" class="toggle-chart">
               <span></span>
             </button>
     </form>

--- a/fava/templates/_charts.html
+++ b/fava/templates/_charts.html
@@ -57,18 +57,16 @@
 
 {% macro skeleton(hide_interval_filter=False) %}
 {% set show_charts = ledger.fava_options['charts'] %}
-<button type="button" data-event="toggle-chart" data-key="ctrl+c" class="toggle-chart{% if not show_charts %} hide-charts{% endif %}">
-    <span></span>
-</button>
-<div id="charts" class="charts {% if not show_charts %} hidden{% endif %}">
-    <form id="chart-form">
+<div id="charts" class="charts{% if not show_charts %} hide-charts{% endif %}">
+    <form id="chart-form" class="wide-form">
         <span id="chart-legend" class="chart-legend"></span>
-        <select name="chart-currency" id="chart-currency" class="hidden">
+        <span class="spacer"></span>
+        <select name="chart-currency" id="chart-currency" class="chart-currency hidden">
         {% for currency in operating_currencies %}
             <option value="{{ currency }}">{{ currency }}</option>
         {% endfor %}
         </select>
-        <span id="chart-mode" class="hidden">
+        <span id="chart-mode" class="chart-mode hidden">
             <input name="mode" type="radio" value="treemap" id="mode-treemap" checked> <label for="mode-treemap">{{ _('Treemap') }}</label>
             <input name="mode" type="radio" value="sunburst" id="mode-sunburst"> <label for="mode-sunburst">{{ _('Sunburst') }}</label>
         </span>
@@ -85,13 +83,16 @@
         {% if not hide_interval_filter %}
             <select name="chart-interval" id="chart-interval" data-default="{{ ledger.fava_options['interval'] }}">
                 {% for interval_ in ['day', 'week', 'month', 'quarter', 'year'] %}
-                    <option value="{{ interval_ }}"{% if interval == interval_ %} selected="selected"{% endif %}>{{ interval_macros.interval_labels[interval_] }}</option>
+                <option value="{{ interval_ }}"{% if interval == interval_ %} selected="selected"{% endif %}>{{ interval_macros.interval_labels[interval_] }}</option>
                 {% endfor %}
             </select>
-        {% endif %}
+            {% endif %}
+            <button type="button" data-event="toggle-chart" data-key="ctrl+c" class="toggle-chart{% if not show_charts %} hide-charts{% endif %}">
+              <span></span>
+            </button>
     </form>
     <div id="chart-container" class="chart-container">
-        <div class="loading">{{ _('Loading charts&hellip;') }}</div>
+      <div class="loading">{{ _('Loading charts&hellip;') }}</div>
     </div>
     <div id="chart-labels" class="chart-labels"></div>
 </div>

--- a/tests/test_core_fava_options.py
+++ b/tests/test_core_fava_options.py
@@ -25,7 +25,6 @@ def test_fava_options(load_doc):
             datetime.date(2016, 4, 14),
             re.compile('Ausgaben:Test'), '<string>', 6)
     ]
-    assert options['charts']
     assert options['show-closed-accounts']
     assert options['journal-show'] == ['transaction', 'open']
     assert options['editor-print-margin-column'] == 10


### PR DESCRIPTION
- When hiding the charts, the selects should still be shown (as they influence the tree tables for example).
- Remove the 'charts' option - due to the above I doubt that anyone is using it. Rather I'll save the toggle state of the charts in the app state, i.e., in the URL.
- Lazily render the charts