### PR TITLE
Move to more standard css.

### DIFF
--- a/fava/static/css/base.css
+++ b/fava/static/css/base.css
@@ -182,7 +182,7 @@ textarea {
 
 input,
 textarea {
-  border: 1px solid color(var(--color-background-darkest));
+  border: 1px solid var(--color-background-darkest);
   padding: 6px 10px;
 }
 
@@ -405,7 +405,7 @@ aside {
 
     &.selected,
     &:hover {
-      background-color: color(var(--color-sidebar-background) shade(15%));
+      filter: brightness(85%);
     }
   }
 }

--- a/fava/static/css/base.css
+++ b/fava/static/css/base.css
@@ -30,7 +30,7 @@ table {
 tbody {
   & tr {
     &:nth-child(2n) {
-      background-color: color(var(--color-background) shade(5%));
+      background-color: var(--color-sidebar-background);
     }
   }
 
@@ -100,7 +100,7 @@ h5 {
 }
 
 hr {
-  border: 1px solid color(var(--color-background) shade(20%));
+  border: 1px solid var(--color-background-darker);
 }
 
 b,
@@ -113,7 +113,7 @@ a {
 
   &:hover,
   &:focus {
-    color: color(var(--color-links) shade(40%));
+    color: var(--color-links-hover);
   }
 
   &:link,
@@ -223,21 +223,21 @@ button,
   &:focus,
   &:active,
   &:hover {
-    background-color: color(var(--color-header) shade(10%));
+    background-color: var(--color-header-darker);
     box-shadow: 0 0 5px var(--color-header);
   }
 
   &:disabled,
   &.inactive,
   &.muted {
-    background-color: color(var(--color-header-text) shade(20%));
+    background-color: var(--color-background-darker);
     color: var(--color-text);
 
     &:focus,
     &:active,
     &:hover {
-      background-color: color(var(--color-header-text) shade(30%));
-      box-shadow: 0 0 5px color(var(--color-header-text) shade(20%));
+      box-shadow: 0 0 5px var(--color-background-darker);
+      filter: brightness(90%);
     }
   }
 
@@ -251,7 +251,7 @@ button,
     &:active,
     &:hover {
       box-shadow: none;
-      color: color(var(--color-links) shade(10%));
+      filter: brightness(90%);
     }
   }
 
@@ -374,13 +374,8 @@ aside {
       color: var(--color-sidebar-background);
     }
 
-    & a.selected,
-    & a:hover {
-      background-color: color(var(--color-error) shade(5%));
-    }
-
     & .bubble {
-      background-color: color(var(--color-error) tint(60%));
+      background-color: var(--color-transparent-white);
     }
   }
 
@@ -433,7 +428,7 @@ article {
   }
 }
 
-.dragover { background-color: color(var(--color-links) tint(50%)); }
+.dragover { background-color: var(--color-links-transparent); }
 
 .headerline {
   align-items: center;
@@ -538,7 +533,7 @@ kbd {
 [data-order='desc']::after {
   border-left: 5px solid transparent;
   border-right: 5px solid transparent;
-  border-top: 5px solid color(var(--color-background) shade(50%));
+  border-top: 5px solid var(--color-text-lightest);
   content: '';
   display: block;
   position: absolute;
@@ -547,7 +542,7 @@ kbd {
 }
 
 [data-order='asc']::after {
-  border-bottom: 5px solid color(var(--color-background) shade(50%));
+  border-bottom: 5px solid var(--color-text-lightest);
   border-left: 5px solid transparent;
   border-right: 5px solid transparent;
   content: '';

--- a/fava/static/css/header.css
+++ b/fava/static/css/header.css
@@ -9,16 +9,14 @@
   }
 }
 
-header > svg {
-  &.loading {
-    animation: spinner 1s linear infinite;
-    border-radius: 50%;
-    border-top: 2px solid var(--color-header-text);
-    padding: 0;
+header > svg.loading {
+  animation: spinner 1s linear infinite;
+  border-radius: 50%;
+  border-top: 2px solid var(--color-header-text);
+  padding: 0;
 
-    & path {
-      opacity: 0;
-    }
+  & path {
+    opacity: 0;
   }
 }
 

--- a/fava/static/css/header.css
+++ b/fava/static/css/header.css
@@ -1,8 +1,3 @@
-:root {
-  --color-header-text-half: color(var(--color-header-text) alpha(50%)));
-  --color-text-transparent: color(var(--color-text) alpha(20%));
-}
-
 @keyframes spinner {
   to {
     transform: rotate(360deg);
@@ -142,14 +137,14 @@ h1 {
   & [type='text'] {
     &:placeholder-shown,
     &::placeholder {
-      color: color(var(--color-header) tint(50%));
+      color: var(--color-header-tinted);
       opacity: 1;
     }
 
     &:focus {
       &:placeholder-shown,
       &::placeholder {
-        color: color(var(--color-header) tint(50%));
+        color: var(--color-header-tinted);
       }
 
       background-color: var(--color-background);
@@ -163,7 +158,7 @@ h1 {
 
   & .empty {
     & input {
-      background-color: color(var(--color-header) tint(20%));
+      background-color: var(--color-header-light);
     }
 
     & .close {

--- a/fava/static/css/journal-table.css
+++ b/fava/static/css/journal-table.css
@@ -60,9 +60,7 @@
   & .close { background-color: var(--color-journal-entry-close); }
   & .query { background-color: var(--color-journal-entry-note); }
   & .pad { background-color: var(--color-journal-entry-pad); }
-
   & .note { background-color: var(--color-journal-entry-note); }
-  & .note label { color: color(var(--color-journal-entry-note) shade(50%)); }
 
   & .balance { background-color: var(--color-journal-entry-balance); }
   & .balance.fail { background-color: var(--color-journal-entry-txn-pending); }
@@ -160,11 +158,8 @@
     background-color: var(--color-journal-entry-document);
 
     & .account-link {
-      color: color(var(--color-journal-tag-document) shade(15%));
-
-      & span {
-        color: color(var(--color-journal-tag-document) shade(25%));
-      }
+      color: var(--color-journal-tag-document);
+      filter: brightness(85%);
     }
 
     & .filename {
@@ -183,7 +178,7 @@
     justify-content: flex-end;
 
     & span {
-      background-color: var(--color-journal-indicator);
+      background-color: var(--color-journal-posting-indicator);
       border-radius: 3px;
       height: 6px;
       margin-right: 4px;
@@ -197,7 +192,7 @@
 
     & .metadata-indicator {
       border-radius: 20px;
-      color: color(var(--color-journal-indicator) shade(30%));
+      color: var(--color-journal-metadata-indicator);
       font-size: 10px;
       height: 16px;
       line-height: 16px;

--- a/fava/static/css/style.css
+++ b/fava/static/css/style.css
@@ -54,31 +54,30 @@ body {
 
   --color-links: #0067a5;
   --color-headings: #333;
-  --color-error: #900;
-  --color-warning: #edd42f;
+  --color-error: hsl(0, 100%, 30%);
+  --color-warning: hsl(52, 84%, 56%);
   --color-code-background: #f8f8f8;
 
   --color-sidebar-text: #444;
   --color-sidebar-text-hover: var(--color-links);
-  --color-sidebar-background: #f5f5f5;
-  --color-sidebar-border: color(var(--color-sidebar-background) shade(10%));
+  --color-sidebar-background: hsl(0, 0%, 96%);
+  --color-sidebar-border: hsl(0, 0%, 87%);
 
-  --color-scrollbar: color(var(--color-sidebar-background) shade(30%));
+  --color-scrollbar: hsl(0, 0, 67%);
   --color-autocomplete-match: #ffd27c;
 
-  --color-header: #0067a5;
-  --color-header-bottom: color(var(--color-header) shade(10%));
+  --color-header: hsl(203, 100%, 32%);
   --color-header-text: #fff;
 
-  --color-status-red: #900;
-  --color-status-yellow: #edd42f;
-  --color-status-green: #007f41;
+  --color-status-red: var(--color-error);
+  --color-status-yellow: var(--color-warning);
+  --color-status-green: hsl(151, 100%, 25%);
   --color-status-gray: #aaa;
 
   --color-notification: #fff;
-  --color-notification-info: color(var(--color-status-green) alpha(70%));
-  --color-notification-error: color(var(--color-error) alpha(70%));
-  --color-notification-warning: color(var(--color-warning) alpha(70%));
+  --color-notification-info: hsl(151, 100%, 25%, .7);
+  --color-notification-error: hsl(0, 100%, 30%, .7));
+  --color-notification-warning: hsl(52, 84%, 56%, .7);
 
   --color-table-header-text: #666;
   --color-table-header-background: #e6e6e6;
@@ -101,7 +100,8 @@ body {
   --color-journal-tag-document: #bb7ebb;
   --color-journal-link: #cbdde8;
   --color-journal-link-document: #c79cc7;
-  --color-journal-indicator: #c1d0d9;
+  --color-journal-posting-indicator: hsl(203, 24%, 80%);
+  --color-journal-metadata-indicator: hsl(203, 24%, 60%);
 
   --color-treetable-expander: #afc1d3;
 

--- a/fava/static/css/style.css
+++ b/fava/static/css/style.css
@@ -48,9 +48,9 @@ body {
   --color-background: #fff;
   --color-background-darker: #d9d9d9;
   --color-background-darkest: #ccc;
-  --color-text: #444;
-  --color-text-lighter: #555;
-  --color-text-lightest: #777;
+  --color-text: hsl(0, 0%, 27%);
+  --color-text-lighter: hsl(0, 0%, 33%);
+  --color-text-lightest: hsl(0, 0%, 47%);
 
   --color-links: #0067a5;
   --color-headings: #333;
@@ -67,7 +67,11 @@ body {
   --color-autocomplete-match: #ffd27c;
 
   --color-header: hsl(203, 100%, 32%);
-  --color-header-text: #fff;
+  --color-header-light: hsl(203, 56%, 45%);
+  --color-header-tinted: hsl(203, 47%, 66%);
+  --color-header-text: hsl(0, 0%, 100%);
+  --color-header-text-half: hsl(0, 0%, 100%, .5);
+  --color-text-transparent: hsl(0, 0%, 27%, .2);
 
   --color-status-red: var(--color-error);
   --color-status-yellow: var(--color-warning);

--- a/fava/static/css/style.css
+++ b/fava/static/css/style.css
@@ -45,6 +45,8 @@ body {
   --z-index-autocomplete: 8;
   --z-index-overlay: 4;
 
+  --color-transparent-white: hsl(0, 0%, 100%, .5);
+
   --color-background: #fff;
   --color-background-darker: #d9d9d9;
   --color-background-darkest: #ccc;
@@ -52,7 +54,9 @@ body {
   --color-text-lighter: hsl(0, 0%, 33%);
   --color-text-lightest: hsl(0, 0%, 47%);
 
-  --color-links: #0067a5;
+  --color-links: hsl(203, 100%, 32%);
+  --color-links-hover: hsl(203, 100%, 22%);
+  --color-links-transparent: hsl(203, 100%, 32%, .5);
   --color-headings: #333;
   --color-error: hsl(0, 100%, 30%);
   --color-warning: hsl(52, 84%, 56%);
@@ -67,6 +71,7 @@ body {
   --color-autocomplete-match: #ffd27c;
 
   --color-header: hsl(203, 100%, 32%);
+  --color-header-darker: hsl(203, 100%, 22%);
   --color-header-light: hsl(203, 56%, 45%);
   --color-header-tinted: hsl(203, 47%, 66%);
   --color-header-text: hsl(0, 0%, 100%);

--- a/fava/static/package.json
+++ b/fava/static/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "rollup -c",
     "watch-js": "rollup -c -w",
-    "watch-css": "postcss -lw -u 'postcss-import' -u 'postcss-custom-properties' -u 'postcss-nesting' -u 'postcss-color-function' -o 'gen/app.css' css/style.css",
+    "watch-css": "postcss -lw -u 'postcss-import' -u 'postcss-custom-properties' -u 'postcss-nesting' -o 'gen/app.css' css/style.css",
     "lint": "eslint javascript --ext .js && stylelint 'css/*.css'"
   },
   "eslintConfig": {
@@ -34,7 +34,6 @@
     "eslint-plugin-import": "^2.8.0",
     "postcss": "^6.0.16",
     "postcss-cli": "^4.1.1",
-    "postcss-color-function": "^4.0.1",
     "postcss-copy": "^7.1.0",
     "postcss-custom-properties": "^6.2.0",
     "postcss-import": "^11.0.0",

--- a/fava/static/package.json
+++ b/fava/static/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "rollup -c",
     "watch-js": "rollup -c -w",
-    "watch-css": "postcss -lw -u 'postcss-import' -u 'postcss-custom-properties' -u 'postcss-nesting' -o 'gen/app.css' css/style.css",
+    "watch-css": "postcss -lw -u 'postcss-import' -u 'postcss-nesting' -o 'gen/app.css' css/style.css",
     "lint": "eslint javascript --ext .js && stylelint 'css/*.css'"
   },
   "eslintConfig": {
@@ -35,7 +35,6 @@
     "postcss": "^6.0.16",
     "postcss-cli": "^4.1.1",
     "postcss-copy": "^7.1.0",
-    "postcss-custom-properties": "^6.2.0",
     "postcss-import": "^11.0.0",
     "postcss-nesting": "^4.2.1",
     "rollup": "^0.55.3",

--- a/fava/static/rollup.config.js
+++ b/fava/static/rollup.config.js
@@ -6,7 +6,6 @@ import postcss from 'rollup-plugin-postcss';
 
 import postcssCopy from 'postcss-copy';
 import postcssImport from 'postcss-import';
-import postcssCustomProperties from 'postcss-custom-properties';
 import postcssNesting from 'postcss-nesting';
 
 export default {
@@ -29,7 +28,6 @@ export default {
           src: ['css', 'node_modules'],
           dest: 'gen',
         }),
-        postcssCustomProperties(),
         postcssNesting(),
       ],
       extract: true,

--- a/fava/static/rollup.config.js
+++ b/fava/static/rollup.config.js
@@ -6,7 +6,6 @@ import postcss from 'rollup-plugin-postcss';
 
 import postcssCopy from 'postcss-copy';
 import postcssImport from 'postcss-import';
-import postcssColorFunction from 'postcss-color-function';
 import postcssCustomProperties from 'postcss-custom-properties';
 import postcssNesting from 'postcss-nesting';
 
@@ -31,7 +30,6 @@ export default {
           dest: 'gen',
         }),
         postcssCustomProperties(),
-        postcssColorFunction(),
         postcssNesting(),
       ],
       extract: true,


### PR DESCRIPTION
The css color() function doesn't seem to be on a standard track - remove it, by specifying colors using hsl() it's often just as easy to achieve the same. Also custom properties are supported by all modern browsers now, so we don't need to remove them via postcss