### PR TITLE
Fix BQL error on holdings by account page

### DIFF
--- a/fava/templates/holdings.html
+++ b/fava/templates/holdings.html
@@ -18,7 +18,7 @@
     cost(sum(position)) as book_value,
     value(sum(position)) as market_value
   WHERE account_sortkey(account) ~ "^[01]"
-  GROUP BY account, cost_currency, account_sortkey(account)
+  GROUP BY account, cost_currency, account_sortkey(account), currency
   ORDER BY account_sortkey(account), currency',
 'currency': 'SELECT
     units(sum(position)) as units,


### PR DESCRIPTION
Commit dcf718e ("Use better default order for holdings") introduced
a BQL error on the "Holdings by Account" page.