### PR TITLE
Statement-download: Keep original filename (#688)

### DIFF
--- a/fava/application.py
+++ b/fava/application.py
@@ -33,7 +33,7 @@ from fava.core.charts import FavaJSONEncoder
 from fava.core.helpers import FavaAPIException, FilterException
 from fava.help import HELP_PAGES
 from fava.json_api import json_api
-from fava.util import slugify, resource_path, setup_logging, send_as_inline
+from fava.util import slugify, resource_path, setup_logging, send_file_inline
 from fava.util.excel import HAVE_EXCEL
 
 
@@ -241,7 +241,7 @@ def document():
     if not any((filename == document.filename for document in
                 g.ledger.all_entries_by_type[Document])):
         abort(404)
-    return send_as_inline(filename)
+    return send_file_inline(filename)
 
 
 @app.route('/<bfile>/statement/', methods=['GET'])
@@ -250,7 +250,7 @@ def statement():
     entry_hash = request.args.get('entry_hash')
     key = request.args.get('key')
     document_path = g.ledger.statement_path(entry_hash, key)
-    return send_as_inline(document_path)
+    return send_file_inline(document_path)
 
 
 @app.route('/<bfile>/holdings/by_<aggregation_key>/')

--- a/fava/application.py
+++ b/fava/application.py
@@ -250,7 +250,10 @@ def statement():
     entry_hash = request.args.get('entry_hash')
     key = request.args.get('key')
     document_path = g.ledger.statement_path(entry_hash, key)
-    return send_file(document_path)
+    response = send_file(document_path)
+    cont_disp = 'inline; filename="{}"'.format(os.path.basename(document_path))
+    response.headers['Content-Disposition'] = cont_disp
+    return response
 
 
 @app.route('/<bfile>/holdings/by_<aggregation_key>/')

--- a/fava/static/javascript/router.js
+++ b/fava/static/javascript/router.js
@@ -57,12 +57,6 @@ class Router {
   // Go to URL. If load is `true`, load the page at URL, otherwise only update
   // the current state.
   navigate(url, load = true) {
-    const state = { interrupt: false };
-    e.trigger('navigate', state);
-    if (state.interrupt) {
-      return;
-    }
-
     if (load) {
       this.loadURL(url);
     } else {

--- a/fava/static/javascript/router.js
+++ b/fava/static/javascript/router.js
@@ -57,6 +57,12 @@ class Router {
   // Go to URL. If load is `true`, load the page at URL, otherwise only update
   // the current state.
   navigate(url, load = true) {
+    const state = { interrupt: false };
+    e.trigger('navigate', state);
+    if (state.interrupt) {
+      return;
+    }
+
     if (load) {
       this.loadURL(url);
     } else {

--- a/fava/util/__init__.py
+++ b/fava/util/__init__.py
@@ -87,21 +87,10 @@ def simple_wsgi(_, start_response):
     return [b'']
 
 
-def send_as_inline(file_path):
-    """Send  a file as an inline, including the original filename."""
+def send_file_inline(file_path):
+    """Send a file inline, including the original filename."""
     response = send_file(file_path)
-    cont_disp = 'inline; filename='
-    filename = os.path.basename(file_path)
-    try:
-        filename = filename.encode('latin-1')
-    except UnicodeEncodeError:
-        normalized_filename = unicodedata.normalize('NFKD', filename)
-        cont_disp += '"{}"; filename*={}'.format(
-            normalized_filename.encode('latin-1', 'ignore').decode(),
-            "UTF-8''{}".format(url_quote(filename))
-        )
-    else:
-        cont_disp += '"{}"'.format(filename.decode())
-
+    basename = os.path.basename(file_path)
+    cont_disp = "inline; filename*=UTF-8''{}".format(url_quote(basename))
     response.headers['Content-Disposition'] = cont_disp
     return response

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,7 +1,7 @@
 from werkzeug.test import Client
 from werkzeug.wrappers import BaseResponse
 
-from fava.util import simple_wsgi, slugify, pairwise, listify, send_as_inline
+from fava.util import simple_wsgi, slugify, pairwise, listify, send_file_inline
 
 from .conftest import data_file
 
@@ -39,13 +39,13 @@ def test_slugify():
     assert slugify('ASDF test test') == 'asdf-test-test'
 
 
-def test_send_as_inline(app):
+def test_send_file_inline(app):
     with app.test_request_context():
         app.preprocess_request()
-        resp = send_as_inline(data_file('example-balances.csv'))
+        resp = send_file_inline(data_file('example-balances.csv'))
         assert resp.headers['Content-Disposition'] == \
-            'inline; filename="example-balances.csv"'
-        resp = send_as_inline(data_file('example-utf8-🦁.txt'))
+            'inline; filename*=UTF-8\'\'example-balances.csv'
+        resp = send_file_inline(data_file('example-utf8-🦁.txt'))
         # pylint: disable=line-too-long
         assert resp.headers['Content-Disposition'] == \
-            'inline; filename="example-utf8-.txt"; filename*=UTF-8\'\'example-utf8-%F0%9F%A6%81.txt'  # noqa: ignore=E501
+            'inline; filename*=UTF-8\'\'example-utf8-%F0%9F%A6%81.txt'

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,7 +1,9 @@
 from werkzeug.test import Client
 from werkzeug.wrappers import BaseResponse
 
-from fava.util import simple_wsgi, slugify, pairwise, listify
+from fava.util import simple_wsgi, slugify, pairwise, listify, send_as_inline
+
+from .conftest import data_file
 
 
 def test_listify():
@@ -35,3 +37,15 @@ def test_slugify():
     assert slugify('söße') == 'söße'
     assert slugify('ASDF') == 'asdf'
     assert slugify('ASDF test test') == 'asdf-test-test'
+
+
+def test_send_as_inline(app):
+    with app.test_request_context():
+        app.preprocess_request()
+        resp = send_as_inline(data_file('example-balances.csv'))
+        assert resp.headers['Content-Disposition'] == \
+            'inline; filename="example-balances.csv"'
+        resp = send_as_inline(data_file('example-utf8-🦁.txt'))
+        # pylint: disable=line-too-long
+        assert resp.headers['Content-Disposition'] == \
+            'inline; filename="example-utf8-.txt"; filename*=UTF-8\'\'example-utf8-%F0%9F%A6%81.txt'  # noqa: ignore=E501


### PR DESCRIPTION
This PR fixes #688 by suggesting the original filename to the browser when sending the statement. 

It still displays the original file inline in the browser (instead
of forcing a direct download), as IMHO this feature is often used for
previewing invoices (PDFs) and most modern browsers can display PDFs
inline.