### PR TITLE
tox: allow all Python 3 versions

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = lint, py36
+envlist = lint, py3
 
 [testenv]
 deps =
@@ -7,6 +7,11 @@ deps =
     pyexcel
     pyexcel-ods3
 commands = pytest tests
+
+[testenv:py3-dev]
+deps =
+    {[testenv]deps}
+    hg+https://bitbucket.org/blais/beancount#egg=beancount
 
 [testenv:py36-dev]
 deps =


### PR DESCRIPTION
The test suite works fine with Python 3.5.  Since Debian 9 (stretch)
doesn't have Python 3.6, allow other Python 3 versions.