### PR TITLE
avoid page load on error

### DIFF
--- a/fava/core/filters.py
+++ b/fava/core/filters.py
@@ -309,8 +309,9 @@ class TimeFilter(EntryFilter):  # pylint: disable=abstract-method
 
         self.begin_date, self.end_date = parse_date(self.value)
         if not self.begin_date:
+            self.value = None
             raise FilterException('time', 'Failed to parse date: {}'.format(
-                self.value))
+                value))
         return True
 
     def _filter(self, entries, options):
@@ -346,6 +347,7 @@ class AdvancedFilter(EntryFilter):
                     tokenfunc=lambda toks=tokens: next(toks, None))
             except FilterException as exception:
                 exception.message = exception.message + value
+                self.value = None
                 raise exception
         else:
             self._include = None

--- a/fava/static/javascript/notifications.js
+++ b/fava/static/javascript/notifications.js
@@ -45,12 +45,3 @@ e.on('page-init', () => {
     event.target.closest('li').remove();
   });
 });
-
-e.on('page-loaded', () => {
-  const messages = $('#flashed-messages');
-  if (messages) {
-    JSON.parse($('#flashed-messages').innerHTML).forEach((msg) => {
-      e.trigger('error', msg);
-    });
-  }
-});

--- a/fava/static/javascript/router.js
+++ b/fava/static/javascript/router.js
@@ -79,20 +79,27 @@ class Router {
     svg.classList.add('loading');
 
     $.fetch(getUrl.toString())
-      .then(response => response.text())
-      .then((data) => {
-        svg.classList.remove('loading');
-        if (historyState) {
-          window.history.pushState(null, null, url);
-          window.scroll(0, 0);
-        }
-        this.updateState();
-        $('article').innerHTML = data;
-        e.trigger('page-loaded');
-        handleHash();
+      .then((response) => {
+        response.text()
+          .then((data) => {
+            if (!response.ok) {
+              e.trigger('error', data);
+              return;
+            }
+            if (historyState) {
+              window.history.pushState(null, null, url);
+              window.scroll(0, 0);
+            }
+            this.updateState();
+            $('article').innerHTML = data;
+            e.trigger('page-loaded');
+            handleHash();
+          });
       }, () => {
-        svg.classList.remove('loading');
         e.trigger('error', `Loading ${url} failed.`);
+      })
+      .finally(() => {
+        svg.classList.remove('loading');
       });
   }
 

--- a/fava/templates/_error.html
+++ b/fava/templates/_error.html
@@ -1,0 +1,6 @@
+{% extends "_layout.html" %}
+{% set active_page = 'error' %}
+{% set page_title = 'Error' %}
+{% block content %}
+{{ error.message }}
+{% endblock %}

--- a/fava/templates/_layout.html
+++ b/fava/templates/_layout.html
@@ -1,9 +1,8 @@
 {% import "_charts.html" as charts with context %}
 {% import "_globals.html" as globals with context %}
-{% set partial = request.args.get('partial', False) %}
 {% set page_title = globals.all_pages[active_page].0 if not page_title else page_title %}
 {% set short_title = page_title if not short_title else short_title %}
-{% if not partial %}
+{% if not g.partial %}
 <!doctype html>
 <html>
   <head>
@@ -58,10 +57,7 @@
         'tags': ledger.attributes.tags,
         'years': ledger.attributes.years,
     }|tojson|safe }}</script>
-      {% if partial -%}
-      <script type="application/json" id="flashed-messages">{{ get_flashed_messages()|tojson|safe }}</script>
-      {%- endif %}
-      {%- if not partial %}
+      {%- if not g.partial %}
     </article>
     {% include "_overlays.html" %}
     <ul id="notifications" class="notifications"></ul>


### PR DESCRIPTION
In case of some error (most commonly when the user provides an invalid
filter expression), do not render the page but immediately throw a HTTP
error.

Close #697 
Close #706 