### PR TITLE
Propagate end date to balance tree

### DIFF
--- a/fava/templates/_tree_table.html
+++ b/fava/templates/_tree_table.html
@@ -31,8 +31,8 @@ Hold Ctrl or Cmd while clicking to expand one level.') %}
     </p>
   </li>
   {% for account in ([account_node] if account_node.name else account_node.children) if account|should_show recursive %}
-  {% set balance = account.balance|cost_or_value %}
-  {% set balance_children = account.balance_children|cost_or_value %}
+  {% set balance = account.balance|cost_or_value(account_node.end_date) %}
+  {% set balance_children = account.balance_children|cost_or_value(account_node.end_date) %}
   {% set cost = account.balance|cost if g.conversion == 'at_value' else {} %}
   {% set cost_children = account.balance_children|cost if g.conversion == 'at_value' else {} %}
   <li{{ ' class=toggled' if ledger.accounts[account.name].meta.get('fava-collapse-account') else '' }}>


### PR DESCRIPTION
Tree and TreeNodes are used to render the balance sheet and they have no access to the global end date filtering. We need a way to specify the date to look up prices for calculating market value. Use the transaction date of the last entry in the TreeNode to calculate the price.

Fixes https://github.com/beancount/fava/issues/726.