### PR TITLE
Mention missing deps for fava in index

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,9 +17,11 @@ You can try out an online `demo <https://fava.pythonanywhere.com>`__.
 
 If you are new to Fava and Beancount, begin with the :doc:`usage` guide.
 
-If you are already familiar with Beancount, this is enough to get you up and
-running::
+If you are already familiar with Beancount and have `Python3.6` installed,
+this is enough to get you up and running::
 
+    pip3 install setuptools
+    pip3 install wheel
     pip3 install fava
     fava ledger.beancount
 


### PR DESCRIPTION
I tested on fresh box that just got fresh Python3.6.
Had to also run this fix to be able to build wheels
on my system (Debian Buster) 
```
ln -s /usr/include/locale.h /usr/include/xlocale.h
```
I guess last fix is quite specific. Details:
https://forum.alpinelinux.org/forum/general-discussion/xlocaleh