### PR TITLE
Add autocompletion for links in editor and filter

### DIFF
--- a/fava/core/attributes.py
+++ b/fava/core/attributes.py
@@ -15,11 +15,13 @@ class AttributesModule(FavaModule):
         self.accounts = None
         self.currencies = None
         self.payees = None
+        self.links = None
         self.tags = None
         self.years = None
 
     def load_file(self):
         all_entries = self.ledger.all_entries
+        self.links = getters.get_all_links(all_entries)
         self.tags = getters.get_all_tags(all_entries)
         self.years = list(getters.get_active_years(all_entries))[::-1]
 

--- a/fava/static/javascript/autocomplete.js
+++ b/fava/static/javascript/autocomplete.js
@@ -163,6 +163,7 @@ class CompletionList {
     }
     if (this.list === 'tags') {
       const suggestions = window.favaAPI.tags.map(tag => `#${tag}`)
+        .concat(window.favaAPI.links.map(link => `^${link}`))
         .concat(window.favaAPI.payees.map(payee => `payee:"${payee}"`));
       return new Promise((resolve) => { resolve(suggestions); });
     }

--- a/fava/static/javascript/codemirror/hint-beancount.js
+++ b/fava/static/javascript/codemirror/hint-beancount.js
@@ -33,6 +33,12 @@ CodeMirror.registerHelper('hint', 'beancount', (cm) => {
       from: cursor,
       to: cursor,
     };
+  } else if (currentCharacter === '^') {
+    return {
+      list: window.favaAPI.links,
+      from: cursor,
+      to: cursor,
+    };
   }
 
   if (token.type === 'tag') {

--- a/fava/templates/_layout.html
+++ b/fava/templates/_layout.html
@@ -53,6 +53,7 @@
         'favaOptions': ledger.fava_options,
         'accounts': ledger.attributes.accounts,
         'currencies': ledger.attributes.currencies,
+        'links': ledger.attributes.links,
         'payees': ledger.attributes.payees,
         'tags': ledger.attributes.tags,
         'years': ledger.attributes.years,

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
         'Flask-Babel>=0.10.0',
         'Flask>=0.10.1',
         'Jinja2>=2.10',
-        'beancount>=2.0',
+        'beancount>=2.1.2',
         'click',
         'markdown2>=2.3.0',
         'ply',


### PR DESCRIPTION
beancount 2.1 introduced getters.get_all_links() so we can add autocompletion for links now.

