### PR TITLE
remove meaningless headers from sidebar

### DIFF
--- a/fava/static/css/base.css
+++ b/fava/static/css/base.css
@@ -332,6 +332,7 @@ aside {
   left: 0;
   margin: 0;
   overflow-y: auto;
+  padding-top: .5rem;
   position: fixed;
   top: var(--header-height);
   transition: var(--transitions);
@@ -346,7 +347,14 @@ aside h3 {
   text-transform: uppercase;
 }
 
+.navigation {
+  border-bottom: 1px solid var(--color-sidebar-border);
+  margin-bottom: .5rem;
+  padding-bottom: .5rem;
+}
+
 .navigation:last-child {
+  border: none;
   margin-bottom: 0;
 }
 

--- a/fava/templates/_aside.html
+++ b/fava/templates/_aside.html
@@ -8,8 +8,7 @@
   {% endfor %}
 </ul>
 {% endif %}
-{% for title_, menuitems in globals.navigation_bar %}
-<h3>{{ title_ }}</h3>
+{% for menuitems in globals.navigation_bar %}
 <ul class="navigation">
   {% for id in menuitems %}
   <li><a{% if id == active_page %} class="selected"{% endif %} data-key="{{ globals.all_pages[id].1 }}" href="{{ url_for('report', report_name=id) }}">{{ globals.all_pages[id].0 }}

--- a/fava/templates/_globals.html
+++ b/fava/templates/_globals.html
@@ -14,7 +14,7 @@
     'help':             (_('Help'),             'g H'),
 } %}
 {% set navigation_bar = [
-    (_('Reports'),       ['income_statement', 'balance_sheet', 'trial_balance', 'journal', 'query']),
-    (_("Other"),         ['holdings', 'commodities', 'events', 'statistics']),
-    (_("Configuration"), ['editor', 'import', 'options', 'help'])
+    ['income_statement', 'balance_sheet', 'trial_balance', 'journal', 'query'],
+    ['holdings', 'commodities', 'events', 'statistics'],
+    ['editor', 'import', 'options', 'help']
 ] %}


### PR DESCRIPTION
"Reports", "Other", "Configuration" don't really say much and are not accurate for all items listed under these headers, e.g., everything under "Other" is a report too and "Import" doesn't have much to do with "Configuration".