### PR TITLE
Improved net worth visualisation

### DIFF
--- a/fava/core/charts.py
+++ b/fava/core/charts.py
@@ -155,6 +155,7 @@ class ChartModule(FavaModule):
         inventory = CounterInventory()
         assets_inventory = CounterInventory()
         liabilities_inventory = CounterInventory()
+
         def reduce_inventory(date, inventory):
             return {
                 currency: inventory.reduce(convert.convert_position,
@@ -170,7 +171,10 @@ class ChartModule(FavaModule):
                     # Since we will be reducing the inventory to the operating
                     # currencies, pre-aggregate the positions to reduce the
                     # number of elements in the inventory.
-                    cost = Cost(ZERO, posting.cost.currency, None, None) if posting.cost else None
+                    if posting.cost:
+                        cost = Cost(ZERO, posting.cost.currency, None, None)
+                    else:
+                        cost = None
                     inventory.add_amount(posting.units, cost)
                     if posting.account.startswith(name_assets):
                         assets_inventory.add_amount(posting.units, cost)
@@ -179,8 +183,8 @@ class ChartModule(FavaModule):
                 txn = next(transactions, None)
             yield {
                 'date': date,
-                # TODO: we could just keep track of assets_inventory and liabilities_inventory
-                # balance is just their sum
+                # TODO: we could just keep track of assets_inventory and
+                # liabilities_inventory balance is just their sum
                 'balance': reduce_inventory(date, inventory),
                 'assets': reduce_inventory(date, assets_inventory),
                 'liabilities': reduce_inventory(date, liabilities_inventory),

--- a/fava/static/javascript/charts.js
+++ b/fava/static/javascript/charts.js
@@ -844,7 +844,8 @@ e.on('page-loaded', () => {
   JSON.parse($('#chart-data').innerHTML).forEach((chart, index) => {
     const id = `${chart.type}-${index}`;
     switch (chart.type) {
-      case 'balances': {
+      case 'balances':
+      case 'net_worth': {
         const series = window.favaAPI.options.commodities
           .map(c => ({
             name: c,

--- a/fava/static/javascript/charts.js
+++ b/fava/static/javascript/charts.js
@@ -844,8 +844,7 @@ e.on('page-loaded', () => {
   JSON.parse($('#chart-data').innerHTML).forEach((chart, index) => {
     const id = `${chart.type}-${index}`;
     switch (chart.type) {
-      case 'balances':
-      case 'net_worth': {
+      case 'balances':{
         const series = window.favaAPI.options.commodities
           .map(c => ({
             name: c,
@@ -858,6 +857,53 @@ e.on('page-loaded', () => {
               })),
           }))
           .filter(d => d.values.length);
+
+        renderers[id] = svg => new LineChart(svg)
+          .set('tooltipText', d => `${formatCurrency(d.value)} ${d.name}<em>${dateFormat.day(d.date)}</em>`)
+          .draw(series);
+        break;
+      }
+      case 'net_worth':{
+        const balanceSeries = window.favaAPI.options.commodities
+          .map(c => ({
+            name: "Net Worth " + c,
+            values: chart.data
+              .filter(d => !(d.balance[c] === undefined))
+              .map(d => ({
+                name: "Net Worth " + c,
+                date: new Date(d.date),
+                value: Number(d.balance[c]),
+              })),
+          }))
+          .filter(d => d.values.length);
+        const assetsSeries = window.favaAPI.options.commodities
+          .map(c => ({
+            name: "Assets " + c,
+            values: chart.data
+              .filter(d => !(d.assets[c] === undefined))
+              .map(d => ({
+                name: "Assets " + c,
+                date: new Date(d.date),
+                value: Number(d.assets[c]),
+              })),
+          }))
+          .filter(d => d.values.length);
+        const liabilitiesSeries = window.favaAPI.options.commodities
+          .map(c => ({
+            name: "Liabilities " + c,
+            values: chart.data
+              .filter(d => !(d.liabilities[c] === undefined))
+              .map(d => ({
+                name: "Liabilities " + c,
+                date: new Date(d.date),
+                value: Number(d.liabilities[c]),
+              })),
+          }))
+          .filter(d => d.values.length);
+        const series =
+          balanceSeries
+          .concat(assetsSeries)
+          .concat(liabilitiesSeries);
 
         renderers[id] = svg => new LineChart(svg)
           .set('tooltipText', d => `${formatCurrency(d.value)} ${d.name}<em>${dateFormat.day(d.date)}</em>`)

--- a/fava/templates/_charts.html
+++ b/fava/templates/_charts.html
@@ -27,7 +27,7 @@
 
 {% macro net_worth(interval) %}
 {% do chart_data.append({
-    'type': 'balances',
+    'type': 'net_worth',
     'label': _('Net Worth'),
     'data': ledger.charts.net_worth(interval),
 }) %}


### PR DESCRIPTION
This PR has been inspired by https://github.com/beancount/fava/issues/745, where @tbm suggested to visualisation net worth, assets and liabilities as it's done by YNAB.

I don't know [d3js](https://d3js.org/) but I figured out that we could rely on what `LineChart` already does to display different lines for different currencies.

This sample file
```
option "operating_currency" "GBP"
2018-01-01 open Liabilities:Mortgage GBP
2018-01-01 open Equity:OpeningBalances GBP
2018-01-01 open Assets:Current GBP
2018-01-01 open Income:Salary GBP
2018-01-01 open Expenses:Interests GBP
2018-01-01 * "Opening balances" ""
  Assets:Current 11000 GBP
  Liabilities:Mortgage -10000 GBP
  Equity:OpeningBalances

2018-02-01 * "Salary" ""
  Income:Salary
  Assets:Current 1500 GBP
2018-02-01 * "Interests" ""
  Liabilities:Mortgage
  Expenses:Interests 500 GBP
2018-02-10 * "Mortgage" ""
  Liabilities:Mortgage
  Assets:Current -1000 GBP

2018-03-01 * "Salary" ""
  Income:Salary
  Assets:Current 1500 GBP
2018-03-01 * "Interests" ""
  Liabilities:Mortgage
  Expenses:Interests 500 GBP
2018-03-10 * "Mortgage" ""
  Liabilities:Mortgage
  Assets:Current -1000 GBP
```
results in this chart being drawn
![screen shot 2018-07-07 at 00 24 48](https://user-images.githubusercontent.com/153130/42403928-e68e861c-817c-11e8-9512-05e74ce4b13d.png)

@yagebu do you think an approach like this could make sense?
I am not completely convinced this is the best solution, but now knowing d3js it was the easiest way I could get to the results we wanted.