### PR TITLE
Fixup in the journal table for link_statements generalisation

### DIFF
--- a/fava/static/css/journal-table.css
+++ b/fava/static/css/journal-table.css
@@ -58,7 +58,7 @@
 .journal > li,
 .journal.show-custom .custom.budget,
 .journal.show-document .document.discovered,
-.journal.show-document .document.statement,
+.journal.show-document .document.linked,
 .journal .metadata,
 .journal .postings {
   display: none;
@@ -83,7 +83,7 @@
 .journal.show-transaction.show-pending .transaction.pending,
 .journal.show-transaction.show-other .transaction.other,
 .journal.show-document.show-discovered .document.discovered,
-.journal.show-document.show-statement .document.statement,
+.journal.show-document.show-linked .document.linked,
 .journal.show-custom.show-budget .custom.budget {
   display: block;
 }

--- a/fava/templates/_journal_table.html
+++ b/fava/templates/_journal_table.html
@@ -52,7 +52,7 @@
   {% for key, value in metadata.items() %}
   <dt>{{ key }}:</dt>
   <dd>
-  {%- if key.startswith('document') %}<a class="filename" data-remote target=_blank href="{{ url_for('document', entry_hash=entry_hash, key=key) }}">{% endif -%}
+  {%- if key.startswith('document') %}<a class="filename" data-remote target=_blank href="{{ url_for('statement', entry_hash=entry_hash, key=key) }}">{% endif -%}
     {{ value }}
     {%- if key.startswith('document') %}</a>{% endif -%}
   </dd>
@@ -102,7 +102,7 @@
     {% set type = entry.__class__.__name__.lower() %}
     {% set entry_hash = entry|hash_entry %}
     {% set metadata = entry.meta|remove_keys(['__tolerances__', '__automatic__', 'filename', 'lineno']) %}
-    <li class="{{ type }} {{ entry.type or '' }} {{ entry.flag|flag_to_type if entry.flag else '' }}{{ ' document' if entry.tags and 'document' in entry.tags else '' }}{{ ' discovered' if entry.tags and 'discovered' in entry.tags else '' }}">
+    <li class="{{ type }} {{ entry.type or '' }} {{ entry.flag|flag_to_type if entry.flag else '' }}{{ ' linked' if entry.tags and 'linked' in entry.tags else '' }}{{ ' discovered' if entry.tags and 'discovered' in entry.tags else '' }}">
         <p>
         <span class="datecell" data-sort-value=-{{ loop.index }}><a href="#context-{{ entry_hash }}">{{ entry.date }}</a></span>
         <span class="flag">{% if type == 'transaction' %}{{ entry.flag }}{% else %}{{ short_type.get(type, type[:3]) }}{% endif %}</span>


### PR DESCRIPTION
Following up #777. Document entries were not being hidden in the journal, and metadata links were broken.

Not sure if the `/<bfile>/statement/` routing needs a new name. Ping @zacchiro :)