### PR TITLE
Fix for variable substitution in time filter

### DIFF
--- a/fava/util/date.py
+++ b/fava/util/date.py
@@ -179,7 +179,7 @@ def parse_date(string):  # pylint: disable=too-many-return-statements
     if not string:
         return None, None
 
-    string = substitute(string)
+    string = substitute(string).lower()
 
     match = IS_RANGE_RE.match(string)
     if match:

--- a/tests/test_util_date.py
+++ b/tests/test_util_date.py
@@ -120,6 +120,7 @@ def test_parse_date(expect_start, expect_end, text):
     ('2014-01-01', '2016-06-27', 'year-2-day+2'),
     ('2016-01-01', '2016-06-25', 'year-day'),
     ('2015-01-01', '2017-01-01', '2015-year'),
+    ('2016-01-01', '2016-04-01', 'quarter-1'),
 ])
 def test_parse_date_relative(expect_start, expect_end, text):
     start, end = _to_date(expect_start), _to_date(expect_end)


### PR DESCRIPTION
Version: master
Bug: currently fails to parse `quarter` and `week` in time filter.

`parse_date()` requires lowercase but `substitute()` returns uppercase 'Q' and 'W'
