### PR TITLE
Wrap text in the source row

### DIFF
--- a/fava/static/css/ingest.css
+++ b/fava/static/css/ingest.css
@@ -18,6 +18,11 @@
 
 .ingest-row .source pre {
   font-size: .9em;
+  white-space: pre-wrap;       /* Since CSS 2.1 */
+  white-space: -moz-pre-wrap;  /* Mozilla, since 1999 */
+  white-space: -pre-wrap;      /* Opera 4-6 */
+  white-space: -o-pre-wrap;    /* Opera 7 */
+  word-wrap: break-word;       /* Internet Explorer 5.5+ */
 }
 
 .ingest-row .entry-form {

--- a/fava/static/css/ingest.css
+++ b/fava/static/css/ingest.css
@@ -18,11 +18,7 @@
 
 .ingest-row .source pre {
   font-size: .9em;
-  white-space: pre-wrap;       /* Since CSS 2.1 */
-  white-space: -moz-pre-wrap;  /* Mozilla, since 1999 */
-  white-space: -pre-wrap;      /* Opera 4-6 */
-  white-space: -o-pre-wrap;    /* Opera 7 */
-  word-wrap: break-word;       /* Internet Explorer 5.5+ */
+  white-space: pre-wrap;
 }
 
 .ingest-row .entry-form {


### PR DESCRIPTION
Source lines may be long and they get cut off inside the pre, as text is not wrapped and scrolling is not possible. This change wraps text so the full line is displayed.

