### PR TITLE
use L as icon for linked documents in journal table

### DIFF
--- a/fava/templates/_journal_table.html
+++ b/fava/templates/_journal_table.html
@@ -5,7 +5,7 @@
   ),
   'document': (
     ('discovered', 'D', _('Documents with a #discovered tag')),
-    ('linked', 'S', _('Documents with a #linked tag')),
+    ('linked', 'L', _('Documents with a #linked tag')),
   ),
   'transaction': (
     ('cleared', '*', _('Cleared transactions')),


### PR DESCRIPTION
... instead of S, which is a left over from when the plugin was called
link *S*tatements