### PR TITLE
Configurable filters

### DIFF
--- a/fava/core/__init__.py
+++ b/fava/core/__init__.py
@@ -112,11 +112,7 @@ class FavaLedger():
         #: The path to the main Beancount file.
         self.beancount_file_path = path
         self._is_encrypted = is_encrypted_file(path)
-        self._filters = {
-            'account': AccountFilter(),
-            'filter': AdvancedFilter(),
-            'time': TimeFilter(),
-        }
+        self._filters = {}
 
         #: An :class:`AttributesModule` instance.
         self.attributes = AttributesModule(self)
@@ -205,6 +201,12 @@ class FavaLedger():
         for mod in MODULES:
             getattr(self, mod).load_file()
 
+        self._filters = {
+            'account': AccountFilter(self.options, self.fava_options),
+            'filter': AdvancedFilter(self.options, self.fava_options),
+            'time': TimeFilter(self.options, self.fava_options),
+        }
+
         self.filter(True)
 
     # pylint: disable=attribute-defined-outside-init
@@ -221,7 +223,7 @@ class FavaLedger():
         self.entries = self.all_entries
 
         for filter_class in self._filters.values():
-            self.entries = filter_class.apply(self.entries, self.options)
+            self.entries = filter_class.apply(self.entries)
 
         self.root_account = realization.realize(self.entries,
                                                 self.account_types)

--- a/fava/core/filters.py
+++ b/fava/core/filters.py
@@ -269,7 +269,9 @@ class FilterSyntaxParser():
 class EntryFilter():
     """Filters a list of entries. """
 
-    def __init__(self):
+    def __init__(self, options, fava_options):
+        self.options = options
+        self.fava_options = fava_options
         self.value = None
 
     def set(self, value):
@@ -285,10 +287,10 @@ class EntryFilter():
     def _include_entry(self, entry):
         raise NotImplementedError
 
-    def _filter(self, entries, _):
+    def _filter(self, entries):
         return [entry for entry in entries if self._include_entry(entry)]
 
-    def apply(self, entries, options):
+    def apply(self, entries):
         """Apply filter.
 
         Args:
@@ -300,7 +302,7 @@ class EntryFilter():
 
         """
         if self.value:
-            return self._filter(entries, options)
+            return self._filter(entries)
         return entries
 
     def __bool__(self):
@@ -310,8 +312,8 @@ class EntryFilter():
 class TimeFilter(EntryFilter):  # pylint: disable=abstract-method
     """Filter by dates."""
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, *args):
+        super().__init__(*args)
         self.begin_date = None
         self.end_date = None
 
@@ -329,9 +331,9 @@ class TimeFilter(EntryFilter):  # pylint: disable=abstract-method
                                   'Failed to parse date: {}'.format(value))
         return True
 
-    def _filter(self, entries, options):
+    def _filter(self, entries):
         entries, _ = summarize.clamp_opt(entries, self.begin_date,
-                                         self.end_date, options)
+                                         self.end_date, self.options)
         return entries
 
 
@@ -346,8 +348,8 @@ PARSE = ply.yacc.yacc(
 class AdvancedFilter(EntryFilter):
     """Filter by tags and links and keys."""
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, *args):
+        super().__init__(*args)
         self._include = None
 
     def set(self, value):
@@ -400,8 +402,8 @@ class AccountFilter(EntryFilter):
     The filter string can either a regular expression or a parent account.
     """
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, *args):
+        super().__init__(*args)
         self.match = None
 
     def set(self, value):

--- a/tests/test_core_filters.py
+++ b/tests/test_core_filters.py
@@ -61,7 +61,7 @@ def test_lexer_parentheses():
     ]
 
 
-FILTER = AdvancedFilter()
+FILTER = AdvancedFilter({}, {})
 
 
 def test_filterexception():
@@ -106,18 +106,17 @@ def test_filterexception():
 ])
 def test_advanced_filter(example_ledger, string, number):
     FILTER.set(string)
-    filtered_entries = FILTER.apply(example_ledger.all_entries,
-                                    example_ledger.options)
+    filtered_entries = FILTER.apply(example_ledger.all_entries)
     assert len(filtered_entries) == number
     FILTER.set('')
 
 
 def test_account_filter(example_ledger):
-    account_filter = AccountFilter()
+    account_filter = AccountFilter(example_ledger.options,
+                                   example_ledger.fava_options)
 
     account_filter.set('Assets')
-    filtered_entries = account_filter.apply(example_ledger.all_entries,
-                                            example_ledger.options)
+    filtered_entries = account_filter.apply(example_ledger.all_entries)
     assert len(filtered_entries) == 541
     assert all(map(
         lambda x: hasattr(x, 'account') and
@@ -126,29 +125,26 @@ def test_account_filter(example_ledger):
         filtered_entries))
 
     account_filter.set('.*US:State')
-    filtered_entries = account_filter.apply(example_ledger.all_entries,
-                                            example_ledger.options)
+    filtered_entries = account_filter.apply(example_ledger.all_entries)
     assert len(filtered_entries) == 67
 
 
 def test_time_filter(example_ledger):
-    time_filter = TimeFilter()
+    time_filter = TimeFilter(example_ledger.options,
+                             example_ledger.fava_options)
 
     time_filter.set('2017')
     assert time_filter.begin_date == datetime.date(2017, 1, 1)
     assert time_filter.end_date == datetime.date(2018, 1, 1)
-    filtered_entries = time_filter.apply(example_ledger.all_entries,
-                                         example_ledger.options)
+    filtered_entries = time_filter.apply(example_ledger.all_entries)
     assert len(filtered_entries) == 82
 
     time_filter.set('1000')
-    filtered_entries = time_filter.apply(example_ledger.all_entries,
-                                         example_ledger.options)
+    filtered_entries = time_filter.apply(example_ledger.all_entries)
     assert not filtered_entries
 
     time_filter.set(None)
-    filtered_entries = time_filter.apply(example_ledger.all_entries,
-                                         example_ledger.options)
+    filtered_entries = time_filter.apply(example_ledger.all_entries)
     assert len(filtered_entries) == len(example_ledger.all_entries)
 
     with pytest.raises(FilterException):


### PR DESCRIPTION
Possible solution for #799.

The `Filter` objects may need access to the options from the beancount file - currently the beancount options are being passed to the `apply()` method.  #799 requires access to the `fava_options` during the `set()` call, which is all a bit messy.

In my mind it is better to configure the filter instances once the files have been read and the filters can then use that however they need which avoids any flask globals black magic.

I think file reloads should be handled gracefully but need one of the maintainers to confirm.