### PR TITLE
Transaction form: Make narration wider than payee

### DIFF
--- a/fava/static/css/entry-forms.css
+++ b/fava/static/css/entry-forms.css
@@ -22,10 +22,16 @@
 }
 
 .entry-form input.account,
-.entry-form input[name='narration'],
+.entry-form input[name='narration'] {
+  flex-grow: 1;
+  flex-basis: 200px;
+  min-width: 20em;
+}
+
 .entry-form input[name='payee'] {
   flex-grow: 1;
-  min-width: 15em;
+  flex-basis: 100px;
+  min-width: 10em;
 }
 
 .entry-form input.metadata-value {

--- a/fava/static/css/entry-forms.css
+++ b/fava/static/css/entry-forms.css
@@ -23,14 +23,14 @@
 
 .entry-form input.account,
 .entry-form input[name='narration'] {
-  flex-grow: 1;
   flex-basis: 200px;
+  flex-grow: 1;
   min-width: 20em;
 }
 
 .entry-form input[name='payee'] {
-  flex-grow: 1;
   flex-basis: 100px;
+  flex-grow: 1;
   min-width: 10em;
 }
 

--- a/fava/static/css/ingest.css
+++ b/fava/static/css/ingest.css
@@ -23,6 +23,7 @@
 
 .ingest-row .entry-form {
   flex-shrink: 0;
+  max-width: 1000px;
   min-width: 600px;
 }
 

--- a/fava/static/css/ingest.css
+++ b/fava/static/css/ingest.css
@@ -26,6 +26,10 @@
   min-width: 600px;
 }
 
+.ingest-row .source.hidden + .entry-form {
+  flex: 1;
+}
+
 .ingest-row input[name='payee'] {
   width: 140px;
 }
@@ -39,7 +43,7 @@
   min-width: 100px;
   text-align: left;
   transform: rotate(90deg);
-  transform-origin: 30% 50%;
+  transform-origin: 28% 50%;
 }
 
 .ingest-row .actions label {


### PR DESCRIPTION
This PR makes the narration slightly wider than the payee field in the transaction form, and uses the full width for the form in the extract view when source is hidden.