### PR TITLE
entry-forms: set type of amount input to text, fix #824

### DIFF
--- a/fava/templates/_entry_forms.html
+++ b/fava/templates/_entry_forms.html
@@ -12,7 +12,7 @@
 <div class="fieldset posting">
   <button class="muted round remove-fieldset" data-event="remove-fieldset" type="button" tabindex="-1">×</button>
   {{ input_account(posting.account) }}
-  <input type="tel" class="amount" placeholder="{{ _('Amount') }}" value="{{ posting.amount if posting else '' }}">
+  <input type="text" class="amount" placeholder="{{ _('Amount') }}" value="{{ posting.amount if posting else '' }}">
   <button class="muted round add-row" type="button" data-event="add-posting" title="{{ _('Add posting') }}">+</button>
 </div>
 {% endmacro %}


### PR DESCRIPTION
As the amount field is not just for numbers but also the currency, the "tel" type is not sufficient for that and in particular means on-screen keyboards will not offer any way to enter the currency.