### PR TITLE
line charts now span y-axis from min to max value

### DIFF
--- a/fava/static/javascript/charts.js
+++ b/fava/static/javascript/charts.js
@@ -540,13 +540,13 @@ class LineChart extends BaseChart {
       max(this.data, s => s.values[s.values.length - 1].date),
     ]);
 
-    // Span y-axis min to max value plus margin as percent of either value
-    this.yMarginPercent = 0.03;
-    this.minDataValue = min(this.data, d => min(d.values, x => x.value));
-    this.maxDataValue = max(this.data, d => max(d.values, x => x.value));
+    // Span y-axis as max minus min value plus 3 percent margin
+    const minDataValue = min(this.data, d => min(d.values, x => x.value));
+    const maxDataValue = max(this.data, d => max(d.values, x => x.value));
+    const yMarginValue = (maxDataValue - minDataValue) * 0.03;
     this.y.domain([
-      this.minDataValue - (this.minDataValue * this.yMarginPercent),
-      this.maxDataValue + (this.maxDataValue * this.yMarginPercent)
+      minDataValue - yMarginValue,
+      maxDataValue + yMarginValue,
     ]);
 
     this.selections.lines = this.canvas.selectAll('.line')

--- a/fava/static/javascript/charts.js
+++ b/fava/static/javascript/charts.js
@@ -540,13 +540,12 @@ class LineChart extends BaseChart {
       max(this.data, s => s.values[s.values.length - 1].date),
     ]);
 
-    // Span y-axis as max minus min value plus 3 percent margin
+    // Span y-axis as max minus min value plus 5 percent margin
     const minDataValue = min(this.data, d => min(d.values, x => x.value));
     const maxDataValue = max(this.data, d => max(d.values, x => x.value));
-    const yMarginValue = (maxDataValue - minDataValue) * 0.03;
     this.y.domain([
-      minDataValue - yMarginValue,
-      maxDataValue + yMarginValue,
+      minDataValue - (maxDataValue - minDataValue) * 0.05,
+      maxDataValue + (maxDataValue - minDataValue) * 0.05,
     ]);
 
     this.selections.lines = this.canvas.selectAll('.line')

--- a/fava/static/javascript/charts.js
+++ b/fava/static/javascript/charts.js
@@ -539,9 +539,14 @@ class LineChart extends BaseChart {
       min(this.data, s => s.values[0].date),
       max(this.data, s => s.values[s.values.length - 1].date),
     ]);
+
+    // Span y-axis min to max value plus margin as percent of either value
+    this.yMarginPercent = 0.03;
+    this.minDataValue = min(this.data, d => min(d.values, x => x.value));
+    this.maxDataValue = max(this.data, d => max(d.values, x => x.value));
     this.y.domain([
-      Math.min(0, min(this.data, d => min(d.values, x => x.value))),
-      Math.max(0, max(this.data, d => max(d.values, x => x.value))),
+      this.minDataValue - (this.minDataValue * this.yMarginPercent),
+      this.maxDataValue + (this.maxDataValue * this.yMarginPercent)
     ]);
 
     this.selections.lines = this.canvas.selectAll('.line')


### PR DESCRIPTION
This is a draft for enhancement request #840 

I chose a 3% margin after trying a few values. This seemed to me to use up the available space without feeling cramped.