### PR TITLE
Reduce docker image size and fix libpng CVEs

### DIFF
--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -1,13 +1,13 @@
-FROM python:3.6.3-alpine
+FROM python:3.6.7-alpine
 
 ENV BEANCOUNT_INPUT_FILE ""
 ENV FAVA_OPTIONS "-H 0.0.0.0"
 ENV FINGERPRINT "4e:65:3e:76:0f:81:59:85:5b:50:06:0c:c2:4d:3c:56:53:8b:83:3e:9b:fa:55:26:98:9a:ca:e2:25:03:92:47"
-ENV BUILDDEPS "libxml2-dev libxslt-dev gcc musl-dev mercurial git nodejs make g++"
+ENV BUILDDEPS "libxml2-dev libxslt-dev gcc musl-dev mercurial git npm make g++"
 ENV RUNDEPS "libxml2 libxslt"
 
 RUN cd /root \
-        && apk add --update $BUILDDEPS $RUNDEPS \
+        && apk add --no-cache $BUILDDEPS $RUNDEPS \
         && hg clone --config bitbucket.org:fingerprints=sha256:$FINGERPRINT https://bitbucket.org/blais/beancount \
         && (cd beancount && hg log -l1) \
         && rm -rf ./beancount/.hg/cache/checklink \
@@ -19,10 +19,10 @@ RUN cd /root \
         && rm fava/docs/changelog.rst \
         && python3 -mpip install ./fava \
         && python3 -mpip uninstall --yes pip \
-        && find /usr/local/lib/python3.6/site-packages -name *.so -print0|xargs -0 strip -v \
+        && find /usr/local/lib/python3.6/site-packages -name '*.so' -print0|xargs -0 strip -v \
+        && find /usr/local/lib/python3.6/site-packages -name '*.pyc' -delete \
         && apk del $BUILDDEPS \
-        && rm -rf /var/cache/apk/* /var/cache/apk/.[!.]* /tmp/* /tmp/.[!.]* /root/* /root/.[!.]*
-
+        && rm -rf /tmp/* /tmp/.[!.]* /root/* /root/.[!.]*
 
 # Default fava port number
 EXPOSE 5000


### PR DESCRIPTION
Upgrades python to pull in newer alpine which fixes a load of  libpng CVEs (https://snyk.io/vuln/SNYK-LINUX-LIBPNG-174098 and https://snyk.io/vuln/SNYK-LINUX-LIBPNG-174252).

Additionally removes apk cache to remove need to clean it up later and purges pyc files to reduce the size.