### PR TITLE
setup.cfg: ship tests in distribution tarball

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -58,7 +58,3 @@ excel =
     pyexcel-ods3>=0.1.1
     pyexcel-xls>=0.1.0
     pyexcel-xlsx>=0.1.0
-
-[options.packages.find]
-exclude =
-    tests


### PR DESCRIPTION
rationale: 3rd party distributors of Fava (e.g., GNU/Linux distributions) might
want to run tests at package build time, for quality assurance purposes