### PR TITLE
Fix generated metadata uploading statements

### DIFF
--- a/fava/help/features.md
+++ b/fava/help/features.md
@@ -135,7 +135,7 @@ be tagged with `#discovered` and can be filtered in the Journal:
 ### Uploading statements
 
 When dropping a file on a transaction (or one of its postings) in the Journal,
-the file will be uploaded as described above, and a `statement`-metadata-entry
+the file will be uploaded as described above, and a `document`-metadata-entry
 inserted for the transaction in your Beancount file.
 
 When dropped on the description the subfolder corresponds to the account of the

--- a/fava/json_api.py
+++ b/fava/json_api.py
@@ -161,7 +161,7 @@ def add_document():
 
     if request.form.get("hash"):
         g.ledger.file.insert_metadata(
-            request.form["hash"], "statement", filename
+            request.form["hash"], "document", filename
         )
     return {"message": "Uploaded to {}".format(filepath)}
 

--- a/tests/data/example.beancount
+++ b/tests/data/example.beancount
@@ -40,7 +40,7 @@ plugin "beancount.plugins.auto_accounts"
 2012-12-11 balance Assets:Account1   10.00 EUR
 
 2012-12-12 * "Payee" "Narration"
-    statement: "file.pdf"
+    document: "file.pdf"
     Expenses:Food                    10.00 EUR
     Assets:Account1                 -10.00 EUR
 


### PR DESCRIPTION
The `statement` metadata key is not recognized as special by fava
anymore, since it has been renamed to `document`.  However, fava was
still inserting the now-obsolete `statement` metadata when uploading a
document by dropping it on a transaction in the journal view.

This patch makes fava add a `document` metadata instead of a `statement`
metadata.

Fixes #860