### PR TITLE
Fix documents metadata with relative paths

### DIFF
--- a/fava/core/__init__.py
+++ b/fava/core/__init__.py
@@ -527,7 +527,7 @@ class FavaLedger:
         value = entry.meta[metadata_key]
 
         beancount_dir = os.path.dirname(self.beancount_file_path)
-        paths = [os.path.join(beancount_dir, value)]
+        paths = [os.path.join(os.path.dirname(entry.meta['filename']), value)]
         paths.extend(
             [
                 os.path.join(


### PR DESCRIPTION
Documents specified with the `document` metadata may contain relative
paths.  Such paths were resolved against the directory containing the
top beancount file.  For consistency with the beancount `document`
directive and the link_documents plugin, this patch resolves relative
paths against the directory containing the beancount file containing the
transaction.