### PR TITLE
ingest: Fix duplicate detection with recent Beancount versions

### DIFF
--- a/fava/core/ingest.py
+++ b/fava/core/ingest.py
@@ -119,6 +119,10 @@ class IngestModule(FavaModule):
 
         if isinstance(new_entries, tuple):
             new_entries, _ = new_entries
+        else:
+            new_entries = extract.find_duplicate_entries(
+                [(filename, new_entries)], self.ledger.all_entries
+            )[0][1]
 
         return new_entries
 

--- a/tests/data/import.beancount
+++ b/tests/data/import.beancount
@@ -2,3 +2,6 @@
 2017-01-01 custom "fava-option" "import-dirs" "."
 2017-01-01 open Assets:Checking
 2017-01-01 open Expenses:Widgets
+
+2017-02-14 * "" " BANKOMAT  00000483 K2 UM 11:56"
+  Assets:Checking -100.00 EUR

--- a/tests/test_core_ingest.py
+++ b/tests/test_core_ingest.py
@@ -30,3 +30,5 @@ def test_ingest_examplefile():
     assert entries[1].postings[1].account == "Assets:Checking"
     assert entries[1].postings[1].units.number == -50.00
     assert entries[1].postings[1].units.currency == "EUR"
+    assert "__duplicate__" not in entries[1].meta
+    assert "__duplicate__" in entries[2].meta


### PR DESCRIPTION
https://bitbucket.org/blais/beancount/commits/b00e95b9c61ceac924826cd0ac15f64f9d9cd8f0
changed Beancount such that the extract.extract_from_file function no
longer calls extract.find_duplicate_entries. This means that when using
Fava with a recent vesion of Beancount, no duplicate detection would be
performed.

This commit fixes the behaviour and adds some assertions to ensure it is
tested.