### PR TITLE
Add 'collapse-below-level' option

### DIFF
--- a/fava/core/fava_options.py
+++ b/fava/core/fava_options.py
@@ -16,6 +16,7 @@ InsertEntryOption = namedtuple("InsertEntryOption", "date re filename lineno")
 DEFAULTS = {
     "account-journal-include-children": True,
     "currency-column": 61,
+    "collapse-below-level": None,
     "auto-reload": False,
     "default-file": None,
     "extensions": [],
@@ -57,6 +58,7 @@ BOOL_OPTS = [
 ]
 
 INT_OPTS = [
+    "collapse-below-level",
     "currency-column",
     "upcoming-events",
     "uptodate-indicator-grey-lookback-days",

--- a/fava/help/features.md
+++ b/fava/help/features.md
@@ -56,6 +56,7 @@ number or a deep hierarchy of accounts, Fava offers the following options:
 -   `show-closed-accounts`
 -   `show-accounts-with-zero-balance`
 -   `show-accounts-with-zero-transactions`
+-   `collapse-below-level`
 
 Additionally, accounts that have the metadata `fava-collapse-account` set to
 `TRUE` on their Open directive will be collapsed in the account trees.

--- a/fava/help/options.md
+++ b/fava/help/options.md
@@ -205,6 +205,17 @@ will always be shown.
 
 ---
 
+## `collapse-below-level`
+
+Default: Not set
+
+If set to a number all accounts at or below this depth in the account tree will
+be collapsed by default. Setting the option to `0` will thus collapse all
+accounts by default. The `fava-collapse-account` metadata on an account takes
+precedence over this option.
+
+---
+
 ## `use-external-editor`
 
 Default: `false`

--- a/fava/template_filters.py
+++ b/fava/template_filters.py
@@ -182,3 +182,13 @@ def format_errormsg(message):
         .replace("for '", "for ")
         .replace("': ", ": ")
     )
+
+def collapse_account_at_level(account_name, level):
+    """Return true if account should be collapsed at the given tree depth."""
+    collapse_account = g.ledger.accounts[account_name].meta.get('fava-collapse-account')
+    if collapse_account is not None:
+        return collapse_account
+    collapse_level = g.ledger.fava_options['collapse-below-level']
+    if collapse_level is not None:
+        return level >= collapse_level
+    return False

--- a/fava/templates/_tree_table.html
+++ b/fava/templates/_tree_table.html
@@ -35,7 +35,7 @@ Hold Ctrl or Cmd while clicking to expand one level.') %}
   {% set balance_children = account.balance_children|cost_or_value(ledger.end_date) %}
   {% set cost = account.balance|cost if g.conversion == 'at_value' else {} %}
   {% set cost_children = account.balance_children|cost if g.conversion == 'at_value' else {} %}
-  <li{{ ' class=toggled' if ledger.accounts[account.name].meta.get('fava-collapse-account') else '' }}>
+  <li{{ ' class=toggled' if account.name|collapse_account_at_level(loop.depth0) else '' }}>
     <p{{ ' class=has-balance' if not balance.is_empty() else '' }}>
     <span class="account-cell depth-{{ loop.depth0 }} droptarget{{ ' has-children' if account.children else '' }}" data-account-name="{{ account.name }}">
       {{ account_macros.account_name(account.name, last_segment=True) }}


### PR DESCRIPTION
Setting the 'collapse-below-level' option will collapse accounts at or
below this depth in the account tree. The 'fava-collapse-account'
metadata on an account will override this setting.

