### PR TITLE
Make use of chardet library when opening ledger files

### DIFF
--- a/tests/data/long-example.beancount
+++ b/tests/data/long-example.beancount
@@ -1,7 +1,6 @@
 ;; -*- mode: org; mode: beancount; -*-
 ;; Birth: 1980-05-12
 ;; Dates: 2014-01-01 - 2016-05-09
-;; THIS FILE HAS BEEN AUTO-GENERATED.
 * Options
 
 option "title" "Example Beancount file"
@@ -5811,7 +5810,7 @@ option "operating_currency" "USD"
   Assets:Testing:MultipleCommodities                    1 XYZ {50 USD}
   Assets:Testing:MultipleCommodities                  -50 USD
 
-2000-01-03 *
+2000-01-03 * "Árvíztűrő tükörfúrógép" "Árvíztűrő tükörfúrógép"
   Assets:Testing:MultipleCommodities                    1 ABC {50 USD}
   Assets:Testing:MultipleCommodities                  -50 USD
 

--- a/tests/test_json_api.py
+++ b/tests/test_json_api.py
@@ -67,7 +67,7 @@ def test_api_source_put(app, test_client):
     assert response.status_code == 200
 
     path = app.config["BEANCOUNT_FILES"][0]
-    payload = open(path).read()
+    payload = open(path, "r", encoding="utf-8").read()
     sha256sum = hashlib.sha256(open(path, mode="rb").read()).hexdigest()
 
     # change source
@@ -88,7 +88,7 @@ def test_api_source_put(app, test_client):
     assert response_data == {"success": True, "sha256sum": sha256sum}
 
     # check if the file has been written
-    assert open(path).read() == "asdf" + payload
+    assert open(path, "r", encoding="utf-8").read() == "asdf" + payload
 
     # write original source file
     result = test_client.put(
@@ -99,7 +99,7 @@ def test_api_source_put(app, test_client):
         content_type="application/json",
     )
     assert result.status_code == 200
-    assert open(path).read() == payload
+    assert open(path, "r", encoding="utf-8").read() == payload
 
 
 def test_api_format_source(app, test_client):
@@ -108,7 +108,7 @@ def test_api_format_source(app, test_client):
         url = flask.url_for("json_api.format_source")
 
     path = app.config["BEANCOUNT_FILES"][0]
-    payload = open(path).read()
+    payload = open(path, "r", encoding="utf-8").read()
 
     result = test_client.post(
         url,
@@ -122,7 +122,7 @@ def test_api_format_source(app, test_client):
 def test_api_format_source_options(app, test_client):
     # pylint: disable=too-many-function-args
     path = app.config["BEANCOUNT_FILES"][0]
-    payload = open(path).read()
+    payload = open(path, "r", encoding="utf-8").read()
     with app.test_request_context():
         app.preprocess_request()
         url = flask.url_for("json_api.format_source")
@@ -148,7 +148,7 @@ def test_api_add_entries(app, test_client, tmpdir):
         app.preprocess_request()
         old_beancount_file = flask.g.ledger.beancount_file_path
         test_file = tmpdir.join("test_file")
-        test_file.open("a")
+        test_file.open("a", encoding="utf-8")
         flask.g.ledger.beancount_file_path = str(test_file)
 
         data = {


### PR DESCRIPTION
This is an alternative (and probably better) solution to the same problem already fixed in#883.

Unlike #884 this solution is based on the [chardet](https://chardet.readthedocs.io/en/latest/index.html) automatic character encoding detection library which is already required by beancount so it is available for the fava environment too.

This fix implements a `detect_encoding(filename: str)->str` function which returns the detected encoding or `utf-8` if the original file doesn't contain any characters other than standard ASCII. 

This way when the user opens an ASCII-encoded file then adds new items with non-ASCII characters it will automatically saved in UTF-8.

Fixes #883