### PR TITLE
dont set page_title for popups #895

### DIFF
--- a/fava/templates/_layout.html
+++ b/fava/templates/_layout.html
@@ -1,6 +1,8 @@
 {% import "_charts.html" as charts with context %}
 {% import "_globals.html" as globals %}
-{% set page_title = globals.all_pages[active_page].0 if not page_title else page_title %}
+{% if active_page in globals.all_pages and not page_title %}
+{% set page_title = globals.all_pages[active_page].0 %}
+{% endif %}
 {% set short_title = page_title if not short_title else short_title %}
 {% if not g.partial %}
 <!doctype html>


### PR DESCRIPTION
Hi,
i tried debugging #895. It seems that the template tries to set a page_title when opening the transaction view (_context.html) which is just a popup and has no entry in _globals.html.
I guess it makes no sense giving it a title in _globals, so I changed the condition for setting page_title.

I'm not familiar with the codebase so please review if this is a proper fix.

Also the layout is a bit broken when the popup is active: the close button does not work (but clicking the backgroud works fine) and the search bars move from top right to top left. I guess this is not directly related?
Should i open another bug for that?