### PR TITLE
Consider leap years for FYE 02-28

### DIFF
--- a/fava/util/date.py
+++ b/fava/util/date.py
@@ -307,6 +307,9 @@ def get_fiscal_period(year, fye, quarter=None):
                 )
                 + datetime.timedelta(days=1)
             ).date()
+            # Special case 02-28 because of leap years
+            if fye == "02-28":
+                start_date = start_date.replace(month=3, day=1)
         except ValueError:
             return None, None
 

--- a/tests/test_util_date.py
+++ b/tests/test_util_date.py
@@ -249,6 +249,9 @@ def test_month_offset(date_input, offset, expected):
         # 5th Apr - UK [FYE=04-05]
         (2018, None, "04-05", "2017-04-06", "2018-04-06"),
         (2018, 1, "04-05", "None", "None"),
+        # 28th February - consider leap years [FYE=02-28]
+        (2016, None, "02-28", "2015-03-01", "2016-03-01"),
+        (2017, None, "02-28", "2016-03-01", "2017-03-01"),
         # expected errors
         (2018, None, "foo", "None", "None"),
         (2018, 0, "12-31", "None", "None"),


### PR DESCRIPTION
A FYE of 02-28 would lead to the following error for certain years:

        return start_date, start_date.replace(year=start_date.year + 1)
    ValueError: day is out of range for month

This is because the start_date was incorrectly calculated as 2016-02-29
(instead of 2016-03-01) but 2017-02-29 (start_date plus a year) doesn't
exist.

Fixes #911