### PR TITLE
fix #918: add collapse-patterns to collapse based on regex list

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,9 +5,9 @@ Unreleased
 ----------
 
 The import page of Fava has been reworked - it now supports moving files to the
-documents folder and the import process should be a bit more interactive.
-This release also contains various fixes and a new `collapse-patterns`
-option to collapse accounts in account trees.
+documents folder and the import process should be a bit more interactive. This release
+also contains various fixes and a new `collapse-pattern` option to collapse accounts in
+account trees based on regular expressions.
 
 v1.10 (2019-01-31)
 ------------------

--- a/CHANGES
+++ b/CHANGES
@@ -6,14 +6,14 @@ Unreleased
 
 The import page of Fava has been reworked - it now supports moving files to the
 documents folder and the import process should be a bit more interactive.
-This release also contains various fixes and a new `collapse-below-level`
+This release also contains various fixes and a new `collapse-patterns`
 option to collapse accounts in account trees.
 
 v1.10 (2019-01-31)
 ------------------
 
 This release contains mostly smaller changes and fixes. In particular, the net
-worth chart will now follow the seleected conversion.
+worth chart will now follow the selected conversion.
 
 v1.9 (2018-10-08)
 -----------------

--- a/fava/core/fava_options.py
+++ b/fava/core/fava_options.py
@@ -16,7 +16,7 @@ InsertEntryOption = namedtuple("InsertEntryOption", "date re filename lineno")
 DEFAULTS = {
     "account-journal-include-children": True,
     "currency-column": 61,
-    "collapse-patterns": [],
+    "collapse-pattern": [],
     "auto-reload": False,
     "default-file": None,
     "fiscal-year-end": "12-31",
@@ -58,13 +58,12 @@ BOOL_OPTS = [
 
 INT_OPTS = [
     "currency-column",
+    "sidebar-show-queries",
     "upcoming-events",
     "uptodate-indicator-grey-lookback-days",
-    "sidebar-show-queries",
 ]
 
 LIST_OPTS = [
-    "collapse-patterns",
     "import-dirs",
     "journal-show",
     "journal-show-document",
@@ -72,15 +71,20 @@ LIST_OPTS = [
 ]
 
 STR_OPTS = [
+    "collapse-pattern",
+    "fiscal-year-end",
     "import-config",
     "interval",
     "language",
     "locale",
     "unrealized",
-    "fiscal-year-end",
 ]
 
+# options that can be specified multiple times
+MULTI_OPTS = ["collapse-pattern"]
 
+
+# pylint: disable=too-many-branches
 def parse_options(custom_entries):
     """Parse custom entries for Fava options.
 
@@ -120,14 +124,22 @@ def parse_options(custom_entries):
                     value = entry.values[1].value
                     assert isinstance(value, str)
 
+                processed_value = None
                 if key in STR_OPTS:
-                    options[key] = value
+                    processed_value = value
                 elif key in BOOL_OPTS:
-                    options[key] = value.lower() == "true"
+                    processed_value = value.lower() == "true"
                 elif key in INT_OPTS:
-                    options[key] = int(value)
+                    processed_value = int(value)
                 elif key in LIST_OPTS:
-                    options[key] = str(value).strip().split(" ")
+                    processed_value = str(value).strip().split(" ")
+
+                if processed_value is not None:
+                    if key in MULTI_OPTS:
+                        options[key].append(processed_value)
+                    else:
+                        options[key] = processed_value
+
             except (IndexError, TypeError, AssertionError):
                 errors.append(
                     OptionError(

--- a/fava/core/fava_options.py
+++ b/fava/core/fava_options.py
@@ -16,7 +16,6 @@ InsertEntryOption = namedtuple("InsertEntryOption", "date re filename lineno")
 DEFAULTS = {
     "account-journal-include-children": True,
     "currency-column": 61,
-    "collapse-below-level": None,
     "collapse-patterns": [],
     "auto-reload": False,
     "default-file": None,
@@ -58,7 +57,6 @@ BOOL_OPTS = [
 ]
 
 INT_OPTS = [
-    "collapse-below-level",
     "currency-column",
     "upcoming-events",
     "uptodate-indicator-grey-lookback-days",

--- a/fava/core/fava_options.py
+++ b/fava/core/fava_options.py
@@ -17,6 +17,7 @@ DEFAULTS = {
     "account-journal-include-children": True,
     "currency-column": 61,
     "collapse-below-level": None,
+    "collapse-patterns": [],
     "auto-reload": False,
     "default-file": None,
     "fiscal-year-end": "12-31",
@@ -65,6 +66,7 @@ INT_OPTS = [
 ]
 
 LIST_OPTS = [
+    "collapse-patterns",
     "import-dirs",
     "journal-show",
     "journal-show-document",

--- a/fava/help/features.md
+++ b/fava/help/features.md
@@ -57,9 +57,7 @@ number or a deep hierarchy of accounts, Fava offers the following options:
 -   `show-accounts-with-zero-balance`
 -   `show-accounts-with-zero-transactions`
 -   `collapse-below-level`
-
-Additionally, accounts that have the metadata `fava-collapse-account` set to
-`TRUE` on their Open directive will be collapsed in the account trees.
+-   `collapse-patterns`
 
 ## Opening an external editor
 

--- a/fava/help/features.md
+++ b/fava/help/features.md
@@ -56,7 +56,6 @@ number or a deep hierarchy of accounts, Fava offers the following options:
 -   `show-closed-accounts`
 -   `show-accounts-with-zero-balance`
 -   `show-accounts-with-zero-transactions`
--   `collapse-below-level`
 -   `collapse-patterns`
 
 ## Opening an external editor

--- a/fava/help/features.md
+++ b/fava/help/features.md
@@ -56,7 +56,7 @@ number or a deep hierarchy of accounts, Fava offers the following options:
 -   `show-closed-accounts`
 -   `show-accounts-with-zero-balance`
 -   `show-accounts-with-zero-transactions`
--   `collapse-patterns`
+-   `collapse-pattern`
 
 ## Opening an external editor
 

--- a/fava/help/options.md
+++ b/fava/help/options.md
@@ -193,12 +193,17 @@ will always be shown.
 
 ---
 
-## `collapse-patterns`
+## `collapse-pattern`
 
 Default: Not set
 
-A space-separated list of regex patterns. Accounts matching a pattern on this list will
-be collapsed.
+This option is used to specify accounts that will be collapsed in the displayed account
+trees. The argument to this option is a regular expression matching account names. This
+option can be specified multiple times.
+
+Collapsing all accounts below a specific depth in the account tree can be accomplished
+by a regex such as: `.*:.*:.*` (this example collapses all accounts that are three
+levels deep).
 
 ---
 ## `use-external-editor`

--- a/fava/help/options.md
+++ b/fava/help/options.md
@@ -199,11 +199,18 @@ Default: Not set
 
 If set to a number all accounts at or below this depth in the account tree will
 be collapsed by default. Setting the option to `0` will thus collapse all
-accounts by default. The `fava-collapse-account` metadata on an account takes
-precedence over this option.
+accounts by default.
 
 ---
 
+## `collapse-patterns`
+
+Default: Not set
+
+A space-separated list of regex patterns. Accounts matching a pattern on this list will
+be collapsed. Also see `collapse-below-level`.
+
+---
 ## `use-external-editor`
 
 Default: `false`

--- a/fava/help/options.md
+++ b/fava/help/options.md
@@ -193,22 +193,12 @@ will always be shown.
 
 ---
 
-## `collapse-below-level`
-
-Default: Not set
-
-If set to a number all accounts at or below this depth in the account tree will
-be collapsed by default. Setting the option to `0` will thus collapse all
-accounts by default.
-
----
-
 ## `collapse-patterns`
 
 Default: Not set
 
 A space-separated list of regex patterns. Accounts matching a pattern on this list will
-be collapsed. Also see `collapse-below-level`.
+be collapsed.
 
 ---
 ## `use-external-editor`

--- a/fava/template_filters.py
+++ b/fava/template_filters.py
@@ -184,9 +184,9 @@ def format_errormsg(message):
     )
 
 
-def collapse_account_at_level(account_name, level):
+def collapse_account_at_level(account_name):
     """Return true if account should be collapsed at the given tree depth."""
-    collapse_patterns = g.ledger.fava_options["collapse-patterns"]
+    collapse_patterns = g.ledger.fava_options["collapse-pattern"]
     for pattern in collapse_patterns:
         if re.match(pattern, account_name):
             return True

--- a/fava/template_filters.py
+++ b/fava/template_filters.py
@@ -186,12 +186,15 @@ def format_errormsg(message):
 
 def collapse_account_at_level(account_name, level):
     """Return true if account should be collapsed at the given tree depth."""
-    collapse_account = g.ledger.accounts[account_name].meta.get(
-        "fava-collapse-account"
-    )
-    if collapse_account is not None:
-        return collapse_account
+
     collapse_level = g.ledger.fava_options["collapse-below-level"]
     if collapse_level is not None:
-        return level >= collapse_level
+        if level >= collapse_level:
+            return True
+
+    collapse_patterns = g.ledger.fava_options["collapse-patterns"]
+    for pattern in collapse_patterns:
+        if re.match(pattern, account_name):
+            return True
+
     return False

--- a/fava/template_filters.py
+++ b/fava/template_filters.py
@@ -186,12 +186,6 @@ def format_errormsg(message):
 
 def collapse_account_at_level(account_name, level):
     """Return true if account should be collapsed at the given tree depth."""
-
-    collapse_level = g.ledger.fava_options["collapse-below-level"]
-    if collapse_level is not None:
-        if level >= collapse_level:
-            return True
-
     collapse_patterns = g.ledger.fava_options["collapse-patterns"]
     for pattern in collapse_patterns:
         if re.match(pattern, account_name):

--- a/fava/templates/_tree_table.html
+++ b/fava/templates/_tree_table.html
@@ -35,7 +35,7 @@ Hold Ctrl or Cmd while clicking to expand one level.') %}
   {% set balance_children = account.balance_children|cost_or_value(ledger.end_date) %}
   {% set cost = account.balance|cost if g.conversion == 'at_value' else {} %}
   {% set cost_children = account.balance_children|cost if g.conversion == 'at_value' else {} %}
-  <li{{ ' class=toggled' if account.name|collapse_account_at_level(loop.depth0) else '' }}>
+  <li{{ ' class=toggled' if account.name|collapse_account_at_level() else '' }}>
     <p{{ ' class=has-balance' if not balance.is_empty() else '' }}>
     <span class="account-cell depth-{{ loop.depth0 }} droptarget{{ ' has-children' if account.children else '' }}" data-account-name="{{ account.name }}">
       {{ account_macros.account_name(account.name, last_segment=True) }}
@@ -97,7 +97,7 @@ Hold Ctrl or Cmd while clicking to expand one level.') %}
         </p>
     </li>
 {% for account in [interval_balances[0]|get_or_create(account_name)] recursive %}
-    <li{{ ' class=toggled' if account.name|collapse_account_at_level(loop.depth0) else '' }}>
+    <li{{ ' class=toggled' if account.name|collapse_account_at_level() else '' }}>
         <p>
         <span class="account-cell depth-{{ loop.depth0 }} droptarget
         {{- '' if not account|length else ' has-children'}}

--- a/tests/data/long-example.beancount
+++ b/tests/data/long-example.beancount
@@ -2737,7 +2737,6 @@ option "operating_currency" "USD"
 2014-01-01 open Assets:US:ETrade:GLD                       GLD
 2014-01-01 open Income:US:ETrade:Gains                      USD
 2014-01-01 open Income:US:ETrade:Dividends                  USD
-    fava-collapse-account: TRUE
 
 2014-09-18 * "Dividends on portfolio" #test
   Assets:US:ETrade:Cash                              0.00 USD

--- a/tests/test_template_filters.py
+++ b/tests/test_template_filters.py
@@ -67,7 +67,6 @@ def test_format_errormsg(app):
 def test_collapse_account_at_level(app):
     with app.test_request_context("/"):
         app.preprocess_request()
-        g.ledger.fava_options["collapse-below-level"] = 2
         g.ledger.fava_options["collapse-patterns"] = [
             "^Assets:Stock$",
             "^Assets:Property:.*",
@@ -77,7 +76,6 @@ def test_collapse_account_at_level(app):
 
         assert collapse_account_at_level("Assets:Cash", 0) is False
         assert collapse_account_at_level("Assets:Cash", 1) is False
-        assert collapse_account_at_level("Assets:Cash", 2) is True
 
         assert collapse_account_at_level("Assets:Stock", 0) is True
         assert collapse_account_at_level("Assets:Stock", 1) is True

--- a/tests/test_template_filters.py
+++ b/tests/test_template_filters.py
@@ -67,22 +67,20 @@ def test_format_errormsg(app):
 def test_collapse_account_at_level(app):
     with app.test_request_context("/"):
         app.preprocess_request()
-        g.ledger.fava_options["collapse-patterns"] = [
+        g.ledger.fava_options["collapse-pattern"] = [
             "^Assets:Stock$",
             "^Assets:Property:.*",
         ]
         g.ledger.accounts["Assets:Stock"] = AccountData()
         g.ledger.accounts["Assets:Property"] = AccountData()
 
-        assert collapse_account_at_level("Assets:Cash", 0) is False
-        assert collapse_account_at_level("Assets:Cash", 1) is False
+        assert collapse_account_at_level("Assets:Cash") is False
+        assert collapse_account_at_level("Assets:Cash") is False
 
-        assert collapse_account_at_level("Assets:Stock", 0) is True
-        assert collapse_account_at_level("Assets:Stock", 1) is True
-        assert collapse_account_at_level("Assets:Stock", 2) is True
+        assert collapse_account_at_level("Assets:Stock") is True
+        assert collapse_account_at_level("Assets:Stock") is True
+        assert collapse_account_at_level("Assets:Stock") is True
 
-        assert collapse_account_at_level("Assets:Property", 0) is False
-        assert collapse_account_at_level("Assets:Property:Real", 0) is True
-        assert (
-            collapse_account_at_level("Assets:Property:Real:Land", 0) is True
-        )
+        assert collapse_account_at_level("Assets:Property") is False
+        assert collapse_account_at_level("Assets:Property:Real") is True
+        assert collapse_account_at_level("Assets:Property:Real:Land") is True

--- a/tests/test_template_filters.py
+++ b/tests/test_template_filters.py
@@ -67,16 +67,16 @@ def test_format_errormsg(app):
 def test_collapse_account_at_level(app):
     with app.test_request_context("/"):
         app.preprocess_request()
-        g.ledger.fava_options["collapse-below-level"] = 1
+        g.ledger.fava_options["collapse-below-level"] = 2
+        g.ledger.fava_options["collapse-patterns"] = [
+            "^Assets:Stock$",
+            "^Assets:Property:.*",
+        ]
         g.ledger.accounts["Assets:Stock"] = AccountData()
         g.ledger.accounts["Assets:Property"] = AccountData()
-        g.ledger.accounts["Assets:Stock"].meta["fava-collapse-account"] = True
-        g.ledger.accounts["Assets:Property"].meta[
-            "fava-collapse-account"
-        ] = False
 
         assert collapse_account_at_level("Assets:Cash", 0) is False
-        assert collapse_account_at_level("Assets:Cash", 1) is True
+        assert collapse_account_at_level("Assets:Cash", 1) is False
         assert collapse_account_at_level("Assets:Cash", 2) is True
 
         assert collapse_account_at_level("Assets:Stock", 0) is True
@@ -84,5 +84,7 @@ def test_collapse_account_at_level(app):
         assert collapse_account_at_level("Assets:Stock", 2) is True
 
         assert collapse_account_at_level("Assets:Property", 0) is False
-        assert collapse_account_at_level("Assets:Property", 1) is False
-        assert collapse_account_at_level("Assets:Property", 2) is False
+        assert collapse_account_at_level("Assets:Property:Real", 0) is True
+        assert (
+            collapse_account_at_level("Assets:Property:Real:Land", 0) is True
+        )


### PR DESCRIPTION
#918: add 'collapse-patterns' that collapses accounts based on regex list. Removes fava-collapse-account option.