### PR TITLE
Autocompletion (fix #933)

### DIFF
--- a/fava/static/javascript/codemirror/hint-beancount.js
+++ b/fava/static/javascript/codemirror/hint-beancount.js
@@ -19,14 +19,14 @@ const completionSources = {
 };
 
 const directiveCompletions = {
-  open: ["accounts", "commodities"],
+  open: ["accounts", "currencies"],
   close: ["accounts"],
-  commodity: ["commodities"],
-  balance: ["accounts", null, "commodities"],
+  commodity: ["currencies"],
+  balance: ["accounts", null, "currencies"],
   pad: ["accounts", "accounts"],
   note: ["accounts"],
   document: ["accounts"],
-  price: ["commodities", null, "commodities"],
+  price: ["currencies", null, "currencies"],
 };
 
 CodeMirror.registerHelper("hint", "beancount", cm => {
@@ -97,12 +97,16 @@ CodeMirror.registerHelper("hint", "beancount", cm => {
         };
       }
 
-      if (previousTokens.length % 2 === 0) {
+      // Ignore negative sign from previousTokens
+      let tokenLength = previousTokens.filter(t => t.type != null).length;
+      if (tokenLength % 2 === 0) {
         const directiveType = previousTokens[2].string;
         if (directiveType in directiveCompletions) {
           const complType =
-            directiveCompletions[directiveType][previousTokens.length / 2 - 2];
-          return fuzzyMatch(cursor, currentWord, completionSources[complType]);
+              directiveCompletions[directiveType][tokenLength / 2 - 2];
+          if (complType) {
+            return fuzzyMatch(cursor, currentWord, window.favaAPI[complType]);
+          }
         }
       }
     }

--- a/fava/static/javascript/codemirror/hint-beancount.js
+++ b/fava/static/javascript/codemirror/hint-beancount.js
@@ -98,7 +98,7 @@ CodeMirror.registerHelper("hint", "beancount", cm => {
       }
 
       // Ignore negative sign from previousTokens
-      let tokenLength = previousTokens.filter(t => t.type != null).length;
+      const tokenLength = previousTokens.filter(t => t.type != null).length;
       if (tokenLength % 2 === 0) {
         const directiveType = previousTokens[2].string;
         if (directiveType in directiveCompletions) {


### PR DESCRIPTION
Fixes #933 

Give `fuzzyMatch` the actual list to filter instead of an undefined string.