### PR TITLE
change to show table header text-align to 'center'

### DIFF
--- a/fava/static/css/journal-table.css
+++ b/fava/static/css/journal-table.css
@@ -47,7 +47,7 @@
 .journal .head .num {
   font-family: var(--font-family);
   color: var(--color-table-header-text);
-  text-align: inherit;
+  text-align: center;
   background-color: var(--color-table-header-background);
 }
 


### PR DESCRIPTION
feel the header text is better to be `'center'` aligned than inherited `'left'` ? especially when you have multi-currency accounts, or when travelling in many countries, spending when >=5 different currencies

![image](https://user-images.githubusercontent.com/14798161/58767442-ad20da00-8550-11e9-99b0-894ad75acd99.png)
