### PR TITLE
Allow specify command line flags from environ

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -48,8 +48,8 @@ There are some command-line options available, run ``fava --help`` for an overvi
 
 Note you can also specify command-line options via environment variable. For
 example, ``--host=0.0.0.0`` is equivalent to setting environment variable
-``FAVA_HOST=0.0.0.0`` when run the ``fava`` command line. You can get all
-available environment variables via ``fava --help``.
+``FAVA_HOST=0.0.0.0``. You can get all available environment variables via
+``fava --help``.
 
 For more information on Fava's features, refer to the help pages that are
 available through Fava's web-interface.  Fava comes with Gmail-style keyboard

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -46,6 +46,11 @@ pointing it to your Beancount file -- and visit the web interface at
 
 There are some command-line options available, run ``fava --help`` for an overview.
 
+Note you can also specify command-line options via environment variable. For
+example, ``--host=0.0.0.0`` is equivalent to setting environment variable
+``FAVA_HOST=0.0.0.0`` when run the ``fava`` command line. You can get all
+available environment variables via ``fava --help``.
+
 For more information on Fava's features, refer to the help pages that are
 available through Fava's web-interface.  Fava comes with Gmail-style keyboard
 shortcuts; press ``?`` to show an overview.

--- a/fava/cli.py
+++ b/fava/cli.py
@@ -13,7 +13,7 @@ from fava import __version__
 
 
 # pylint: disable=too-many-arguments
-@click.command()
+@click.command(context_settings=dict(auto_envvar_prefix="FAVA"))
 @click.argument(
     "filenames",
     nargs=-1,

--- a/fava/cli.py
+++ b/fava/cli.py
@@ -11,6 +11,13 @@ from fava.application import app
 from fava.util import simple_wsgi
 from fava import __version__
 
+def click_option(*args, **kwargs):
+    """A wrapper around click.option decorator to always show environment
+    variable name."""
+    show_envvar = kwargs.pop("show_envvar", True)
+
+    return click.option(*args, show_envvar=show_envvar, **kwargs)
+
 
 # pylint: disable=too-many-arguments
 @click.command(context_settings=dict(auto_envvar_prefix="FAVA"))
@@ -19,7 +26,7 @@ from fava import __version__
     nargs=-1,
     type=click.Path(exists=True, dir_okay=False, resolve_path=True),
 )
-@click.option(
+@click_option(
     "-p",
     "--port",
     type=int,
@@ -27,7 +34,7 @@ from fava import __version__
     metavar="<port>",
     help="The port to listen on. (default: 5000)",
 )
-@click.option(
+@click_option(
     "-H",
     "--host",
     type=str,
@@ -35,19 +42,19 @@ from fava import __version__
     metavar="<host>",
     help="The host to listen on. (default: localhost)",
 )
-@click.option(
+@click_option(
     "--prefix", type=str, help="Set an URL prefix. (for reverse proxy)"
 )
-@click.option(
+@click_option(
     "--incognito",
     is_flag=True,
     help="Run in incognito mode (obscure all numbers).",
 )
-@click.option("-d", "--debug", is_flag=True, help="Turn on debugging.")
-@click.option(
+@click_option("-d", "--debug", is_flag=True, help="Turn on debugging.")
+@click_option(
     "--profile", is_flag=True, help="Turn on profiling. Implies --debug."
 )
-@click.option(
+@click_option(
     "--profile-dir",
     type=click.Path(),
     help="Output directory for profiling data.",

--- a/fava/cli.py
+++ b/fava/cli.py
@@ -11,6 +11,7 @@ from fava.application import app
 from fava.util import simple_wsgi
 from fava import __version__
 
+
 def click_option(*args, **kwargs):
     """A wrapper around click.option decorator to always show environment
     variable name."""


### PR DESCRIPTION
With this option, command line flags can be specified via environment variables like `FAVA_HOST`.