### PR TITLE
documents upload: retain the filename entered in the UI form when saving the file

### DIFF
--- a/fava/json_api.py
+++ b/fava/json_api.py
@@ -205,7 +205,9 @@ def add_document():
         raise FavaAPIException("No file uploaded.")
 
     filepath = filepath_in_document_folder(
-        request.form["folder"], request.form["account"], request.form["filename"]
+        request.form["folder"],
+        request.form["account"],
+        request.form["filename"],
     )
     directory, filename = path.split(filepath)
 

--- a/fava/json_api.py
+++ b/fava/json_api.py
@@ -205,7 +205,7 @@ def add_document():
         raise FavaAPIException("No file uploaded.")
 
     filepath = filepath_in_document_folder(
-        request.form["folder"], request.form["account"], upload.filename
+        request.form["folder"], request.form["account"], request.form["filename"]
     )
     directory, filename = path.split(filepath)
 

--- a/fava/static/javascript/modals/DocumentUpload.svelte
+++ b/fava/static/javascript/modals/DocumentUpload.svelte
@@ -84,7 +84,7 @@
     <h3>{_('Upload file(s)')}:</h3>
     {#each files as file}
       <div class="fieldset">
-        <input value={file.name} />
+        <input name="filename" value={file.name} />
       </div>
     {/each}
     <div class="fieldset">

--- a/tests/test_json_api.py
+++ b/tests/test_json_api.py
@@ -27,7 +27,8 @@ def test_api_add_document(app, test_client, tmpdir):
         request_data = {
             "folder": str(tmpdir),
             "account": "Expenses:Food:Restaurant",
-            "file": (BytesIO(b"asdfasdf"), "2015-12-12 test"),
+            "file": (BytesIO(b"asdfasdf"), "test"),
+            "filename": "2015-12-12 test",
         }
         url = flask.url_for("json_api.add_document")
 


### PR DESCRIPTION
It's important to preserve the Beancount convention that documents should start with `YYYY-MM-DD`. In fact, the UI already prepares a filename with such a prefix, but somehow it is disregarded in the web form.

Was it intended? Or did it just get lost along the way?