### PR TITLE
Fix Serialization of Balance.amount.number field

### DIFF
--- a/fava/serialisation.py
+++ b/fava/serialisation.py
@@ -67,6 +67,9 @@ def serialise(entry):
         del ret["links"]
         del ret["tags"]
         ret["postings"] = [serialise(pos) for pos in entry.postings]
+    elif ret["type"] == "Balance":
+        amt = ret["amount"]
+        ret["amount"] = {"number":str(amt.number), "currency":amt.currency}
     return ret
 
 

--- a/fava/serialisation.py
+++ b/fava/serialisation.py
@@ -69,7 +69,7 @@ def serialise(entry):
         ret["postings"] = [serialise(pos) for pos in entry.postings]
     elif ret["type"] == "Balance":
         amt = ret["amount"]
-        ret["amount"] = {"number":str(amt.number), "currency":amt.currency}
+        ret["amount"] = {"number": str(amt.number), "currency": amt.currency}
     return ret
 
 

--- a/tests/test_serialisation.py
+++ b/tests/test_serialisation.py
@@ -102,6 +102,30 @@ def test_serialise_posting(pos, amount):
     assert loads(dumps(serialise(pos))) == json
     assert deserialise_posting(json) == pos
 
+def test_serialise_balance(app):
+    bal = Balance(
+        {},
+        datetime.date(2019, 9, 17),
+        "Assets:ETrade:Cash",
+        A("0.1234567891011121314151617 CHF"),
+        None,
+        None
+    )
+
+    json = {
+        "date": "2019-09-17",
+        "amount": {"currency": "CHF", "number": "0.1234567891011121314151617"},
+        "diff_amount": None,
+        "meta": {},
+        "tolerance": None,
+        "account": "Assets:ETrade:Cash",
+        "type": "Balance"
+    }
+
+    with app.test_request_context():
+        serialised = loads(dumps(serialise(bal)))
+
+    assert serialised == json
 
 def test_deserialise():
     postings = [

--- a/tests/test_serialisation.py
+++ b/tests/test_serialisation.py
@@ -102,6 +102,7 @@ def test_serialise_posting(pos, amount):
     assert loads(dumps(serialise(pos))) == json
     assert deserialise_posting(json) == pos
 
+
 def test_serialise_balance(app):
     bal = Balance(
         {},
@@ -109,7 +110,7 @@ def test_serialise_balance(app):
         "Assets:ETrade:Cash",
         A("0.1234567891011121314151617 CHF"),
         None,
-        None
+        None,
     )
 
     json = {
@@ -119,13 +120,14 @@ def test_serialise_balance(app):
         "meta": {},
         "tolerance": None,
         "account": "Assets:ETrade:Cash",
-        "type": "Balance"
+        "type": "Balance",
     }
 
     with app.test_request_context():
         serialised = loads(dumps(serialise(bal)))
 
     assert serialised == json
+
 
 def test_deserialise():
     postings = [


### PR DESCRIPTION
The current serialization of a Amount field in a entry like "...... balance .... 204.2 CHF" results in a
in a json object {"amount": 202.4, "currency": CHF"). While this is technically correct most
json parsers treat json numbers as floating point numbers which can cause problems later
on (see #964).

We replace amount with a dictionary to force serialization of the amount field as a string instead
(i.e json object will be .{"amount": "202.4", "currency": CHF"}.