### PR TITLE
documents report

### DIFF
--- a/fava/application.py
+++ b/fava/application.py
@@ -70,6 +70,7 @@ REPORTS = [
     "_context",
     "balance_sheet",
     "commodities",
+    "documents",
     "events",
     "editor",
     "errors",

--- a/fava/core/__init__.py
+++ b/fava/core/__init__.py
@@ -18,6 +18,7 @@ from beancount.core.data import (
     Balance,
     TxnPosting,
     Transaction,
+    Document,
     Event,
     Custom,
 )
@@ -389,6 +390,11 @@ class FavaLedger:
                 balance,
             ) in realization.iterate_with_balance(postings)
         ]
+
+    @property
+    def documents(self):
+        """All currently filtered documents."""
+        return list(filter_type(self.entries, Document))
 
     def events(self, event_type=None):
         """List events (possibly filtered by type)."""

--- a/fava/static/css/base.css
+++ b/fava/static/css/base.css
@@ -64,7 +64,7 @@ table {
 
 td,
 th {
-  padding: 2px 6px;
+  padding: 2px 5px;
   white-space: nowrap;
 }
 

--- a/fava/static/css/journal-table.css
+++ b/fava/static/css/journal-table.css
@@ -1,57 +1,47 @@
 /* stylelint-disable no-descending-specificity */
 
-.tree-table p,
-.tree-table li,
-.tree-table ul,
-.tree-table ol,
-.journal p,
-.journal li,
-.journal ul,
-.journal ol {
+.flex-table p,
+.flex-table li,
+.flex-table ul,
+.flex-table ol {
   padding: 0;
   margin: 0;
 }
 
-.tree-table p,
-.journal p {
+.flex-table p {
   display: flex;
 }
 
-.tree-table p > span,
-.journal p > span {
+.flex-table p > span {
   flex-shrink: 0;
   padding: 2px 4px;
   margin: 0;
 }
 
-.tree-table .num,
-.journal .num {
+.flex-table .num {
   font-family: var(--font-family-monospaced);
   color: var(--color-text);
   text-align: right;
-}
-
-.tree-table .number,
-.journal .num {
   white-space: nowrap;
 }
 
-.tree-table .head p > span,
-.journal .head p > span {
+.flex-table .number {
+  white-space: nowrap;
+}
+
+.flex-table .head p > span {
   padding: 3px 4px;
   color: var(--color-table-header-text);
   background-color: var(--color-table-header-background);
 }
 
-.tree-table .head .num,
-.journal .head .num {
+.flex-table .head .num {
   font-family: var(--font-family);
   color: var(--color-table-header-text);
   background-color: var(--color-table-header-background);
 }
 
-.tree-table .totals p > span,
-.journal .totals p > span {
+.flex-table .totals p > span {
   color: var(--color-table-header-text);
   background-color: var(--color-table-header-background);
 }
@@ -111,13 +101,13 @@
 }
 
 /* Metadata */
-.journal dl {
+.journal .metadata {
   padding: 2px 0;
   margin: 0;
   font-size: 0.9em;
 }
 
-.journal dt {
+.journal .metadata dt {
   display: inline-block;
   float: left;
   width: auto;
@@ -126,7 +116,7 @@
   color: var(--color-journal-metadata);
 }
 
-.journal dd {
+.journal .metadata dd {
   margin-left: 15rem;
   cursor: pointer;
 }

--- a/fava/static/javascript/Import.svelte
+++ b/fava/static/javascript/Import.svelte
@@ -1,6 +1,6 @@
 <script>
-  import { _, fetchAPI } from "./helpers";
-  import { notify } from "./notifications";
+  import { _ } from "./helpers";
+  import { moveDocument } from "./api";
 
   import AccountInput from "./entry-forms/AccountInput.svelte";
 
@@ -43,18 +43,11 @@
   }
 
   async function move(filename, account, newName) {
-    try {
-      const msg = await fetchAPI("move", {
-        filename,
-        account,
-        newName,
-      });
-      notify(msg);
+    const moved = await moveDocument(filename, account, newName);
+    if (moved) {
       for (const [directory, items] of Object.entries(data)) {
         data[directory] = items.filter(item => item.name !== filename);
       }
-    } catch (error) {
-      notify(error, "error");
     }
   }
 </script>

--- a/fava/static/javascript/api.ts
+++ b/fava/static/javascript/api.ts
@@ -3,6 +3,7 @@ import { notify } from "./notifications";
 
 /**
  * Move a file, either in an import directory or a document.
+ * @returns whether the file was moved successfully.
  */
 export async function moveDocument(
   filename: string,

--- a/fava/static/javascript/api.ts
+++ b/fava/static/javascript/api.ts
@@ -1,0 +1,24 @@
+import { fetchAPI } from "./helpers";
+import { notify } from "./notifications";
+
+/**
+ * Move a file, either in an import directory or a document.
+ */
+export async function moveDocument(
+  filename: string,
+  account: string,
+  newName: string
+): Promise<boolean> {
+  try {
+    const msg = await fetchAPI("move", {
+      filename,
+      account,
+      newName,
+    });
+    notify(msg as string);
+    return true;
+  } catch (error) {
+    notify(error, "error");
+    return false;
+  }
+}

--- a/fava/static/javascript/document-upload.ts
+++ b/fava/static/javascript/document-upload.ts
@@ -1,0 +1,69 @@
+/*
+ * File uploads via Drag and Drop on elements with class "droptarget"
+ * and attribute "data-account-name"
+ */
+
+import { writable, Writable } from "svelte/store";
+
+import { delegate, _ } from "./helpers";
+import { favaAPI } from "./stores";
+import { notify } from "./notifications";
+
+function dragover(event: DragEvent, closestTarget: HTMLElement) {
+  closestTarget.classList.add("dragover");
+  event.preventDefault();
+}
+delegate(document, "dragenter", ".droptarget", dragover);
+delegate(document, "dragover", ".droptarget", dragover);
+
+function dragleave(event: DragEvent, closestTarget: HTMLElement) {
+  closestTarget.classList.remove("dragover");
+  event.preventDefault();
+}
+delegate(document, "dragleave", ".droptarget", dragleave);
+
+/* Stores that the Svelte component accesses. */
+export const account = writable("");
+export const hash = writable("");
+export const files: Writable<
+  { dataTransferFile: File; name: string }[]
+> = writable([]);
+
+function drop(event: DragEvent, target: HTMLElement) {
+  target.classList.remove("dragover");
+  event.preventDefault();
+  event.stopPropagation();
+
+  if (!event.dataTransfer || !event.dataTransfer.files.length) {
+    return;
+  }
+  if (!favaAPI.options.documents.length) {
+    notify(
+      _('You need to set the "documents" Beancount option for file uploads.'),
+      "error"
+    );
+    return;
+  }
+
+  const dateAttribute = target.getAttribute("data-entry-date");
+  const entryDate = dateAttribute || new Date().toISOString().substring(0, 10);
+  account.set(target.getAttribute("data-account-name") || "");
+  hash.set(target.getAttribute("data-entry") || "");
+
+  const uploadedFiles: { dataTransferFile: File; name: string }[] = [];
+  for (const dataTransferFile of event.dataTransfer.files) {
+    let { name } = dataTransferFile;
+
+    if (!/^\d{4}-\d{2}-\d{2}/.test(name)) {
+      name = `${entryDate} ${name}`;
+    }
+
+    uploadedFiles.push({
+      dataTransferFile,
+      name,
+    });
+  }
+  files.set(uploadedFiles);
+}
+
+delegate(document, "drop", ".droptarget", drop);

--- a/fava/static/javascript/documents/Accounts.svelte
+++ b/fava/static/javascript/documents/Accounts.svelte
@@ -57,6 +57,8 @@
     }}
     on:drop|preventDefault={drop}
     title={node.fullname}
+    class="droptarget"
+    data-account-name={node.fullname}
     class:expanded
     class:selected={$selectedAccount === node.fullname}
     class:drag>

--- a/fava/static/javascript/documents/Accounts.svelte
+++ b/fava/static/javascript/documents/Accounts.svelte
@@ -1,0 +1,77 @@
+<script>
+  import { createEventDispatcher } from "svelte";
+
+  import { selectedAccount } from "./stores";
+
+  export let node;
+
+  const expanded = true;
+  let drag = false;
+
+  function click() {
+    $selectedAccount = $selectedAccount === node.fullname ? "" : node.fullname;
+  }
+
+  function dragenter(event) {
+    if (event.dataTransfer.types.includes("fava/filename")) {
+      event.preventDefault();
+      drag = true;
+    }
+  }
+  const dragover = dragenter;
+
+  const dispatch = createEventDispatcher();
+
+  function drop(event) {
+    const filename = event.dataTransfer.getData("fava/filename");
+    if (filename) {
+      dispatch("drop", { account: node.fullname, filename });
+      drag = false;
+    }
+  }
+</script>
+
+<style>
+  ul {
+    padding: 0 0 0 0.5em;
+  }
+  p {
+    border: 1px solid var(--color-table-border);
+    margin-bottom: -1px;
+    overflow: hidden;
+    cursor: pointer;
+  }
+  .selected,
+  .drag {
+    background-color: var(--color-table-header-background);
+  }
+</style>
+
+{#if node.name}
+  <p
+    on:click={click}
+    on:dragenter={dragenter}
+    on:dragover={dragover}
+    on:dragleave={() => {
+      drag = false;
+    }}
+    on:drop|preventDefault={drop}
+    title={node.fullname}
+    class:expanded
+    class:selected={$selectedAccount === node.fullname}
+    class:drag>
+    <span>{node.name}</span>
+  </p>
+{/if}
+
+{#if node.children.size}
+  <ul class="flex-table" hidden={!expanded}>
+    {#each [...node.children.values()] as child}
+      <li>
+        {#if node.children.size}
+          <svelte:self on:drop node={child} />
+        {:else}node.name{/if}
+      </li>
+    {/each}
+  </ul>
+{/if}

--- a/fava/static/javascript/documents/Documents.svelte
+++ b/fava/static/javascript/documents/Documents.svelte
@@ -1,0 +1,107 @@
+<script>
+  import { moveDocument } from "../api";
+  import { favaAPI } from "../stores";
+  import { _ } from "../helpers";
+
+  import { basename, entriesToTree } from "./util";
+
+  import AccountInput from "../entry-forms/AccountInput.svelte";
+  import ModalBase from "../modals/ModalBase.svelte";
+  import Accounts from "./Accounts.svelte";
+  import Table from "./Table.svelte";
+
+  export let data;
+  let selected;
+  let moving = null;
+
+  /**
+   * Rename the selected document with <F2>.
+   */
+  function keyup(ev) {
+    if (ev.key === "F2" && selected) {
+      moving = {
+        account: selected.account,
+        filename: selected.filename,
+        newName: basename(selected.filename),
+      };
+    }
+  }
+
+  /**
+   * Move a document to the account it is dropped on.
+   */
+  function drop(ev) {
+    moving = {
+      account: ev.detail.account,
+      filename: ev.detail.filename,
+      newName: basename(ev.detail.filename),
+    };
+  }
+
+  async function move() {
+    const moved = await moveDocument(
+      moving.filename,
+      moving.account,
+      moving.newName
+    );
+    if (moved) {
+      moving = null;
+      // TODO: remove document
+    }
+  }
+</script>
+
+<style>
+  .container {
+    display: flex;
+    position: fixed;
+    top: var(--header-height);
+    right: 0;
+    bottom: 0;
+    left: var(--aside-width);
+  }
+  .half-column {
+    width: 33%;
+    height: 100%;
+    overflow: auto;
+    resize: horizontal;
+    border-right: thin solid var(--color-sidebar-border);
+  }
+</style>
+
+<svelte:window on:keyup={keyup} />
+{#if moving}
+  <ModalBase
+    shown={true}
+    closeHandler={() => {
+      moving = null;
+    }}>
+    <div>
+      <h3>{_('Move or rename document')}</h3>
+      <p>
+        <code>{moving.filename}</code>
+      </p>
+      <p>
+        <AccountInput bind:value={moving.account} />
+        <input size="40" bind:value={moving.newName} />
+        <button type="button" on:click={move}>{'Move'}</button>
+      </p>
+    </div>
+  </ModalBase>
+{/if}
+<div class="container">
+  <div class="half-column" style="width: 14rem;">
+    <Accounts node={entriesToTree(data)} on:drop={drop} />
+  </div>
+  <div class="half-column">
+    <Table bind:selected {data} />
+  </div>
+  <div style="flex: 1;">
+    {#if selected}
+      <object
+        title={selected.filename}
+        data={`${favaAPI.baseURL}document/?filename=${selected.filename}`}
+        style="width:100%;height:100%" />
+    {/if}
+  </div>
+</div>

--- a/fava/static/javascript/documents/Documents.svelte
+++ b/fava/static/javascript/documents/Documents.svelte
@@ -2,6 +2,7 @@
   import { moveDocument } from "../api";
   import { favaAPI } from "../stores";
   import { _ } from "../helpers";
+  import router from "../router";
 
   import { basename, entriesToTree } from "./util";
 
@@ -46,7 +47,7 @@
     );
     if (moved) {
       moving = null;
-      // TODO: remove document
+      router.reload();
     }
   }
 </script>

--- a/fava/static/javascript/documents/Table.svelte
+++ b/fava/static/javascript/documents/Table.svelte
@@ -1,0 +1,88 @@
+<script>
+  import { sortFunc } from "../sort";
+  import { _ } from "../helpers";
+
+  import { selectedAccount } from "./stores";
+  import { basename } from "./util";
+
+  export let data;
+  export let selected;
+
+  /* Extract just the latter part of the filename if it starts with a date. */
+  function name(doc) {
+    const base = basename(doc.filename);
+    if (`${doc.date}` === base.substring(0, 10)) {
+      return base.substring(11);
+    }
+    return base;
+  }
+
+  const tableColumns = [
+    {
+      header: _("Date"),
+      getter: e => e.date,
+    },
+    {
+      header: _("Name"),
+      getter: e => name(e),
+    },
+  ];
+
+  /** Index of the table column and order to sort by */
+  let sort = [0, "desc"];
+  $: table = data
+    .filter(e => e.account.startsWith($selectedAccount))
+    .map(e => [e, tableColumns.map(th => th.getter(e))])
+    .sort(sortFunc("string", sort[1], row => row[1][sort[0]]));
+
+  function setSort(index) {
+    const [col, order] = sort;
+    if (index === col) {
+      sort = [index, order === "asc" ? "desc" : "asc"];
+    } else {
+      sort = [index, "asc"];
+    }
+  }
+</script>
+
+<style>
+  tr {
+    cursor: pointer;
+  }
+  .selected,
+  tr:hover {
+    background-color: var(--color-table-header-background);
+  }
+</style>
+
+<table style="width: 100%">
+  <thead>
+    <tr>
+      {#each tableColumns as col, index}
+        <th
+          on:click={() => setSort(index)}
+          data-sort
+          data-order={index === sort[0] ? sort[1] : null}>
+          {col.header}
+        </th>
+      {/each}
+    </tr>
+  </thead>
+  <tbody>
+    {#each table as [doc, row]}
+      <tr
+        class:selected={selected === doc}
+        draggable="true"
+        title={doc.filename}
+        on:dragstart={ev => {
+          ev.dataTransfer.setData('fava/filename', doc.filename);
+        }}
+        on:click={() => {
+          selected = doc;
+        }}>
+        <td>{row[0]}</td>
+        <td>{row[1]}</td>
+      </tr>
+    {/each}
+  </tbody>
+</table>

--- a/fava/static/javascript/documents/stores.ts
+++ b/fava/static/javascript/documents/stores.ts
@@ -1,0 +1,3 @@
+import { writable } from "svelte/store";
+
+export const selectedAccount = writable("");

--- a/fava/static/javascript/documents/util.ts
+++ b/fava/static/javascript/documents/util.ts
@@ -1,0 +1,38 @@
+import { group } from "d3-array";
+
+interface Node {
+  name: string;
+  fullname: string;
+  children: Map<string, Node>;
+}
+
+export function basename(filename: string) {
+  const parts = filename.split("/");
+  return parts[parts.length - 1];
+}
+
+/**
+ * Generate an account tree from an array of entries.
+ */
+export function entriesToTree<T extends { account: string }>(data: T[]): Node {
+  const groups = group(data, e => e.account);
+  const root: Node = { name: "", fullname: "", children: new Map() };
+  for (const account of [...groups.keys()].sort()) {
+    let node: Node | undefined = root;
+    let parent: Node;
+    const parts = account.split(":");
+    for (const part of parts) {
+      parent = node;
+      node = parent.children.get(part);
+      if (!node) {
+        node = {
+          name: part,
+          fullname: parent.fullname ? `${parent.fullname}:${part}` : part,
+          children: new Map(),
+        };
+        parent.children.set(part, node);
+      }
+    }
+  }
+  return root;
+}

--- a/fava/static/javascript/main.ts
+++ b/fava/static/javascript/main.ts
@@ -69,6 +69,8 @@ import ChartSwitcher from "./ChartSwitcher.svelte";
 // @ts-ignore
 import FilterForm from "./FilterForm.svelte";
 // @ts-ignore
+import Documents from "./documents/Documents.svelte";
+// @ts-ignore
 import Modals from "./modals/Modals.svelte";
 
 function initSvelteComponent(selector: string, SvelteComponent: any) {
@@ -89,6 +91,7 @@ e.on("page-loaded", () => {
 
   initSvelteComponent("#svelte-charts", ChartSwitcher);
   initSvelteComponent("#svelte-import", Import);
+  initSvelteComponent("#svelte-documents", Documents);
 
   document.title = favaAPI.documentTitle;
   select("h1 strong")!.innerHTML = favaAPI.pageTitle;

--- a/fava/static/javascript/modals/DocumentUpload.svelte
+++ b/fava/static/javascript/modals/DocumentUpload.svelte
@@ -3,23 +3,20 @@
   import { notify } from "../notifications";
   import { _, fetch, handleJSON } from "../helpers";
   import { favaAPI } from "../stores";
+  import { account, hash, files } from "../document-upload";
 
   import ModalBase from "./ModalBase.svelte";
   import AccountInput from "../entry-forms/AccountInput.svelte";
 
-  let account = "";
-  let hash = "";
-  let files = [];
-  let folders = [];
   let form;
 
-  $: shown = files.length;
+  $: shown = $files.length;
 
   async function submit() {
     await Promise.all(
-      files.map(({ dataTransferFile, name }) => {
+      $files.map(({ dataTransferFile, name }) => {
         const formData = new FormData(form);
-        formData.append("account", account);
+        formData.append("account", $account);
         formData.append("file", dataTransferFile, name);
         return fetch(`${favaAPI.baseURL}api/add-document/`, {
           method: "PUT",
@@ -36,56 +33,21 @@
           );
       })
     );
-    files = [];
-    account = "";
-    hash = "";
+    $files = [];
+    $account = "";
+    $hash = "";
     router.reload();
-  }
-
-  export function handleDrop(event, target) {
-    folders = favaAPI.options.documents;
-    files = [];
-
-    if (!event.dataTransfer.files.length) {
-      return;
-    }
-    if (!folders.length) {
-      notify(
-        _('You need to set the "documents" Beancount option for file uploads.'),
-        "error"
-      );
-      return;
-    }
-
-    const dateAttribute = target.getAttribute("data-entry-date");
-    const entryDate =
-      dateAttribute || new Date().toISOString().substring(0, 10);
-    account = target.getAttribute("data-account-name");
-    hash = target.getAttribute("data-entry");
-
-    for (const dataTransferFile of event.dataTransfer.files) {
-      let { name } = dataTransferFile;
-
-      if (!/^\d{4}-\d{2}-\d{2}/.test(name)) {
-        name = `${entryDate} ${name}`;
-      }
-
-      files = files.concat({
-        dataTransferFile,
-        name,
-      });
-    }
   }
   function closeHandler() {
     shown = false;
-    files = [];
+    $files = [];
   }
 </script>
 
 <ModalBase {shown} {closeHandler}>
   <form bind:this={form} on:submit|preventDefault={submit}>
     <h3>{_('Upload file(s)')}:</h3>
-    {#each files as file}
+    {#each $files as file}
       <div class="fieldset">
         <input bind:value={file.name} />
       </div>
@@ -94,7 +56,7 @@
       <label>
         {_('Documents folder')}:
         <select name="folder">
-          {#each folders as folder}
+          {#each favaAPI.options.documents as folder}
             <option>{folder}</option>
           {/each}
         </select>
@@ -103,9 +65,9 @@
     <div class="fieldset">
       <label>
         {_('Account')}:
-        <AccountInput bind:value={account} />
+        <AccountInput bind:value={$account} />
       </label>
-      <input type="hidden" name="hash" value={hash} />
+      <input type="hidden" name="hash" value={$hash} />
     </div>
     <button type="submit">{_('Upload')}</button>
   </form>

--- a/fava/static/javascript/modals/Modals.svelte
+++ b/fava/static/javascript/modals/Modals.svelte
@@ -1,44 +1,13 @@
 <script>
-  import { onMount } from "svelte";
-
-  import { delegate } from "../helpers";
-
   import AddEntry from "./AddEntry.svelte";
   import Context from "./Context.svelte";
   import DocumentUpload from "./DocumentUpload.svelte";
   import Export from "./Export.svelte";
   import Extract from "./Extract.svelte";
-
-  let documentUploadModal;
-  // File uploads via Drag and Drop on elements with class "droptarget" and
-  // attribute "data-account-name"
-  onMount(() => {
-    delegate(document, "dragenter", ".droptarget", (event, closestTarget) => {
-      closestTarget.classList.add("dragover");
-      event.preventDefault();
-    });
-
-    delegate(document, "dragover", ".droptarget", (event, closestTarget) => {
-      closestTarget.classList.add("dragover");
-      event.preventDefault();
-    });
-
-    delegate(document, "dragleave", ".droptarget", (event, closestTarget) => {
-      closestTarget.classList.remove("dragover");
-      event.preventDefault();
-    });
-
-    delegate(document, "drop", ".droptarget", (event, closestTarget) => {
-      closestTarget.classList.remove("dragover");
-      event.preventDefault();
-      event.stopPropagation();
-      documentUploadModal.handleDrop(event, closestTarget);
-    });
-  });
 </script>
 
 <AddEntry />
 <Context />
-<DocumentUpload bind:this={documentUploadModal} />
+<DocumentUpload />
 <Export />
 <Extract />

--- a/fava/templates/_globals.html
+++ b/fava/templates/_globals.html
@@ -1,6 +1,7 @@
 {% set all_pages = {
     'balance_sheet':    (_('Balance Sheet'),    'g b'),
     'commodities':      (_('Commodities'),      'g c'),
+    'documents':        (_('Documents'),        'g d'),
     'editor':           (_('Editor'),           'g e'),
     'errors':           (_('Errors'),           ''),
     'events':           (_('Events'),           'g E'),
@@ -16,6 +17,6 @@
 } %}
 {% set navigation_bar = [
     ['income_statement', 'balance_sheet', 'trial_balance', 'journal', 'query'],
-    ['holdings', 'commodities', 'events', 'statistics'],
+    ['holdings', 'commodities', 'documents', 'events', 'statistics'],
     ['editor', 'import', 'options', 'help']
 ] %}

--- a/fava/templates/_journal_table.html
+++ b/fava/templates/_journal_table.html
@@ -83,7 +83,7 @@
   <button type="button" title="Toggle metadata" data-type="metadata" data-key="m"{% if 'metadata' not in journal_show %} class="inactive"{% endif %}>{{ _('Metadata') }}</button>
   <button type="button" title="Toggle postings" data-type="postings" data-key="p"{% if 'postings' not in journal_show %} class="inactive"{% endif %}>{{ _('Postings') }}</button>
 </form>
-<ol class="journal{% for type in journal_show %} show-{{ type }}{% endfor %}">
+<ol class="flex-table journal{% for type in journal_show %} show-{{ type }}{% endfor %}">
     <li class="head">
         <p>
         <span class="datecell" data-sort="num" data-order="desc">{{ _('Date') }}</span>

--- a/fava/templates/_tree_table.html
+++ b/fava/templates/_tree_table.html
@@ -18,7 +18,7 @@ Hold Ctrl or Cmd while clicking to expand one level.') %}
 {% endmacro %}
 
 {% macro tree(account_node) %}
-<ol class="tree-table{{ ' two-currencies' if ledger.options.operating_currency|length > 1 else '' }}" title="{{ table_hover_text }}">
+<ol class="flex-table tree-table{{ ' two-currencies' if ledger.options.operating_currency|length > 1 else '' }}" title="{{ table_hover_text }}">
   <li class="head">
     <p>
       <span class="account-cell"><button type="button" class="link expand-all hidden" title="{{ _('Expand all accounts') }}">{{ _('Expand all') }}</button></span>
@@ -81,7 +81,7 @@ Hold Ctrl or Cmd while clicking to expand one level.') %}
 {% endmacro %}
 
 {% macro account_tree(account_name, interval_balances, dates, accumulate) %}
-<ol class="fullwidth tree-table">
+<ol class="fullwidth flex-table tree-table">
     <li class="head">
         <p>
         <span class="account-cell"><button type="button" class="link expand-all hidden" title="{{ _('Expand all accounts') }}">{{ _('Expand all') }}</button></span>

--- a/fava/templates/documents.html
+++ b/fava/templates/documents.html
@@ -1,0 +1,1 @@
+<div id="svelte-documents"><script type="application/json">{{ ledger.documents|tojson|safe }}</script></div>


### PR DESCRIPTION
I always found file managers to be cumbersome to deal with the folder-tree of accounts and the documents contained therein.

This new report consists of three columns: 1) an account tree, 2) a documents table 3) a documents preview.

- The accounts can be clicked to only show documents for them.
- Documents can be moved to a different account by dragging them on the account and renamed by selecting them with F2
- PDFs will be shown in the third column (I haven't tried any other file types yet)