### PR TITLE
Fixed file naming for the move function in the import menu.

### DIFF
--- a/fava/static/javascript/Import.svelte
+++ b/fava/static/javascript/Import.svelte
@@ -12,10 +12,10 @@
    * Construct the filename from date and basename.
    */
   function newFilename(date, basename) {
-    if (/\d{4}-\d{2}-\d{2}/.test(basename)) {
+    if (/^\d{4}-\d{2}-\d{2}/.test(basename)) {
       return basename;
     }
-    return `${date} ${basename}`;
+    return `${date}.${basename}`;
   }
 
   // Initially set the file names for all importable files.


### PR DESCRIPTION
Fixes:

1. Do not skip adding date prefix to the filename in case the filename already contains a date but not in the beginning

1. Separate date and original filename by a dot (.) as bean-file does