### PR TITLE
Add margin to custom links header

### DIFF
--- a/fava/static/css/base.css
+++ b/fava/static/css/base.css
@@ -351,11 +351,6 @@ aside {
   border-right: 1px solid var(--color-sidebar-border);
 }
 
-aside .header-custom-links {
-  margin-bottom: 0.5rem;
-  margin-left: 1rem;
-}
-
 .navigation {
   padding-bottom: 0.5rem;
   margin-bottom: 0.5rem;

--- a/fava/static/css/base.css
+++ b/fava/static/css/base.css
@@ -351,6 +351,11 @@ aside {
   border-right: 1px solid var(--color-sidebar-border);
 }
 
+aside .header-custom-links {
+  margin-bottom: 0.5rem;
+  margin-left: 1rem;
+}
+
 .navigation {
   padding-bottom: 0.5rem;
   margin-bottom: 0.5rem;

--- a/fava/templates/_aside.html
+++ b/fava/templates/_aside.html
@@ -1,7 +1,7 @@
 {% import '_globals.html' as globals with context %}
 {% set user_queries = ledger.query_shell.queries[:ledger.fava_options['sidebar-show-queries']] %}
 {% if ledger.misc.sidebar_links %}
-<h3>{{ _('Custom Links') }}</h3>
+<h3 class="header-custom-links">{{ _('Custom Links') }}</h3>
 <ul class="navigation">
   {% for label, link in ledger.misc.sidebar_links %}
   <li><a href="{{ link }}" data-remote>{{ label }}</a></li>

--- a/fava/templates/_aside.html
+++ b/fava/templates/_aside.html
@@ -1,7 +1,6 @@
 {% import '_globals.html' as globals with context %}
 {% set user_queries = ledger.query_shell.queries[:ledger.fava_options['sidebar-show-queries']] %}
 {% if ledger.misc.sidebar_links %}
-<h3 class="header-custom-links">{{ _('Custom Links') }}</h3>
 <ul class="navigation">
   {% for label, link in ledger.misc.sidebar_links %}
   <li><a href="{{ link }}" data-remote>{{ label }}</a></li>


### PR DESCRIPTION
When you add a custom link to fava, it appear at the top of sidebar, preceded by "Custom Links" header which has no proper margin. This PR adds the margin property.

My another proposal is to remove this header entirely to be consistent with the rest sections of sidebar.

![Screenshot 2019-10-04 at 09 24 10](https://user-images.githubusercontent.com/4791560/66189395-f2cdea80-e689-11e9-9579-af73bd874db9.png)
