### PR TITLE
Replace faulty pip CLI option in Dockerfile

### DIFF
--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:alpine as builder
 
 RUN apk add --update libxml2-dev libxslt-dev gcc musl-dev g++
-RUN pip install --install-option="--prefix=/install" fava
+RUN pip install --prefix="/install" fava
 
 FROM python:alpine
 


### PR DESCRIPTION
The provided Dockerfile contains the instruction

    RUN pip install --install-option="--prefix=/install" fava

which results in the following error during the Docker build process for
the latest version of the python:alpine image:

    /usr/local/lib/python3.8/site-packages/pip/_internal/commands/install.py:283: UserWarning: Disabling all use of wheels due to the use of --build-options / --global-options / --install-options.

The image build succeeds, but attempting to create a container with it
results in the following error:

    /bin/sh: fava: not found

This commit replaces `--install-option="--prefix=/install"` with `--prefix="/install"`, which fixes the problem on both my desktop (running Docker 19.03.4 on amd64 / Debian) and my Raspberry Pi (running Docker 19.03.3 on armv6 / Raspbian)