### PR TITLE
Use font packages from @openfonts collection

### DIFF
--- a/fava/static/css/fonts.css
+++ b/fava/static/css/fonts.css
@@ -3,14 +3,14 @@
   font-family: "Source Code Pro";
   font-style: normal;
   font-weight: normal;
-  src: url("./source-code-pro-latin-400.woff2") format("woff2");
+  src: url("./source-code-pro-all-400.woff2") format("woff2");
 }
 
 @font-face {
   font-family: "Source Code Pro";
   font-style: normal;
   font-weight: 500;
-  src: url("./source-code-pro-latin-500.woff2") format("woff2");
+  src: url("./source-code-pro-all-500.woff2") format("woff2");
 }
 
 /* Interface fonts */
@@ -32,14 +32,14 @@
   font-family: "Fira Sans";
   font-style: normal;
   font-weight: normal;
-  src: url("./fira-sans-latin-400.woff2") format("woff2");
+  src: url("./fira-sans-all-400.woff2") format("woff2");
 }
 
 @font-face {
   font-family: "Fira Sans";
   font-style: normal;
   font-weight: 500;
-  src: url("./fira-sans-latin-500.woff2") format("woff2");
+  src: url("./fira-sans-all-500.woff2") format("woff2");
 }
 
 /* The help pages */

--- a/fava/static/css/fonts.css
+++ b/fava/static/css/fonts.css
@@ -18,14 +18,14 @@
   font-family: "Fira Mono";
   font-style: normal;
   font-weight: normal;
-  src: url("./fira-mono-latin-400.woff2") format("woff2");
+  src: url("./fira-mono-all-400.woff2") format("woff2");
 }
 
 @font-face {
   font-family: "Fira Mono";
   font-style: normal;
   font-weight: 500;
-  src: url("./fira-mono-latin-500.woff2") format("woff2");
+  src: url("./fira-mono-all-500.woff2") format("woff2");
 }
 
 @font-face {
@@ -47,12 +47,12 @@
   font-family: "Source Serif Pro";
   font-style: normal;
   font-weight: normal;
-  src: url("./source-serif-pro-400.woff2") format("woff2");
+  src: url("./source-serif-pro-latin-400.woff2") format("woff2");
 }
 
 @font-face {
   font-family: "Source Serif Pro";
   font-style: normal;
   font-weight: 600;
-  src: url("./source-serif-pro-600.woff2") format("woff2");
+  src: url("./source-serif-pro-latin-600.woff2") format("woff2");
 }

--- a/fava/static/package-lock.json
+++ b/fava/static/package-lock.json
@@ -214,6 +214,16 @@
         "fastq": "^1.6.0"
       }
     },
+    "@openfonts/fira-sans_all": {
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/@openfonts/fira-sans_all/-/fira-sans_all-1.43.0.tgz",
+      "integrity": "sha512-c7FvIw4UX8r76LWXVh5eCvyVI3hCBIl6NJp4gwAsF/Cj2SkDSSTiuEpB0tof4O1avxBiDrH9iRLdMKSB81Wmkg=="
+    },
+    "@openfonts/source-code-pro_all": {
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/@openfonts/source-code-pro_all/-/source-code-pro_all-1.43.0.tgz",
+      "integrity": "sha512-oCSYGMcL2zmRCD+pYB++eNbLab33fkdE8ATqV5/s5G6xMn1aF/avXZoYOSRvE//VJZ3wJw3+Bli39SPKFc54pQ=="
+    },
     "@samverschueren/stream-to-observable": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz",
@@ -5786,16 +5796,6 @@
       "version": "0.0.72",
       "resolved": "https://registry.npmjs.org/typeface-fira-mono/-/typeface-fira-mono-0.0.72.tgz",
       "integrity": "sha512-bouzjtniGMrakhazipUl6mskswe7UvH3qynU5Wsl0O7NMuL178VtZ0pOqUGsjBJ42l64GZo9nUMI1eSK4kvJbQ=="
-    },
-    "typeface-fira-sans": {
-      "version": "0.0.75",
-      "resolved": "https://registry.npmjs.org/typeface-fira-sans/-/typeface-fira-sans-0.0.75.tgz",
-      "integrity": "sha512-PeaE4JCzBxbrp3oJzLjz+EVMjMIvrqnpmC7cp+HKYgPFbd9j4TAjGWRCEeaY/j9PRbTMICbrTuvanQFCmcjrYQ=="
-    },
-    "typeface-source-code-pro": {
-      "version": "0.0.71",
-      "resolved": "https://registry.npmjs.org/typeface-source-code-pro/-/typeface-source-code-pro-0.0.71.tgz",
-      "integrity": "sha512-lBpRNuC/wLFVjeFpH1qAby5iTG1jggQFBGteB+kDlMDAlpfguGPj8X0ObXK8xKiAl98+WkGbkumc14AckHr0mQ=="
     },
     "typeface-source-serif-pro": {
       "version": "0.0.75",

--- a/fava/static/package-lock.json
+++ b/fava/static/package-lock.json
@@ -214,6 +214,11 @@
         "fastq": "^1.6.0"
       }
     },
+    "@openfonts/fira-mono_all": {
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/@openfonts/fira-mono_all/-/fira-mono_all-1.43.0.tgz",
+      "integrity": "sha512-1XCnuxFMk+hTezoUBBC8exfHoSpObgFI96gTlbvLudMBgctN12Nq89r01hCxMdNoQbtLIK3b9ckwrdZIbFVf8w=="
+    },
     "@openfonts/fira-sans_all": {
       "version": "1.43.0",
       "resolved": "https://registry.npmjs.org/@openfonts/fira-sans_all/-/fira-sans_all-1.43.0.tgz",
@@ -223,6 +228,11 @@
       "version": "1.43.0",
       "resolved": "https://registry.npmjs.org/@openfonts/source-code-pro_all/-/source-code-pro_all-1.43.0.tgz",
       "integrity": "sha512-oCSYGMcL2zmRCD+pYB++eNbLab33fkdE8ATqV5/s5G6xMn1aF/avXZoYOSRvE//VJZ3wJw3+Bli39SPKFc54pQ=="
+    },
+    "@openfonts/source-serif-pro_latin": {
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/@openfonts/source-serif-pro_latin/-/source-serif-pro_latin-1.43.0.tgz",
+      "integrity": "sha512-w7k3dVkTRcYCBnGCouGrMOVa84ldcZjpuujH4/9GJ6qxOWLtFq33EtUL3EJg4txs7bhLEZ/mvtgECkxGir6MtQ=="
     },
     "@samverschueren/stream-to-observable": {
       "version": "0.3.0",
@@ -5791,16 +5801,6 @@
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
       "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
       "dev": true
-    },
-    "typeface-fira-mono": {
-      "version": "0.0.72",
-      "resolved": "https://registry.npmjs.org/typeface-fira-mono/-/typeface-fira-mono-0.0.72.tgz",
-      "integrity": "sha512-bouzjtniGMrakhazipUl6mskswe7UvH3qynU5Wsl0O7NMuL178VtZ0pOqUGsjBJ42l64GZo9nUMI1eSK4kvJbQ=="
-    },
-    "typeface-source-serif-pro": {
-      "version": "0.0.75",
-      "resolved": "https://registry.npmjs.org/typeface-source-serif-pro/-/typeface-source-serif-pro-0.0.75.tgz",
-      "integrity": "sha512-xgx8PdcUbFR9kSlcbmTidCqzsSM41QEemq8AjNLslEHG1Uol7Knjw32h7GJ6hUtp2YijKLbtv6YD7tBbNymghw=="
     },
     "typescript": {
       "version": "3.6.4",

--- a/fava/static/package.json
+++ b/fava/static/package.json
@@ -138,8 +138,10 @@
     "typescript": "^3.6.4"
   },
   "dependencies": {
+    "@openfonts/fira-mono_all": "^1.43.0",
     "@openfonts/fira-sans_all": "^1.43.0",
     "@openfonts/source-code-pro_all": "^1.43.0",
+    "@openfonts/source-serif-pro_latin": "^1.43.0",
     "codemirror": "^5.49.2",
     "d3-array": "^2.3.3",
     "d3-axis": "^1.0.12",
@@ -153,8 +155,6 @@
     "d3-time-format": "^2.2.1",
     "d3-transition": "^1.2.0",
     "mousetrap": "^1.6.3",
-    "svelte": "^3.12.1",
-    "typeface-fira-mono": "0.0.72",
-    "typeface-source-serif-pro": "0.0.75"
+    "svelte": "^3.12.1"
   }
 }

--- a/fava/static/package.json
+++ b/fava/static/package.json
@@ -138,6 +138,8 @@
     "typescript": "^3.6.4"
   },
   "dependencies": {
+    "@openfonts/fira-sans_all": "^1.43.0",
+    "@openfonts/source-code-pro_all": "^1.43.0",
     "codemirror": "^5.49.2",
     "d3-array": "^2.3.3",
     "d3-axis": "^1.0.12",
@@ -153,8 +155,6 @@
     "mousetrap": "^1.6.3",
     "svelte": "^3.12.1",
     "typeface-fira-mono": "0.0.72",
-    "typeface-fira-sans": "0.0.75",
-    "typeface-source-code-pro": "0.0.71",
     "typeface-source-serif-pro": "0.0.75"
   }
 }

--- a/fava/static/rollup.config.js
+++ b/fava/static/rollup.config.js
@@ -13,10 +13,10 @@ const copyFile = promisify(fs.copyFile);
 const fonts = [
   "node_modules/typeface-fira-mono/files/fira-mono-latin-400.woff2",
   "node_modules/typeface-fira-mono/files/fira-mono-latin-500.woff2",
-  "node_modules/typeface-fira-sans/files/fira-sans-latin-400.woff2",
-  "node_modules/typeface-fira-sans/files/fira-sans-latin-500.woff2",
-  "node_modules/typeface-source-code-pro/files/source-code-pro-latin-400.woff2",
-  "node_modules/typeface-source-code-pro/files/source-code-pro-latin-500.woff2",
+  "node_modules/@openfonts/fira-sans_all/files/fira-sans-all-400.woff2",
+  "node_modules/@openfonts/fira-sans_all/files/fira-sans-all-500.woff2",
+  "node_modules/@openfonts/source-code-pro_all/files/source-code-pro-all-400.woff2",
+  "node_modules/@openfonts/source-code-pro_all/files/source-code-pro-all-500.woff2",
   "node_modules/typeface-source-serif-pro/files/source-serif-pro-400.woff2",
   "node_modules/typeface-source-serif-pro/files/source-serif-pro-600.woff2",
 ];

--- a/fava/static/rollup.config.js
+++ b/fava/static/rollup.config.js
@@ -11,14 +11,14 @@ import { basename, dirname, join } from "path";
 const copyFile = promisify(fs.copyFile);
 
 const fonts = [
-  "node_modules/typeface-fira-mono/files/fira-mono-latin-400.woff2",
-  "node_modules/typeface-fira-mono/files/fira-mono-latin-500.woff2",
+  "node_modules/@openfonts/fira-mono_all/files/fira-mono-all-400.woff2",
+  "node_modules/@openfonts/fira-mono_all/files/fira-mono-all-500.woff2",
   "node_modules/@openfonts/fira-sans_all/files/fira-sans-all-400.woff2",
   "node_modules/@openfonts/fira-sans_all/files/fira-sans-all-500.woff2",
   "node_modules/@openfonts/source-code-pro_all/files/source-code-pro-all-400.woff2",
   "node_modules/@openfonts/source-code-pro_all/files/source-code-pro-all-500.woff2",
-  "node_modules/typeface-source-serif-pro/files/source-serif-pro-400.woff2",
-  "node_modules/typeface-source-serif-pro/files/source-serif-pro-600.woff2",
+  "node_modules/@openfonts/source-serif-pro_latin/files/source-serif-pro-latin-400.woff2",
+  "node_modules/@openfonts/source-serif-pro_latin/files/source-serif-pro-latin-600.woff2",
 ];
 
 function copy(files) {


### PR DESCRIPTION
Fonts from `typeface` collection contain only `latin` subset of characters. I replaced Fira Sans and Source Code Pro font packages with full versions from `@openfonts` collection (which is a [fork](https://github.com/bedlaj/openfonts) of `typeface` project).

**Before**:

![Screenshot from 2019-10-28 17-29-16](https://user-images.githubusercontent.com/1660460/67687189-ff074800-f9a8-11e9-91bd-cdb20b08de7c.png)

**After**:

![Screenshot from 2019-10-28 17-29-20](https://user-images.githubusercontent.com/1660460/67687202-03cbfc00-f9a9-11e9-873a-f68911a6c208.png)

---

I didn't touch Fira Mono and Source Serif Pro packages because these fonts are seemingly used only to display English text (BQL queries and help pages).