### PR TITLE
Fix text overflow in balance table

### DIFF
--- a/fava/static/css/journal-table.css
+++ b/fava/static/css/journal-table.css
@@ -22,7 +22,6 @@
   font-family: var(--font-family-monospaced);
   color: var(--color-text);
   text-align: right;
-  white-space: nowrap;
 }
 
 .flex-table .number {


### PR DESCRIPTION
Fixed text overflow in balance table when amount has many decimal places.

**Before**:

![Screen Shot 2019-11-03 at 15 25 06](https://user-images.githubusercontent.com/1660460/68085132-652f1780-fe4e-11e9-88d0-84fe4af985ee.png)

**After**:

![Screen Shot 2019-11-03 at 15 24 50](https://user-images.githubusercontent.com/1660460/68085134-6e1fe900-fe4e-11e9-9feb-8952dad6ff88.png)
