### PR TITLE
Use local time instead of UTC to fill transaction date

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -20,5 +20,5 @@ trim_trailing_whitespace = false
 [{package.json,.travis.yml}]
 indent_size = 2
 
-[*.{js,css,html,svelte}]
+[*.{js,ts,css,html,svelte}]
 indent_size = 2

--- a/fava/static/javascript/Import.svelte
+++ b/fava/static/javascript/Import.svelte
@@ -1,4 +1,5 @@
 <script>
+  import { todayAsString } from "./format";
   import { _ } from "./helpers";
   import { moveDocument } from "./api";
 
@@ -6,7 +7,7 @@
 
   export let data;
 
-  const today = new Date().toISOString().slice(0, 10);
+  const today = todayAsString();
 
   /**
    * Construct the filename from date and basename.

--- a/fava/static/javascript/document-upload.ts
+++ b/fava/static/javascript/document-upload.ts
@@ -5,6 +5,7 @@
 
 import { writable, Writable } from "svelte/store";
 
+import { todayAsString } from "./format";
 import { delegate, _ } from "./helpers";
 import { favaAPI } from "./stores";
 import { notify } from "./notifications";
@@ -47,7 +48,7 @@ function drop(event: DragEvent, target: HTMLElement) {
   }
 
   const dateAttribute = target.getAttribute("data-entry-date");
-  const entryDate = dateAttribute || new Date().toISOString().substring(0, 10);
+  const entryDate = dateAttribute || todayAsString();
   account.set(target.getAttribute("data-account-name") || "");
   hash.set(target.getAttribute("data-entry") || "");
 

--- a/fava/static/javascript/entries.ts
+++ b/fava/static/javascript/entries.ts
@@ -1,6 +1,6 @@
 import router from "./router";
 import { notify } from "./notifications";
-import { dateToString } from "./format";
+import { todayAsString } from "./format";
 import { putAPI } from "./helpers";
 
 interface Posting {
@@ -25,7 +25,7 @@ abstract class Entry {
   constructor(type: string) {
     this.type = type;
     this.meta = {};
-    this.date = dateToString(new Date());
+    this.date = todayAsString();
   }
 }
 

--- a/fava/static/javascript/entries.ts
+++ b/fava/static/javascript/entries.ts
@@ -1,5 +1,6 @@
 import router from "./router";
 import { notify } from "./notifications";
+import { dateToString } from "./format";
 import { putAPI } from "./helpers";
 
 interface Posting {
@@ -24,7 +25,7 @@ abstract class Entry {
   constructor(type: string) {
     this.type = type;
     this.meta = {};
-    this.date = new Date().toISOString().slice(0, 10);
+    this.date = dateToString(new Date());
   }
 }
 

--- a/fava/static/javascript/format.ts
+++ b/fava/static/javascript/format.ts
@@ -1,7 +1,7 @@
 // Helper functions to format numbers and dates.
 
 import { format } from "d3-format";
-import { utcFormat } from "d3-time-format";
+import { utcFormat, timeFormat } from "d3-time-format";
 
 import e from "./events";
 import { favaAPI, interval } from "./stores";
@@ -70,9 +70,6 @@ interval.subscribe(intervalValue => {
   currentTimeFilterDateFormat = timeFilterDateFormat[intervalValue];
 });
 
-export function dateToString(date: Date): string {
-  const year = date.getFullYear();
-  const month = (date.getMonth() + 1 < 10 ? "0" : "") + (date.getMonth() + 1);
-  const day = (date.getDate() < 10 ? "0" : "") + date.getDate();
-  return `${year}-${month}-${day}`;
+export function todayAsString(): string {
+  return timeFormat("%Y-%m-%d")(new Date());
 }

--- a/fava/static/javascript/format.ts
+++ b/fava/static/javascript/format.ts
@@ -69,3 +69,10 @@ export let currentTimeFilterDateFormat = timeFilterDateFormat.month;
 interval.subscribe(intervalValue => {
   currentTimeFilterDateFormat = timeFilterDateFormat[intervalValue];
 });
+
+export function dateToString(date: Date): string {
+  const year = date.getFullYear();
+  const month = (date.getMonth() + 1 < 10 ? "0" : "") + (date.getMonth() + 1);
+  const day = (date.getDate() < 10 ? "0" : "") + date.getDate();
+  return `${year}-${month}-${day}`;
+}


### PR DESCRIPTION
The `toISOString()` method returns UTC datetime string (at least on my system: Linux, FF/Chrome). Because of this, the auto-filled date in transaction entry form could be inaccurate during certain hours (depending on user's time zone). This PR fixes it by using different method of converting date to string.