### PR TITLE
fixes error when running pyinstaller build

### DIFF
--- a/contrib/pyinstaller.spec
+++ b/contrib/pyinstaller.spec
@@ -6,6 +6,7 @@ hidden_imports = collect_submodules('beancount',
                                     filter=lambda name: 'test' not in name)
 
 data_files = [
+    ('../fava/version.txt', 'fava'),
     ('../fava/help', 'fava/help'),
     ('../fava/static/css', 'fava/static/css'),
     ('../fava/static/gen', 'fava/static/gen'),

--- a/fava/__init__.py
+++ b/fava/__init__.py
@@ -1,12 +1,21 @@
 """Fava – A web interface for Beancount."""
 
+import sys
+from os import path
+
 from pkg_resources import get_distribution, DistributionNotFound
 
+__version__ = None
 try:
     __version__ = get_distribution(__name__).version
 except DistributionNotFound:
     # package is not installed
     pass
+
+# if running as pyinstaller bundle, try reading from bundled `version.txt`.
+if not __version__ and getattr(sys, 'frozen') and hasattr(sys, '_MEIPASS'):
+    with open(path.join(sys._MEIPASS, "fava/version.txt"), "r") as file:
+        __version__ = file.read().strip()
 
 LOCALES = [
     "de",

--- a/fava/__init__.py
+++ b/fava/__init__.py
@@ -12,10 +12,14 @@ except DistributionNotFound:
     # package is not installed
     pass
 
-# if running as pyinstaller bundle, try reading from bundled `version.txt`.
-if not __version__ and getattr(sys, 'frozen') and hasattr(sys, '_MEIPASS'):
-    with open(path.join(sys._MEIPASS, "fava/version.txt"), "r") as file:
-        __version__ = file.read().strip()
+try:
+    # if running as pyinstaller bundle, try reading from bundled `version.txt`.
+    if not __version__ and getattr(sys, 'frozen') and hasattr(sys, '_MEIPASS'):
+        with open(path.join(sys._MEIPASS, "fava/version.txt"), "r") as file:
+            __version__ = file.read().strip()
+except:
+    # version number could not be read from file
+    pass
 
 LOCALES = [
     "de",


### PR DESCRIPTION
problem: the following code from `fava/__init.py__` does not work if running as pyinstaller bundle: 

```python
__version__ = get_distribution(__name__).version
```

proposed solution: this pull request provides a fallback for when fava is running as pyinstaller bundle. in this case, fava will read the version number from a bundled file version.txt

note: the file version.txt will written as part of `fava-electron`'s build process