### PR TITLE
Fix linechart y-domain when the minimum value in the range is zero.

### DIFF
--- a/fava/static/javascript/charts/line.ts
+++ b/fava/static/javascript/charts/line.ts
@@ -86,7 +86,7 @@ export class LineChart extends BaseChart {
     // Span y-axis as max minus min value plus 5 percent margin
     const minDataValue = min(this.data, d => min(d.values, x => x.value));
     const maxDataValue = max(this.data, d => max(d.values, x => x.value));
-    if (minDataValue && maxDataValue) {
+    if (minDataValue !== undefined && maxDataValue !== undefined) {
       this.y.domain([
         minDataValue - (maxDataValue - minDataValue) * 0.05,
         maxDataValue + (maxDataValue - minDataValue) * 0.05,


### PR DESCRIPTION
Fixes issue https://github.com/beancount/fava/issues/1034. If the minimum value in the line chart happens to be 0, the condition to set the chart domain is skipped.