### PR TITLE
Escape filter when clicking on payee in the journal

### DIFF
--- a/fava/static/javascript/journal.ts
+++ b/fava/static/javascript/journal.ts
@@ -3,7 +3,11 @@ import e from "./events";
 import router from "./router";
 import { filters } from "./stores";
 
-function addFilter(value: string): void {
+function addFilter(value: string, escape: boolean = false): void {
+  if (escape) {
+    value = value.replace(/[.*+\-?^${}()|[\]\\]/g, "\\$&");
+  }
+
   filters.update(fs => {
     if (fs.filter) {
       return {
@@ -38,7 +42,9 @@ e.on("page-loaded", () => {
       addFilter(target.innerText);
     } else if (target.className === "payee") {
       // Filter for payees when clicking on them.
-      addFilter(`payee:"${target.innerText}"`);
+      // Note: any special characters in the payee string are escaped so the
+      // filter matches against the payee literally.
+      addFilter(`payee:"${target.innerText}"`, true);
     } else if (target.tagName === "DD") {
       // Filter for metadata when clicking on the value.
       addFilter(


### PR DESCRIPTION
As filters use regular expression matching, we need to escape certain
characters in the payee string when adding a filter for it after
clicking on it in the journal.

This commit adds an "escape" parameter to addFilter() in case any future
filters need escaping also. As "escape" defaults to false, there is no
impact to old code.

----

An example: Suppose a payee "PayPal (Europe)". Without escaping the payee string, clicking on the payee in the journal will not match that payee correctly. Instead, as the filter is processed as a regular expression, a capture group of "Europe" is created, matching "PayPal Europe". To match against the payee literally, a filter of "PayPay \\(Europe\\)" is needed.

This PR adds code to escape all special characters taken from [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#Escaping)
