### PR TITLE
Fix Pattern typing in InsertEntryOption

### DIFF
--- a/fava/core/fava_options.py
+++ b/fava/core/fava_options.py
@@ -33,7 +33,7 @@ class InsertEntryOption(NamedTuple):
     """
 
     date: datetime.date
-    re: Pattern
+    re: Pattern[str]
     filename: str
     lineno: int
 

--- a/fava/core/fava_options.py
+++ b/fava/core/fava_options.py
@@ -14,6 +14,7 @@ from typing import Iterable
 from typing import List
 from typing import NamedTuple
 from typing import Tuple
+from typing import Pattern
 
 from beancount.core.data import Custom
 
@@ -32,7 +33,7 @@ class InsertEntryOption(NamedTuple):
     """
 
     date: datetime.date
-    re: re.Pattern
+    re: Pattern
     filename: str
     lineno: int
 


### PR DESCRIPTION
Apparently in python 3.6 you can't directly refer to an re.Pattern. Instead for typing purposes, it's an typing.Pattern.