### PR TITLE
Add option to set indent size

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,7 @@ install_requires =
     Flask-Babel>=1.0.0
     Flask>=0.10.1
     Jinja2>=2.10
-    beancount>=2.1.3
+    beancount>=2.3.0
     click
     markdown2>=2.3.0
     ply

--- a/src/fava/core/fava_options.py
+++ b/src/fava/core/fava_options.py
@@ -48,6 +48,7 @@ DEFAULTS = {
     "fiscal-year-end": "12-31",
     "import-config": None,
     "import-dirs": [],
+    "indent": 2,
     "insert-entry": [],
     "interval": "month",
     "journal-show": [
@@ -84,6 +85,7 @@ BOOL_OPTS = [
 
 INT_OPTS = [
     "currency-column",
+    "indent",
     "sidebar-show-queries",
     "upcoming-events",
     "uptodate-indicator-grey-lookback-days",

--- a/src/fava/core/file.py
+++ b/src/fava/core/file.py
@@ -131,8 +131,13 @@ class FileModule(FavaModule):
             self.ledger.changed()
             entry: Directive = self.ledger.get_entry(entry_hash)
             key = next_key(basekey, entry.meta)
+            indent = self.ledger.fava_options["indent"]
             insert_metadata_in_file(
-                entry.meta["filename"], entry.meta["lineno"], key, value
+                entry.meta["filename"],
+                entry.meta["lineno"],
+                indent,
+                key,
+                value,
             )
             self.ledger.extensions.run_hook(
                 "after_insert_metadata", entry, key, value
@@ -169,11 +174,13 @@ class FileModule(FavaModule):
             for entry in sorted(entries, key=incomplete_sortkey):
                 insert_options = fava_options["insert-entry"]
                 currency_column = fava_options["currency-column"]
+                indent = fava_options["indent"]
                 fava_options["insert-entry"] = insert_entry(
                     entry,
                     self.ledger.beancount_file_path,
                     insert_options,
                     currency_column,
+                    indent,
                 )
                 self.ledger.extensions.run_hook("after_insert_entry", entry)
 
@@ -188,7 +195,7 @@ class FileModule(FavaModule):
         Yields:
             The entries rendered in Beancount format.
         """
-
+        indent = self.ledger.fava_options["indent"]
         for entry in entries:
             if isinstance(entry, (Balance, Transaction)):
                 if isinstance(entry, Transaction) and entry.flag in EXCL_FLAGS:
@@ -197,7 +204,9 @@ class FileModule(FavaModule):
                     yield get_entry_slice(entry)[0] + "\n"
                 except (KeyError, FileNotFoundError):
                     yield _format_entry(
-                        entry, self.ledger.fava_options["currency-column"]
+                        entry,
+                        self.ledger.fava_options["currency-column"],
+                        indent,
                     )
 
 
@@ -220,29 +229,15 @@ def next_key(basekey: str, keys: Dict[str, Any]) -> str:
     return f"{basekey}-{i}"
 
 
-DEFAULT_INDENT = "  "
-
-
-def leading_space(line: str) -> str:
-    """Return a string with the leading whitespace of the given line."""
-    return line[: len(line) - len(line.lstrip())] or DEFAULT_INDENT
-
-
 def insert_metadata_in_file(
-    filename: str, lineno: int, key: str, value: str
+    filename: str, lineno: int, indent: int, key: str, value: str
 ) -> None:
     """Inserts the specified metadata in the file below lineno, taking into
     account the whitespace in front of the line that lineno."""
     with open(filename, "r", encoding="utf-8") as file:
         contents = file.readlines()
 
-    # use the whitespace of the following line but at least two spaces.
-    try:
-        indent = leading_space(contents[lineno]) or DEFAULT_INDENT
-    except IndexError:
-        indent = DEFAULT_INDENT
-
-    contents.insert(lineno, f'{indent}{key}: "{value}"\n')
+    contents.insert(lineno, f'{" " * indent}{key}: "{value}"\n')
 
     with open(filename, "w", encoding="utf-8") as file:
         file.write("".join(contents))
@@ -329,6 +324,7 @@ def insert_entry(
     default_filename: str,
     insert_options: List[InsertEntryOption],
     currency_column: int,
+    indent: int,
 ) -> List[InsertEntryOption]:
     """Insert an entry.
 
@@ -337,6 +333,7 @@ def insert_entry(
         default_filename: The default file to insert into if no option matches.
         insert_options: Insert options.
         currency_column: The column to align currencies at.
+        indent: Number of indent spaces.
 
     Returns:
         A list of updated insert options.
@@ -344,7 +341,7 @@ def insert_entry(
     filename, lineno = find_insert_position(
         entry, insert_options, default_filename
     )
-    content = _format_entry(entry, currency_column)
+    content = _format_entry(entry, currency_column, indent)
 
     with open(filename, "r", encoding="utf-8") as file:
         contents = file.readlines()
@@ -370,13 +367,13 @@ def insert_entry(
     ]
 
 
-def _format_entry(entry: Directive, currency_column: int) -> str:
+def _format_entry(entry: Directive, currency_column: int, indent: int) -> str:
     """Wrapper that strips unnecessary whitespace from format_entry."""
     meta = {
         key: entry.meta[key] for key in entry.meta if not key.startswith("_")
     }
     entry = entry._replace(meta=meta)
-    string = align(format_entry(entry), currency_column)
+    string = align(format_entry(entry, prefix=" " * indent), currency_column)
     string = string.replace("<class 'beancount.core.number.MISSING'>", "")
     return "\n".join((line.rstrip() for line in string.split("\n")))
 

--- a/src/fava/help/options.md
+++ b/src/fava/help/options.md
@@ -81,6 +81,12 @@ more examples.
 
 ---
 
+## `indent`
+
+Default: 2.
+
+The number spaces for indentation.
+
 ## `insert-entry`
 
 Default: Not set.

--- a/tests/test_core_fava_options.py
+++ b/tests/test_core_fava_options.py
@@ -13,6 +13,7 @@ def test_fava_options(load_doc):
     2016-04-14 custom "fava-option" "show-closed-accounts" "true"
     2016-04-14 custom "fava-option" "journal-show" "transaction open"
     2016-04-14 custom "fava-option" "currency-column" "10"
+    2016-04-14 custom "fava-option" "indent" "4"
     2016-04-14 custom "fava-option" "insert-entry" "Ausgaben:Test"
     2016-04-14 custom "fava-option" "invalid"
     2016-06-14 custom "fava-option" "conversion" "USD"
@@ -23,13 +24,14 @@ def test_fava_options(load_doc):
 
     assert len(errors) == 1
 
+    assert options["indent"] == 4
     assert options["interval"] == "week"
     assert options["insert-entry"] == [
         InsertEntryOption(
             datetime.date(2016, 4, 14),
             re.compile("Ausgaben:Test"),
             "<string>",
-            7,
+            8,
         )
     ]
     assert options["show-closed-accounts"]

--- a/tests/test_core_file.py
+++ b/tests/test_core_file.py
@@ -15,7 +15,6 @@ from fava.core.file import find_entry_lines
 from fava.core.file import get_entry_slice
 from fava.core.file import insert_entry
 from fava.core.file import insert_metadata_in_file
-from fava.core.file import leading_space
 from fava.core.file import next_key
 from fava.core.file import save_entry_slice
 from fava.helpers import FavaAPIException
@@ -70,15 +69,6 @@ def test_next_key() -> None:
     )
 
 
-def test_leading_space() -> None:
-    assert leading_space("test") == "  "
-    assert leading_space("	test") == "	"
-    assert leading_space("  test") == "  "
-    assert leading_space('    2016-10-31 * "Test" "Test"') == "    "
-    assert leading_space("\r\t\r\ttest") == "\r\t\r\t"
-    assert leading_space("\ntest") == "\n"
-
-
 def test_insert_metadata_in_file(tmp_path) -> None:
     file_content = dedent(
         """\
@@ -91,8 +81,8 @@ def test_insert_metadata_in_file(tmp_path) -> None:
     samplefile.write_text(file_content)
 
     # Insert some metadata lines.
-    insert_metadata_in_file(str(samplefile), 1, "metadata", "test1")
-    insert_metadata_in_file(str(samplefile), 1, "metadata", "test2")
+    insert_metadata_in_file(str(samplefile), 1, 4, "metadata", "test1")
+    insert_metadata_in_file(str(samplefile), 1, 4, "metadata", "test2")
     assert samplefile.read_text("utf-8") == dedent(
         """\
         2016-02-26 * "Uncle Boons" "Eating out alone"
@@ -104,7 +94,7 @@ def test_insert_metadata_in_file(tmp_path) -> None:
     )
 
     # Check that inserting also works if the next line is empty.
-    insert_metadata_in_file(str(samplefile), 5, "metadata", "test1")
+    insert_metadata_in_file(str(samplefile), 5, 2, "metadata", "test1")
     assert samplefile.read_text("utf-8") == dedent(
         """\
         2016-02-26 * "Uncle Boons" "Eating out alone"
@@ -173,7 +163,7 @@ def test_insert_entry_transaction(tmp_path) -> None:
     )
 
     # Test insertion without "insert-entry" options.
-    insert_entry(transaction, str(samplefile), [], 61)
+    insert_entry(transaction, str(samplefile), [], 61, 2)
     assert samplefile.read_text("utf-8") == dedent(
         """\
         2016-02-26 * "Uncle Boons" "Eating out alone"
@@ -200,7 +190,11 @@ def test_insert_entry_transaction(tmp_path) -> None:
         ),
     ]
     new_options = insert_entry(
-        transaction._replace(narration="narr1"), str(samplefile), options, 61
+        transaction._replace(narration="narr1"),
+        str(samplefile),
+        options,
+        61,
+        2,
     )
     assert new_options[0].lineno == 5
     assert new_options[1].lineno == 5
@@ -232,7 +226,7 @@ def test_insert_entry_transaction(tmp_path) -> None:
         ),
     ]
     transaction = transaction._replace(narration="narr2")
-    new_options = insert_entry(transaction, str(samplefile), options, 61)
+    new_options = insert_entry(transaction, str(samplefile), options, 61, 2)
     assert new_options[0].lineno == 9
     assert new_options[1].lineno == 1
     assert samplefile.read_text("utf-8") == dedent(
@@ -266,7 +260,7 @@ def test_insert_entry_transaction(tmp_path) -> None:
         ),
     ]
     transaction = transaction._replace(narration="narr3")
-    insert_entry(transaction, str(samplefile), options, 61)
+    insert_entry(transaction, str(samplefile), options, 61, 2)
     assert samplefile.read_text("utf-8") == dedent(
         """\
         2016-01-01 * "new payee" "narr3"
@@ -319,7 +313,7 @@ def test_insert_entry_align(tmp_path) -> None:
         {}, date(2016, 1, 1), "*", "new payee", "narr", None, None, postings,
     )
 
-    insert_entry(transaction, str(samplefile), [], 50)
+    insert_entry(transaction, str(samplefile), [], 50, 2)
     assert samplefile.read_text("utf-8") == dedent(
         """\
         2016-02-26 * "Uncle Boons" "Eating out alone"

--- a/tests/test_core_file.py
+++ b/tests/test_core_file.py
@@ -94,7 +94,7 @@ def test_insert_metadata_in_file(tmp_path) -> None:
     )
 
     # Check that inserting also works if the next line is empty.
-    insert_metadata_in_file(str(samplefile), 5, 2, "metadata", "test1")
+    insert_metadata_in_file(str(samplefile), 5, 4, "metadata", "test1")
     assert samplefile.read_text("utf-8") == dedent(
         """\
         2016-02-26 * "Uncle Boons" "Eating out alone"
@@ -102,7 +102,7 @@ def test_insert_metadata_in_file(tmp_path) -> None:
             metadata: "test1"
             Liabilities:US:Chase:Slate                       -24.84 USD
             Expenses:Food:Restaurant                          24.84 USD
-          metadata: "test1"
+            metadata: "test1"
         """
     )
 
@@ -163,7 +163,7 @@ def test_insert_entry_transaction(tmp_path) -> None:
     )
 
     # Test insertion without "insert-entry" options.
-    insert_entry(transaction, str(samplefile), [], 61, 2)
+    insert_entry(transaction, str(samplefile), [], 61, 4)
     assert samplefile.read_text("utf-8") == dedent(
         """\
         2016-02-26 * "Uncle Boons" "Eating out alone"
@@ -171,8 +171,8 @@ def test_insert_entry_transaction(tmp_path) -> None:
             Expenses:Food:Restaurant                          24.84 USD
 
         2016-01-01 * "new payee" "narr"
-          Liabilities:US:Chase:Slate                         -10.00 USD
-          Expenses:Food                                       10.00 USD
+            Liabilities:US:Chase:Slate                       -10.00 USD
+            Expenses:Food                                     10.00 USD
         """
     )
 
@@ -194,7 +194,7 @@ def test_insert_entry_transaction(tmp_path) -> None:
         str(samplefile),
         options,
         61,
-        2,
+        4,
     )
     assert new_options[0].lineno == 5
     assert new_options[1].lineno == 5
@@ -202,16 +202,16 @@ def test_insert_entry_transaction(tmp_path) -> None:
     assert samplefile.read_text("utf-8") == dedent(
         """\
         2016-01-01 * "new payee" "narr1"
-          Liabilities:US:Chase:Slate                         -10.00 USD
-          Expenses:Food                                       10.00 USD
+            Liabilities:US:Chase:Slate                       -10.00 USD
+            Expenses:Food                                     10.00 USD
 
         2016-02-26 * "Uncle Boons" "Eating out alone"
             Liabilities:US:Chase:Slate                       -24.84 USD
             Expenses:Food:Restaurant                          24.84 USD
 
         2016-01-01 * "new payee" "narr"
-          Liabilities:US:Chase:Slate                         -10.00 USD
-          Expenses:Food                                       10.00 USD
+            Liabilities:US:Chase:Slate                       -10.00 USD
+            Expenses:Food                                     10.00 USD
         """
     )
 
@@ -226,26 +226,26 @@ def test_insert_entry_transaction(tmp_path) -> None:
         ),
     ]
     transaction = transaction._replace(narration="narr2")
-    new_options = insert_entry(transaction, str(samplefile), options, 61, 2)
+    new_options = insert_entry(transaction, str(samplefile), options, 61, 4)
     assert new_options[0].lineno == 9
     assert new_options[1].lineno == 1
     assert samplefile.read_text("utf-8") == dedent(
         """\
         2016-01-01 * "new payee" "narr1"
-          Liabilities:US:Chase:Slate                         -10.00 USD
-          Expenses:Food                                       10.00 USD
+            Liabilities:US:Chase:Slate                       -10.00 USD
+            Expenses:Food                                     10.00 USD
 
         2016-01-01 * "new payee" "narr2"
-          Liabilities:US:Chase:Slate                         -10.00 USD
-          Expenses:Food                                       10.00 USD
+            Liabilities:US:Chase:Slate                       -10.00 USD
+            Expenses:Food                                     10.00 USD
 
         2016-02-26 * "Uncle Boons" "Eating out alone"
             Liabilities:US:Chase:Slate                       -24.84 USD
             Expenses:Food:Restaurant                          24.84 USD
 
         2016-01-01 * "new payee" "narr"
-          Liabilities:US:Chase:Slate                         -10.00 USD
-          Expenses:Food                                       10.00 USD
+            Liabilities:US:Chase:Slate                       -10.00 USD
+            Expenses:Food                                     10.00 USD
         """
     )
 
@@ -260,28 +260,28 @@ def test_insert_entry_transaction(tmp_path) -> None:
         ),
     ]
     transaction = transaction._replace(narration="narr3")
-    insert_entry(transaction, str(samplefile), options, 61, 2)
+    insert_entry(transaction, str(samplefile), options, 61, 4)
     assert samplefile.read_text("utf-8") == dedent(
         """\
         2016-01-01 * "new payee" "narr3"
-          Liabilities:US:Chase:Slate                         -10.00 USD
-          Expenses:Food                                       10.00 USD
+            Liabilities:US:Chase:Slate                       -10.00 USD
+            Expenses:Food                                     10.00 USD
 
         2016-01-01 * "new payee" "narr1"
-          Liabilities:US:Chase:Slate                         -10.00 USD
-          Expenses:Food                                       10.00 USD
+            Liabilities:US:Chase:Slate                       -10.00 USD
+            Expenses:Food                                     10.00 USD
 
         2016-01-01 * "new payee" "narr2"
-          Liabilities:US:Chase:Slate                         -10.00 USD
-          Expenses:Food                                       10.00 USD
+            Liabilities:US:Chase:Slate                       -10.00 USD
+            Expenses:Food                                     10.00 USD
 
         2016-02-26 * "Uncle Boons" "Eating out alone"
             Liabilities:US:Chase:Slate                       -24.84 USD
             Expenses:Food:Restaurant                          24.84 USD
 
         2016-01-01 * "new payee" "narr"
-          Liabilities:US:Chase:Slate                         -10.00 USD
-          Expenses:Food                                       10.00 USD
+            Liabilities:US:Chase:Slate                       -10.00 USD
+            Expenses:Food                                     10.00 USD
         """
     )
 
@@ -306,14 +306,14 @@ def test_insert_entry_align(tmp_path) -> None:
             None,
             None,
         ),
-        Posting("Expenses:Food", A("10.00 USD"), None, None, None, None,),
+        Posting("Expenses:Food", A("10.00 USD"), None, None, None, None),
     ]
 
     transaction = Transaction(
         {}, date(2016, 1, 1), "*", "new payee", "narr", None, None, postings,
     )
 
-    insert_entry(transaction, str(samplefile), [], 50, 2)
+    insert_entry(transaction, str(samplefile), [], 50, 4)
     assert samplefile.read_text("utf-8") == dedent(
         """\
         2016-02-26 * "Uncle Boons" "Eating out alone"
@@ -321,8 +321,50 @@ def test_insert_entry_align(tmp_path) -> None:
             Expenses:Food:Restaurant                          24.84 USD
 
         2016-01-01 * "new payee" "narr"
-          Liabilities:US:Chase:Slate              -10.00 USD
-          Expenses:Food                            10.00 USD
+            Liabilities:US:Chase:Slate            -10.00 USD
+            Expenses:Food                          10.00 USD
+        """
+    )
+
+
+def test_insert_entry_indent(tmp_path) -> None:
+    file_content = dedent(
+        """\
+        2016-02-26 * "Uncle Boons" "Eating out alone"
+            Liabilities:US:Chase:Slate                       -24.84 USD
+            Expenses:Food:Restaurant                          24.84 USD
+        """
+    )
+    samplefile = tmp_path / "example.beancount"
+    samplefile.write_text(file_content)
+
+    postings = [
+        Posting(
+            "Liabilities:US:Chase:Slate",
+            A("-10.00 USD"),
+            None,
+            None,
+            None,
+            None,
+        ),
+        Posting("Expenses:Food", A("10.00 USD"), None, None, None, None),
+    ]
+
+    transaction = Transaction(
+        {}, date(2016, 1, 1), "*", "new payee", "narr", None, None, postings,
+    )
+
+    # Test insertion with 2-space indent.
+    insert_entry(transaction, str(samplefile), [], 61, 2)
+    assert samplefile.read_text("utf-8") == dedent(
+        """\
+        2016-02-26 * "Uncle Boons" "Eating out alone"
+            Liabilities:US:Chase:Slate                       -24.84 USD
+            Expenses:Food:Restaurant                          24.84 USD
+
+        2016-01-01 * "new payee" "narr"
+          Liabilities:US:Chase:Slate                         -10.00 USD
+          Expenses:Food                                       10.00 USD
         """
     )
 

--- a/tests/test_serialisation.py
+++ b/tests/test_serialisation.py
@@ -143,7 +143,7 @@ def test_deserialise_posting_and_format(snapshot) -> None:
             deserialise_posting({"account": "Assets", "amount": "10 EUR @"}),
         ],
     )
-    snapshot(_format_entry(txn, 61))
+    snapshot(_format_entry(txn, 61, 2))
 
 
 def test_serialise_balance() -> None:


### PR DESCRIPTION
Resolves #993

Beancount moved to GitHub and my patch has been finally merged: https://github.com/beancount/beancount/pull/435/, so now we can implement the `indent` option in fava.

This PR is work-in-progress, I'll finalize it with the next release of beancount on pypi.
