### PR TITLE
Minor metadata filter improvements

### DIFF
--- a/frontend/css/journal-table.css
+++ b/frontend/css/journal-table.css
@@ -121,6 +121,7 @@
   min-width: 4rem;
   margin-left: 9rem;
   color: var(--color-journal-metadata);
+  cursor: pointer;
 }
 
 .journal .metadata dd {

--- a/frontend/src/journal.ts
+++ b/frontend/src/journal.ts
@@ -84,8 +84,13 @@ export class FavaJournal extends SortableJournal {
       // Note: any special characters in the payee string are escaped so the
       // filter matches against the payee literally.
       addFilter(`payee:"^${escape(target.innerText)}$"`);
+    } else if (target.tagName === "DT") {
+      // Filter for metadata key when clicking on the key. The key tag text
+      // includes the colon.
+      addFilter(`${target.innerText}""`);
     } else if (target.tagName === "DD") {
-      // Filter for metadata when clicking on the value.
+      // Filter for metadata key and value when clicking on the value. The key
+      // tag text includes the colon.
       addFilter(
         `${(target.previousElementSibling as HTMLElement).innerText}"^${escape(
           target.innerText

--- a/frontend/src/journal.ts
+++ b/frontend/src/journal.ts
@@ -87,15 +87,27 @@ export class FavaJournal extends SortableJournal {
     } else if (target.tagName === "DT") {
       // Filter for metadata key when clicking on the key. The key tag text
       // includes the colon.
-      addFilter(`${target.innerText}""`);
+      const expr = `${target.innerText}""`;
+      if (target.closest(".postings")) {
+        // Posting metadata.
+        addFilter(`any(${expr})`);
+      } else {
+        // Entry metadata.
+        addFilter(expr);
+      }
     } else if (target.tagName === "DD") {
       // Filter for metadata key and value when clicking on the value. The key
       // tag text includes the colon.
-      addFilter(
-        `${(target.previousElementSibling as HTMLElement).innerText}"^${escape(
-          target.innerText
-        )}$"`
-      );
+      const key = (target.previousElementSibling as HTMLElement).innerText;
+      const value = `"^${escape(target.innerText)}$"`;
+      const expr = `${key}${value}`;
+      if (target.closest(".postings")) {
+        // Posting metadata.
+        addFilter(`any(${expr})`);
+      } else {
+        // Entry metadata.
+        addFilter(expr);
+      }
     } else if (target.closest(".indicators")) {
       // Toggle postings and metadata by clicking on indicators.
       const entry = target.closest(".transaction");

--- a/frontend/src/journal.ts
+++ b/frontend/src/journal.ts
@@ -83,7 +83,7 @@ export class FavaJournal extends SortableJournal {
     } else if (target.tagName === "DD") {
       // Filter for metadata when clicking on the value.
       addFilter(
-        ` ${(target.previousElementSibling as HTMLElement).innerText}"${
+        `${(target.previousElementSibling as HTMLElement).innerText}"${
           target.innerText
         }"`
       );

--- a/frontend/src/journal.ts
+++ b/frontend/src/journal.ts
@@ -83,13 +83,13 @@ export class FavaJournal extends SortableJournal {
       // Filter for payees when clicking on them.
       // Note: any special characters in the payee string are escaped so the
       // filter matches against the payee literally.
-      addFilter(`payee:"${escape(target.innerText)}"`);
+      addFilter(`payee:"^${escape(target.innerText)}$"`);
     } else if (target.tagName === "DD") {
       // Filter for metadata when clicking on the value.
       addFilter(
-        `${(target.previousElementSibling as HTMLElement).innerText}"${
+        `${(target.previousElementSibling as HTMLElement).innerText}"^${escape(
           target.innerText
-        }"`
+        )}$"`
       );
     } else if (target.closest(".indicators")) {
       // Toggle postings and metadata by clicking on indicators.

--- a/frontend/src/journal.ts
+++ b/frontend/src/journal.ts
@@ -4,13 +4,17 @@ import { SortableJournal } from "./sort";
 import { fql_filter } from "./stores/filters";
 
 /**
- * Add filter, possibly escaping it to produce a valid regex.
+ * Escape the value to produce a valid regex.
  */
-function addFilter(value: string, escape = false): void {
-  if (escape) {
-    value = value.replace(/[.*+\-?^${}()|[\]\\]/g, "\\$&");
-  }
+function escape(value: string): string {
+  return value.replace(/[.*+\-?^${}()|[\]\\]/g, "\\$&");
+}
 
+/**
+ * Add a filter to the existing list of filters. Any parts that are interpreted
+ * as a regex must be escaped.
+ */
+function addFilter(value: string): void {
   fql_filter.update((fql_filter_val) =>
     fql_filter_val ? `${fql_filter_val} ${value}` : value
   );
@@ -79,7 +83,7 @@ export class FavaJournal extends SortableJournal {
       // Filter for payees when clicking on them.
       // Note: any special characters in the payee string are escaped so the
       // filter matches against the payee literally.
-      addFilter(`payee:"${target.innerText}"`, true);
+      addFilter(`payee:"${escape(target.innerText)}"`);
     } else if (target.tagName === "DD") {
       // Filter for metadata when clicking on the value.
       addFilter(

--- a/src/fava/templates/_journal_table.html
+++ b/src/fava/templates/_journal_table.html
@@ -46,6 +46,11 @@
 {% endif %}
 
 {% macro account_link(name) %}<a class="account-link" href="{{ url_for('account', name=name) }}">{{ name }}</a>{% endmacro %}
+{% macro render_metadata_indicators(metadata) -%}
+{% for key, value in metadata.items() %}
+<span class="metadata-indicator" title="{{ key }}: {{ value }}">{{ key[:2] }}</span>
+{% endfor %}
+{%- endmacro %}
 {% macro render_metadata(metadata, entry_hash=None) -%}
 {% if metadata %}
 <dl class="metadata">
@@ -142,11 +147,10 @@
         {% endif %}
         </span>
         <span class="indicators">
-          {% for key, value in metadata.items() %}
-          <span class="metadata-indicator" title="{{ key }}: {{ value }}">{{ key[:2] }}</span>
-          {% endfor %}
+          {{ render_metadata_indicators(metadata) }}
           {% for posting in entry.postings %}
           <span{% if posting.flag %} class="{{ posting.flag|flag_to_type }}"{% endif %}></span>
+          {{ render_metadata_indicators(posting.meta|remove_keys(['__automatic__', 'lineno', 'filename'])) }}
           {% endfor %}
         </span>
         {% if type == 'balance' %}

--- a/tests/data/long-example.beancount
+++ b/tests/data/long-example.beancount
@@ -99,6 +99,7 @@ option "operating_currency" "USD"
 2014-01-19 * "Verizon Wireless" ""
   Assets:US:BofA:Checking                          -85.14 USD
   Expenses:Home:Phone                               85.14 USD
+    overage: "12.34 GB"
 
 2014-01-21 balance Assets:US:BofA:Checking        3433.97 USD
 

--- a/tests/test_core_filters.py
+++ b/tests/test_core_filters.py
@@ -120,6 +120,7 @@ def test_filterexception():
         ('name:".*ETF$"', 3),
         ('name:".*etf"', 4),
         ('name:".*etf$"', 3),
+        ('any(overage:"GB$")', 1),
     ],
 )
 def test_advanced_filter(example_ledger, string, number):


### PR DESCRIPTION
Summary of changes:

* Escaped and anchored the filters that are created by clicking on the metadata. This ensures that only exact matches are shown.
* Made metadata keys clickable to filter on only the key. This creates filters of the form `key:""`, which allow anything for the value.
* Added `any()` to filters that are created by clicking posting metadata. This applies the filter to postings rather than entries.
* Added indicators for posting metadata. These make it visible at a glance that collapsed postings have metadata.