### PR TITLE
Fix drag and drop events not being processed

### DIFF
--- a/frontend/src/document-upload.ts
+++ b/frontend/src/document-upload.ts
@@ -14,7 +14,7 @@ import { put } from "./api";
 function dragover(event: DragEvent, closestTarget: HTMLElement): void {
   if (
     event.dataTransfer &&
-    (event.dataTransfer.files.length ||
+    (event.dataTransfer.types.includes("Files") ||
       event.dataTransfer.types.includes("text/uri-list"))
   ) {
     closestTarget.classList.add("dragover");


### PR DESCRIPTION
When uploading documents via drag and drop, we want to make sure that
the DragEvent is only processed if it references dragged files. This is
done by checking the length of the 'event.dataTransfer.files' list.

In a5eec6d6 (support attaching (already uploaded) documents to txns,
2020-05-16), a check for dragged URLs was added and the validation of
'event.dataTransfer.files' was moved from 'drop()' to 'dragover()'.

The HTML Living Standard defines a 'drag data store mode' [1], which
governs read and write access to the drag data store. Specifically, if
the drag data store is in protected mode, the 'files' attribute must
return the empty list [2].

Before commit a5eec6d6, 'event.dataTransfer.files' was accessed in the
'drop' event, with the drag data store in read-only mode. Now, however,
we access it in the 'dragover' event, with the drag data store in
protected mode. The validation in 'dragover()' therefore fails because
'event.dataTransfer.files' is empty. For browsers that are compliant
with the HTML Living Standard, Fava does not process any drag and drop
events.

The standard also defines a 'DataTransferItemList' interface [3], whose
'length' attribute [4] can be used to get the number of items in the
drag data store. This is possible even in protected mode, but some
browsers (notably Safari) do not implement this yet [5].

Instead, similar to checking for URLs, solve this problem by checking
whether the 'types' list includes entries of type "Files". [6]

Closes #1122.

[1] https://html.spec.whatwg.org/multipage/dnd.html#drag-data-store-mode
[2] https://html.spec.whatwg.org/multipage/dnd.html#dom-datatransfer-files
[3] https://html.spec.whatwg.org/multipage/dnd.html#the-datatransferitemlist-interface
[4] https://html.spec.whatwg.org/multipage/dnd.html#dom-datatransferitemlist-length
[5] https://developer.mozilla.org/en-US/docs/Web/API/DataTransfer/items#Browser_compatibility
[6] https://html.spec.whatwg.org/multipage/dnd.html#concept-datatransfer-types