### PR TITLE
Fixed tick format

### DIFF
--- a/frontend/src/format.ts
+++ b/frontend/src/format.ts
@@ -30,7 +30,7 @@ export function formatPercentage(number: number): string {
   return `${formatterPer(Math.abs(number) * 100)}%`;
 }
 
-const formatterShort = format(".2s");
+const formatterShort = format(".3s");
 export function formatCurrencyShort(number: number): string {
   return incognito(formatterShort(number));
 }


### PR DESCRIPTION
The y-Axis of line charts is formatted with ``.2s``, which sets the precision to two digits. This can lead to a problem, if the values use three digits. For instance, here is the chart of USD to CHF rates, which are just below 1. 

![problem](https://user-images.githubusercontent.com/5196024/87695337-aaeb0080-c78f-11ea-8fd6-ac2eca82b8a1.PNG)

The formatter uses the SI prefix "m", which is fine, but it also truncates the number to the two most significant digits. The issue is, that a few ticks now have the same label.

This pull request proposes to use the format ``.3s`` instead. With SI prefixes, all numbers should correctly display with 3 digits. Here is the same data as above with the fix applied:

![fix](https://user-images.githubusercontent.com/5196024/87695772-319fdd80-c790-11ea-91a2-6b6f218c01b7.PNG)
