### PR TITLE
Added an optional area chart visualization wherever line charts can be drawn

### DIFF
--- a/frontend/css/charts.css
+++ b/frontend/css/charts.css
@@ -107,6 +107,24 @@ svg.linechart .lines path {
   stroke-width: 2px;
 }
 
+svg.areachart .area path {
+  opacity: 0.2;
+}
+
+svg.areachart .lines path {
+  fill: none;
+  stroke-width: 2px;
+}
+
+svg.areachart .axis.y line {
+  opacity: 0.1;
+  stroke-dasharray: none;
+}
+
+svg.areachart .axis.y path.domain {
+  display: none;
+}
+
 .tooltip {
   position: absolute;
   z-index: var(--z-index-floating-ui);

--- a/frontend/css/charts.css
+++ b/frontend/css/charts.css
@@ -107,21 +107,16 @@ svg.linechart .lines path {
   stroke-width: 2px;
 }
 
-svg.areachart .area path {
+svg.linechart .area path {
+  opacity: 0.3;
+}
+
+svg.linechart .axis.y line {
   opacity: 0.2;
-}
-
-svg.areachart .lines path {
-  fill: none;
-  stroke-width: 2px;
-}
-
-svg.areachart .axis.y line {
-  opacity: 0.1;
   stroke-dasharray: none;
 }
 
-svg.areachart .axis.y path.domain {
+svg.linechart .axis.y path.domain {
   display: none;
 }
 

--- a/frontend/src/charts/Chart.svelte
+++ b/frontend/src/charts/Chart.svelte
@@ -4,7 +4,12 @@
 
   import { _ } from "../helpers";
   import { keyboardShortcut } from "../keyboard-shortcuts";
-  import { chartCurrency, chartMode, showCharts } from "../stores/chart";
+  import {
+    chartCurrency,
+    lineChartMode,
+    chartMode,
+    showCharts,
+  } from "../stores/chart";
 
   import ChartLegend from "./ChartLegend.svelte";
   import BarChart from "./BarChart.svelte";
@@ -56,6 +61,17 @@
         <label>
           <input type="radio" bind:group={$chartMode} value="sunburst" />
           <span class="button">{_('Sunburst')}</span>
+        </label>
+      </span>
+    {:else if chart.type === 'linechart'}
+      <span class="chart-mode">
+        <label>
+          <input type="radio" bind:group={$lineChartMode} value="line" />
+          <span class="button">{_('Line')}</span>
+        </label>
+        <label>
+          <input type="radio" bind:group={$lineChartMode} value="area" />
+          <span class="button">{_('Area')}</span>
         </label>
       </span>
     {/if}

--- a/frontend/src/charts/LineChart.svelte
+++ b/frontend/src/charts/LineChart.svelte
@@ -75,21 +75,30 @@
   }
 </script>
 
-{#if $lineChartMode === 'line'}
-  <svg class="linechart" {width} {height}>
+<svg class="linechart" {width} {height}>
+  <g
+    use:positionedTooltip={tooltipInfo}
+    transform={`translate(${margin.left},${margin.top})`}>
     <g
-      use:positionedTooltip={tooltipInfo}
-      transform={`translate(${margin.left},${margin.top})`}>
-      <g
-        class="x axis"
-        use:axis={xAxis}
-        transform={`translate(0,${innerHeight})`} />
-      <g class="y axis" use:axis={yAxis} />
-      <g class="lines">
+      class="x axis"
+      use:axis={xAxis}
+      transform={`translate(0,${innerHeight})`} />
+    <g class="y axis" use:axis={yAxis} />
+    {#if $lineChartMode === 'area'}
+      <g class="area">
         {#each data as d}
-          <path d={lineShape(d.values)} stroke={$currenciesScale(d.name)} />
+          <path
+            d={areaShape(d.values, innerHeight)}
+            fill={$currenciesScale(d.name)} />
         {/each}
       </g>
+    {/if}
+    <g class="lines">
+      {#each data as d}
+        <path d={lineShape(d.values)} stroke={$currenciesScale(d.name)} />
+      {/each}
+    </g>
+    {#if $lineChartMode !== 'area'}
       <g>
         {#each data as d}
           <g fill={$currenciesScale(d.name)}>
@@ -99,30 +108,6 @@
           </g>
         {/each}
       </g>
-    </g>
-  </svg>
-{:else if $lineChartMode === 'area'}
-  <svg class="areachart" {width} {height}>
-    <g
-      use:positionedTooltip={tooltipInfo}
-      transform={`translate(${margin.left},${margin.top})`}>
-      <g
-        class="x axis"
-        use:axis={xAxis}
-        transform={`translate(0,${innerHeight})`} />
-      <g class="y axis" use:axis={yAxis} />
-      <g class="area">
-        {#each data as d}
-          <path
-            d={areaShape(d.values, innerHeight)}
-            fill={$currenciesScale(d.name)} />
-        {/each}
-      </g>
-      <g class="lines">
-        {#each data as d}
-          <path d={lineShape(d.values)} stroke={$currenciesScale(d.name)} />
-        {/each}
-      </g>
-    </g>
-  </svg>
-{/if}
+    {/if}
+  </g>
+</svg>

--- a/frontend/src/stores/chart.ts
+++ b/frontend/src/stores/chart.ts
@@ -7,6 +7,7 @@ import { commodities, operating_currency } from ".";
 export const showCharts = writable(true);
 export const activeChart = writable({});
 export const chartMode = writable("treemap");
+export const lineChartMode = writable("line");
 export const chartCurrency = writable("");
 
 const currencySuggestions = derived(


### PR DESCRIPTION
This pull request adds an option to all line charts (for example in "Commodities" or "Balance Sheet") to switch to an area chart. The Line chart is still the default, as it works much better for multiple value series, however, I prefer an area chart for single data series like net worth or stock prices.

The line chart looks as before and hasn't been modified:

![default](https://user-images.githubusercontent.com/5196024/87762174-f5fa2780-c812-11ea-996d-78b86df95ae8.PNG)

Switching to "area" shows this new chart:

![area](https://user-images.githubusercontent.com/5196024/87762391-5ab58200-c813-11ea-8a14-1719d494f894.PNG)

Hovering over data points works as for the line chart, but I took the liberty to make some style changes for the area chart:

- I removed the ``domain`` bounding box around the chart
- I changed the horizontal lines from dashed to solid, but decreased the opacity
- I removed the dots of the line