### PR TITLE
Add ability to filter dates across a range of fiscal years

### DIFF
--- a/src/fava/help/options.md
+++ b/src/fava/help/options.md
@@ -68,7 +68,8 @@ Default: `12-31`
 
 The last day of the fiscal (financial or tax) period for accounting purposes in
 `%m-%d` format. Allows for the use of `FY2018`, `FY2018-Q3`, `fiscal_year` and
-`fiscal_quarter` in the time filter.
+`fiscal_quarter` in the time filter, and `FY2018` as the start date, end date,
+or both dates in a date range in the time filter.
 
 Examples are:
 

--- a/src/fava/util/date.py
+++ b/src/fava/util/date.py
@@ -13,7 +13,7 @@ from typing import Tuple
 
 from flask_babel import gettext  # type: ignore
 
-IS_RANGE_RE = re.compile(r"(.*?)(?:-|to)(?=\s*\d{4})(.*)")
+IS_RANGE_RE = re.compile(r"(.*?)(?:-|to)(?=\s*(?:fy)*\d{4})(.*)")
 
 # these match dates of the form 'year-month-day'
 # day or month and day may be omitted
@@ -224,7 +224,10 @@ def parse_date(
 
     match = IS_RANGE_RE.match(string)
     if match:
-        return (parse_date(match.group(1))[0], parse_date(match.group(2))[1])
+        return (
+            parse_date(match.group(1), fye)[0],
+            parse_date(match.group(2), fye)[1],
+        )
 
     match = YEAR_RE.match(string)
     if match:

--- a/tests/test_util_date.py
+++ b/tests/test_util_date.py
@@ -156,11 +156,15 @@ def test_fiscal_substitute(fye, test_date, string, output):
         ("2014-01-01", "2016-01-01", "2014 to 2015"),
         ("2014-01-01", "2016-01-01", "2014-2015"),
         ("2011-10-01", "2016-01-01", "2011-10 - 2015"),
+        ("2018-07-01", "2020-07-01", "FY2019 - FY2020"),
+        ("2018-07-01", "2021-01-01", "FY2019 - 2020"),
+        ("2010-07-01", "2015-07-01", "FY2011 to FY2015"),
+        ("2011-01-01", "2015-07-01", "2011 to FY2015"),
     ],
 )
 def test_parse_date(expect_start, expect_end, text):
     start, end = _to_date(expect_start), _to_date(expect_end)
-    assert parse_date(text) == (start, end)
+    assert parse_date(text, "06-30") == (start, end)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR allows the date filter box to cope with a fiscal year range.

This allows a "FYxxxx" string to be the starting date in the range, the ending date, or both.

E.g.

- FY2011 - FY2015
- 2011 - FY2015
- FY2011 - 2015

... which all mean different things from one another (unless the fiscal year is configured to start on Jan 1st!)

It also updates the in-app help text for the fiscal-year option, letting the user know they can use the forms above.