### PR TITLE
enable manual dispatching of the ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: Test
 
 on:
+    workflow_dispatch:
+        # workflow_dispatch allows the workflow to be triggered manually, see:
+        # https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/
     push:
         branches:
             - master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,6 @@ name: Test
 
 on:
     workflow_dispatch:
-        # workflow_dispatch allows the workflow to be triggered manually, see:
-        # https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/
     push:
         branches:
             - master


### PR DESCRIPTION
this enables the `workflow_dispatch` feature, which allows to trigger the CI workflow manually through github's GUI, see https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/