### PR TITLE
Pyinstaller now builds a single binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,5 +103,5 @@ gh-pages:
 	git branch -D gh-pages
 
 # Create a binary using pyinstaller
-dist/fava:
+dist/fava: src/fava/static/app.js
 	tox -e pyinstaller

--- a/Makefile
+++ b/Makefile
@@ -103,5 +103,5 @@ gh-pages:
 	git branch -D gh-pages
 
 # Create a binary using pyinstaller
-dist/fava/cli:
+dist/fava:
 	tox -e pyinstaller

--- a/contrib/pyinstaller_spec.spec
+++ b/contrib/pyinstaller_spec.spec
@@ -12,7 +12,7 @@ hidden_imports = collect_submodules(
 # add beancount version file:
 beancount_dir = os.path.dirname(importlib.import_module("beancount").__file__)
 beancount_version_file = os.path.join(beancount_dir, "VERSION")
-data_files += [(beancount_version_file, "beancount")]
+data_files = [(beancount_version_file, "beancount")]
 
 a = Analysis(
     ["../src/fava/cli.py"],

--- a/contrib/pyinstaller_spec.spec
+++ b/contrib/pyinstaller_spec.spec
@@ -41,23 +41,17 @@ a = Analysis(
 
 pyz = PYZ(a.pure, a.zipped_data, cipher=None)
 
-exe = EXE(
-    pyz,
-    a.scripts,
-    exclude_binaries=True,
-    name="cli",
-    debug=False,
-    strip=False,
-    upx=True,
-    console=True,
-)
-
-coll = COLLECT(
-    exe,
-    a.binaries,
-    a.zipfiles,
-    a.datas,
-    strip=False,
-    upx=True,
-    name="fava",
-)
+exe = EXE(pyz,
+          a.scripts,
+          a.binaries,
+          a.zipfiles,
+          a.datas,
+          [],
+          name='fava',
+          debug=False,
+          bootloader_ignore_signals=False,
+          strip=False,
+          upx=True,
+          upx_exclude=[],
+          runtime_tmpdir=None,
+          console=True)

--- a/contrib/pyinstaller_spec.spec
+++ b/contrib/pyinstaller_spec.spec
@@ -4,21 +4,10 @@ import importlib
 import os
 
 from PyInstaller.utils.hooks import collect_submodules
-from PyInstaller.utils.hooks import copy_metadata
 
 hidden_imports = collect_submodules(
     "beancount", filter=lambda name: "test" not in name
 )
-
-data_files = [
-    ("../src/fava/help", "fava/help"),
-    ("../src/fava/static", "fava/static"),
-    ("../src/fava/templates", "fava/templates"),
-    ("../src/fava/translations", "fava/translations"),
-]
-
-# add fava version information:
-data_files += copy_metadata("fava")
 
 # add beancount version file:
 beancount_dir = os.path.dirname(importlib.import_module("beancount").__file__)
@@ -45,4 +34,4 @@ exe = EXE(pyz,
           [],
           name='fava',
           upx=True,
-)
+          )

--- a/contrib/pyinstaller_spec.spec
+++ b/contrib/pyinstaller_spec.spec
@@ -28,18 +28,14 @@ data_files += [(beancount_version_file, "beancount")]
 a = Analysis(
     ["../src/fava/cli.py"],
     pathex=["."],
-    binaries=None,
     datas=data_files,
     hiddenimports=hidden_imports,
-    hookspath=[],
-    runtime_hooks=[],
-    excludes=[],
-    win_no_prefer_redirects=False,
-    win_private_assemblies=False,
-    cipher=None,
 )
 
-pyz = PYZ(a.pure, a.zipped_data, cipher=None)
+pyz = PYZ(
+    a.pure,
+    a.zipped_data,
+)
 
 exe = EXE(pyz,
           a.scripts,
@@ -48,10 +44,5 @@ exe = EXE(pyz,
           a.datas,
           [],
           name='fava',
-          debug=False,
-          bootloader_ignore_signals=False,
-          strip=False,
           upx=True,
-          upx_exclude=[],
-          runtime_tmpdir=None,
-          console=True)
+)

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ classifiers =
 [options]
 zip_safe = False
 include_package_data = True
-package_dir = 
+package_dir =
     =src
 packages = find:
 python_requires = >=3.6
@@ -55,6 +55,8 @@ install_requires =
 [options.entry_points]
 console_scripts =
     fava = fava.cli:main
+pyinstaller40 =
+    hook-dirs = fava.__pyinstaller:get_hook_dirs
 
 [options.extras_require]
 excel =

--- a/src/fava/__pyinstaller/__init__.py
+++ b/src/fava/__pyinstaller/__init__.py
@@ -1,0 +1,9 @@
+"""
+This package provides a hook for PyInstaller to successfully freeze fava.
+"""
+import os
+
+
+def get_hook_dirs():
+    """This function is referenced in fava's package configuration."""
+    return [os.path.dirname(__file__)]

--- a/src/fava/__pyinstaller/hook-fava.py
+++ b/src/fava/__pyinstaller/hook-fava.py
@@ -1,0 +1,8 @@
+"""
+This is a PyInstaller hook needed to successfully freeze fava.
+"""
+from PyInstaller.utils.hooks import collect_data_files
+from PyInstaller.utils.hooks import copy_metadata
+
+datas = collect_data_files("fava")
+datas += copy_metadata("fava")

--- a/src/fava/__pyinstaller/hook-fava.py
+++ b/src/fava/__pyinstaller/hook-fava.py
@@ -1,8 +1,12 @@
 """
 This is a PyInstaller hook needed to successfully freeze fava.
 """
-from PyInstaller.utils.hooks import collect_data_files
-from PyInstaller.utils.hooks import copy_metadata
+from PyInstaller.utils.hooks import (
+    collect_data_files,
+)  # pylint: disable=import-error
+from PyInstaller.utils.hooks import (
+    copy_metadata,
+)  # pylint: disable=import-error
 
 datas = collect_data_files("fava")
 datas += copy_metadata("fava")

--- a/src/fava/__pyinstaller/hook-fava.py
+++ b/src/fava/__pyinstaller/hook-fava.py
@@ -1,12 +1,10 @@
+# pylint: skip-file
+# mypy: ignore-errors
 """
 This is a PyInstaller hook needed to successfully freeze fava.
 """
-from PyInstaller.utils.hooks import (
-    collect_data_files,
-)  # pylint: disable=import-error
-from PyInstaller.utils.hooks import (
-    copy_metadata,
-)  # pylint: disable=import-error
+from PyInstaller.utils.hooks import collect_data_files
+from PyInstaller.utils.hooks import copy_metadata
 
 datas = collect_data_files("fava")
 datas += copy_metadata("fava")

--- a/tox.ini
+++ b/tox.ini
@@ -47,4 +47,4 @@ deps =
     pyinstaller
 commands =
     pyinstaller --clean --noconfirm contrib/pyinstaller_spec.spec
-    {toxinidir}/dist/fava/cli --version
+    {toxinidir}/dist/fava --version


### PR DESCRIPTION
Changed pyinstaller spec file so it builds a single binary file (instead of a folder that contains many files). The binary file is named `dist/fava`.

I tested the following:

* The github CI build is green (in my fork)
* And I manually verified that running `dist/fava example.beancount` produces a usable web interface.

