### PR TITLE
Fix filter with meta key error

### DIFF
--- a/src/fava/core/filters.py
+++ b/src/fava/core/filters.py
@@ -276,7 +276,7 @@ class FilterSyntaxParser:
         def _key(entry):
             if hasattr(entry, key):
                 return match(str(getattr(entry, key) or ""))
-            if key in entry.meta:
+            if entry.meta is not None and key in entry.meta:
                 return match(str(entry.meta.get(key)))
             return False
 

--- a/tests/test_core_filters.py
+++ b/tests/test_core_filters.py
@@ -3,6 +3,7 @@ import datetime
 
 import pytest
 from beancount.core import account
+from beancount.loader import load_string
 
 from fava.core.filters import AccountFilter
 from fava.core.filters import AdvancedFilter
@@ -128,6 +129,22 @@ def test_advanced_filter(example_ledger, string, number):
     filtered_entries = FILTER.apply(example_ledger.all_entries)
     assert len(filtered_entries) == number
     FILTER.set("")
+
+
+def test_null_meta_posting():
+    FILTER.set('any(some_meta:"1")')
+
+    # pad entry produces Posting with null meta:
+    entries, _, _ = load_string("""
+2000-01-01 open Assets:Bank USD
+2000-01-01 open Equity:OpeningBalances USD
+
+2000-01-02 pad Assets:Bank Assets:OpeningBalances
+2000-01-03 balance Assets:Bank 1.00 USD
+    """)
+
+    filtered_entries = FILTER.apply(entries)
+    assert len(filtered_entries) == 0
 
 
 def test_account_filter(example_ledger):

--- a/tests/test_core_filters.py
+++ b/tests/test_core_filters.py
@@ -135,13 +135,15 @@ def test_null_meta_posting():
     FILTER.set('any(some_meta:"1")')
 
     # pad entry produces Posting with null meta:
-    entries, _, _ = load_string("""
+    entries, _, _ = load_string(
+        """
 2000-01-01 open Assets:Bank USD
 2000-01-01 open Equity:OpeningBalances USD
 
 2000-01-02 pad Assets:Bank Assets:OpeningBalances
 2000-01-03 balance Assets:Bank 1.00 USD
-    """)
+    """
+    )
 
     filtered_entries = FILTER.apply(entries)
     assert len(filtered_entries) == 0


### PR DESCRIPTION
With filter like `any(some_meta_name:"^value$")` (which happens when clicking on a meta value in the entry list), it results in error:

```
  File "<...>/lib/python3.8/site-packages/fava/core/filters.py", line 279, in _key
    if key in entry.meta:
TypeError: argument of type 'NoneType' is not iterable
```