### PR TITLE
Highlight journal row on hover to make it easier to read on wide screen

### DIFF
--- a/frontend/css/journal-table.css
+++ b/frontend/css/journal-table.css
@@ -108,7 +108,7 @@
 }
 
 .journal .transaction:hover {
-    background: #f5f5f59c;
+  background: var(--color-journal-hover-highlight);
 }
 
 /* Metadata */

--- a/frontend/css/journal-table.css
+++ b/frontend/css/journal-table.css
@@ -107,6 +107,10 @@
   display: block;
 }
 
+.journal .transaction:hover {
+    background: #f5f5f59c;
+}
+
 /* Metadata */
 .journal .metadata {
   padding: 2px 0;

--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -110,4 +110,5 @@
   --color-journal-link: hsl(203, 39%, 85%);
   --color-journal-posting-indicator: hsl(203, 24%, 80%);
   --color-journal-metadata-indicator: hsl(203, 24%, 40%);
+  --color-journal-hover-highlight: #f5f5f59c;
 }


### PR DESCRIPTION
On a wide screen, it is really hard to match the left side (date, payee, etc.) of an entry with the amount. On hover highlighting helps with that. 

The color is the same shade of gray as in the UI but with some more transparency to make it less intrusive:
![image](https://user-images.githubusercontent.com/9114601/103448141-3c2d3100-4c63-11eb-9741-bc7183c6bb33.png)
