### PR TITLE
Add 'default-path' option

### DIFF
--- a/src/fava/application.py
+++ b/src/fava/application.py
@@ -274,7 +274,11 @@ def index():
     """Redirect to the Income Statement (of the given or first file)."""
     if not g.beancount_file_slug:
         g.beancount_file_slug = next(iter(app.config["LEDGERS"]))
-    return redirect(url_for("report", report_name="income_statement"))
+    index_url = url_for("index")
+    default_path = app.config["LEDGERS"][g.beancount_file_slug].fava_options[
+        "default-path"
+    ]
+    return redirect(f"{index_url}{default_path}")
 
 
 @app.route("/<bfile>/account/<name>/")

--- a/src/fava/core/fava_options.py
+++ b/src/fava/core/fava_options.py
@@ -47,6 +47,7 @@ DEFAULTS = {
     "auto-reload": False,
     "conversion": "at_cost",
     "default-file": None,
+    "default-path": "income_statement/",
     "fiscal-year-end": FiscalYearEnd(12, 31),
     "import-config": None,
     "import-dirs": [],
@@ -103,6 +104,7 @@ LIST_OPTS = [
 STR_OPTS = [
     "collapse-pattern",
     "conversion",
+    "default-path",
     "import-config",
     "interval",
     "language",

--- a/src/fava/help/options.md
+++ b/src/fava/help/options.md
@@ -53,6 +53,29 @@ If this option is not specified, Fava opens the main file by default.
 
 ---
 
+## `default-path`
+
+Default: `income_statement/`
+
+Use this option to specify the path to be redirected to when visiting the main
+Fava webpage. If this option is not specified, you are taken to the income
+statement. You may also use this feature to set options via the URL. For
+example, a `default-path` of `balance_sheet/?time=year-2+-+year` would result in
+you being redirected to a balance sheet reporting the current year and the two
+previous years.
+
+Note that the supplied path is relative. To be taken to your trial balance
+report at `{{url_for("report", report_name="trial_balance", account="Expenses:Restaurants", time="2021")}}` put the following in your
+beancount file:
+
+<pre><textarea is="beancount-textarea">
+2021-01-01 custom "fava-option" "default-path" "trial_balance/?account=Expenses%3ARestaurants&time=2021"</textarea></pre>
+
+It is probably easiest to navigate to the URL in your browser and copy the
+portion of the URL after the 'title' of your beancount file into this option.
+
+---
+
 ## `interval`
 
 Default: `month`

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -60,6 +60,57 @@ def test_urls(test_client, url, return_code):
 
 
 @pytest.mark.parametrize(
+    "url,option,expect",
+    [
+        ("/", None, "/long-example/income_statement/"),
+        ("/long-example/", None, "/long-example/income_statement/"),
+        ("/", "income_statement/", "/long-example/income_statement/"),
+        (
+            "/long-example/",
+            "income_statement/",
+            "/long-example/income_statement/",
+        ),
+        (
+            "/",
+            "balance_sheet/?account=Assets:US:BofA:Checking",
+            "/long-example/balance_sheet/?account=Assets:US:BofA:Checking",
+        ),
+        (
+            "/long-example/",
+            "income_statement/?account=Assets:US:BofA:Checking",
+            "/long-example/income_statement/?account=Assets:US:BofA:Checking",
+        ),
+        (
+            "/",
+            "balance_sheet/?time=year-2+-+year",
+            "/long-example/balance_sheet/?time=year-2+-+year",
+        ),
+        (
+            "/",
+            "balance_sheet/?time=year-2 - year",
+            "/long-example/balance_sheet/?time=year-2%20-%20year",
+        ),
+        (
+            "/",
+            "trial_balance/?time=2014&account=Expenses:Rent",
+            "/long-example/trial_balance/?time=2014&account=Expenses:Rent",
+        ),
+    ],
+)
+def test_default_path_redirection(app, test_client, url, option, expect):
+    """Test that default-path option redirects as expected."""
+    with app.test_request_context("/long-example/"):
+        app.preprocess_request()
+        if option:
+            flask.g.ledger.fava_options["default-path"] = option
+        result = test_client.get(url)
+        get_url = result.headers.get("Location", "")
+        expect_url = werkzeug.urls.url_join("http://localhost/", expect)
+        assert result.status_code == 302
+        assert get_url == expect_url
+
+
+@pytest.mark.parametrize(
     "referer,jump_link,expect",
     [
         ("/?foo=bar", "/jump?foo=baz", "/?foo=baz"),


### PR DESCRIPTION
This allows the user to configure where they'd like to fava to redirect
them to if they visit the default path (previously it was effectively
hard-coded to redirect you to '/income_statement/')

This is my first draft towards addressing https://github.com/beancount/fava/issues/1049