### PR TITLE
Show commodity and account names

### DIFF
--- a/src/fava/core/__init__.py
+++ b/src/fava/core/__init__.py
@@ -21,6 +21,7 @@ from beancount.core.account_types import get_account_sign
 from beancount.core.compare import hash_entry
 from beancount.core.data import Balance
 from beancount.core.data import Close
+from beancount.core.data import Commodity
 from beancount.core.data import Custom
 from beancount.core.data import Directive
 from beancount.core.data import Document
@@ -128,6 +129,7 @@ class FavaLedger:
         "all_entries_by_type",
         "all_root_account",
         "beancount_file_path",
+        "commodities",
         "_date_first",
         "_date_last",
         "entries",
@@ -200,6 +202,9 @@ class FavaLedger:
         #: A dict containing information about the accounts.
         self.accounts = AccountDict()
 
+        #: A dict containing information about the commodities
+        self.commodities: Dict[str, Commodity] = {}
+
         #: A dict with all of Fava's option values.
         self.fava_options: FavaOptions = {}
 
@@ -240,6 +245,10 @@ class FavaLedger:
             self.accounts.setdefault(
                 cast(Close, entry).account
             ).close_date = entry.date
+
+        for entry in entries_by_type[Commodity]:
+            commodity = cast(Commodity, entry)
+            self.commodities[commodity.currency] = commodity
 
         self.fava_options, errors = parse_options(
             cast(List[Custom], entries_by_type[Custom])

--- a/src/fava/template_filters.py
+++ b/src/fava/template_filters.py
@@ -55,6 +55,15 @@ def format_currency(
     return g.ledger.format_decimal(value, currency)
 
 
+def format_commodity(currency: str):
+    """Format commodity along with meta name if provided"""
+    commodity = g.ledger.commodities.get(currency)
+    if commodity:
+        alias_name = commodity.meta.get("name")
+        return f"{currency} ({alias_name})"
+    return currency
+
+
 def format_amount(amount: Amount) -> str:
     """Format an amount to string using the DisplayContext."""
     if amount is None:
@@ -62,7 +71,9 @@ def format_amount(amount: Amount) -> str:
     number, currency = amount
     if number is None:
         return ""
-    return f"{format_currency(number, currency, True)} {currency}"
+
+    currency_str = format_commodity(currency)
+    return f"{format_currency(number, currency, True)} {currency_str}"
 
 
 def format_date(date: datetime.date) -> str:
@@ -171,6 +182,7 @@ FILTERS = [
     cost_or_value,
     flag_to_type,
     format_amount,
+    format_commodity,
     format_currency,
     format_date,
     format_errormsg,

--- a/src/fava/templates/_query_table.html
+++ b/src/fava/templates/_query_table.html
@@ -16,6 +16,10 @@
 <td>
   {% if name == "account" %}
   <a href="{{ url_for('account', name=value) }}">{{ value }}</a>
+  {%- set name_alias = ledger.accounts[value].meta.get('name') -%}
+  {%- if name_alias -%}
+  &nbsp;({{ name_alias }})
+  {%- endif -%}
   {% elif name == "id" %}
   <a href="#context-{{ value }}">{{ value }}</a>
   {% else %}

--- a/src/fava/templates/_tree_table.html
+++ b/src/fava/templates/_tree_table.html
@@ -46,12 +46,12 @@ Hold Ctrl or Cmd while clicking to expand one level.') }}">
     <span class="num other">
       <span class="balance">
         {% for currency in balance.keys()|sort %}
-        {{ render_diff_and_number(balance, cost, currency) }} {{ currency }}<br>
+        {{ render_diff_and_number(balance, cost, currency) }} {{ currency | format_commodity }}<br>
         {% endfor %}
       </span>
       <span class="balance-children">
         {% for currency in balance_children.keys()|sort %}
-        {{ render_diff_and_number(balance_children, cost_children, currency) }} {{ currency }}<br>
+        {{ render_diff_and_number(balance_children, cost_children, currency) }} {{ currency | format_commodity }}<br>
         {% endfor %}
       </span>
     </span>

--- a/src/fava/templates/holdings.html
+++ b/src/fava/templates/holdings.html
@@ -1,4 +1,4 @@
-{% import '_query_table.html' as querytable %}
+{% import '_query_table.html' as querytable with context %}
 
 {% set holdings_all = 'SELECT account,
     units(sum(position)) as units,

--- a/src/fava/templates/macros/_account_macros.html
+++ b/src/fava/templates/macros/_account_macros.html
@@ -33,6 +33,10 @@ Click to copy the balance directives to the clipboard:
 <a href="{{ url_for('account', name=account_name) }}" class="account">
   {{ account_name.split(':')[-1] if last_segment else account_name }}
 </a>
+{%- set name_alias = ledger.accounts[account_name].meta.get('name') -%}
+{%- if name_alias -%}
+&nbsp;({{ name_alias }})
+{%- endif -%}
 
 {% if account_name and ledger.accounts[account_name].meta.get('fava-uptodate-indication') %}
 {{ indicator(account_name) }}

--- a/src/fava/templates/statistics.html
+++ b/src/fava/templates/statistics.html
@@ -1,5 +1,5 @@
 {% import 'macros/_account_macros.html' as account_macros with context %}
-{% import '_query_table.html' as querytable %}
+{% import '_query_table.html' as querytable with context %}
 
 {% macro copy_balance_directives_text() -%}
 {% for account in ledger.attributes.accounts -%}


### PR DESCRIPTION
For the US markets, it's easy to memorize the mapping between commodity (AAPL) and the company (Apple Inc.). But it's hard for most Asian markets as tickers are just numbers. This PR is created for solving this issue.

After this PR, commodities and accounts with `name` will display the name accordingly. Commodities without `name` will not changed.

```
2021-01-01 commodity AAPL
  name: "Apple Inc."

2021-01-01 commodity CN_600519
  name: "Kweichow Moutai"

2021-01-01 open Assets:Stock:IB:Positions USD, HKD
  name: "Interactive Brokers Positions"
```

Please let me know what you guys think about it. Thanks and happy new year!