### PR TITLE
Show commodity and account names on hover

### DIFF
--- a/src/fava/ext/portfolio_list/templates/PortfolioList.html
+++ b/src/fava/ext/portfolio_list/templates/PortfolioList.html
@@ -4,6 +4,6 @@
 <br />
 {% for portfolio in extension.portfolio_accounts() %}
     <h3>{{portfolio[0]}}</h3>
-    {{ querytable.querytable(None, *portfolio[1]) }}
+    {{ querytable.querytable(ledger, None, *portfolio[1]) }}
     <br />
 {% endfor %}

--- a/src/fava/json_api.py
+++ b/src/fava/json_api.py
@@ -119,7 +119,8 @@ def query_result():
     if contents:
         if "ERROR" in contents:
             raise FavaAPIException(contents)
-    table = table(contents, types, rows)
+    table = table(g.ledger, contents, types, rows)
+
     if types and g.ledger.charts.can_plot_query(types):
         return {
             "chart": g.ledger.charts.query(types, rows),

--- a/src/fava/template_filters.py
+++ b/src/fava/template_filters.py
@@ -14,7 +14,6 @@ import flask
 from beancount.core import compare
 from beancount.core import realization
 from beancount.core.account import ACCOUNT_RE
-from beancount.core.amount import Amount
 from beancount.core.number import Decimal
 from beancount.core.number import ZERO
 
@@ -53,16 +52,6 @@ def format_currency(
     if value == ZERO:
         return g.ledger.format_decimal(ZERO, currency)
     return g.ledger.format_decimal(value, currency)
-
-
-def format_amount(amount: Amount) -> str:
-    """Format an amount to string using the DisplayContext."""
-    if amount is None:
-        return ""
-    number, currency = amount
-    if number is None:
-        return ""
-    return f"{format_currency(number, currency, True)} {currency}"
 
 
 def format_date(date: datetime.date) -> str:
@@ -170,7 +159,6 @@ FILTERS = [
     cost_or_value,
     cost_or_value,
     flag_to_type,
-    format_amount,
     format_currency,
     format_date,
     format_errormsg,

--- a/src/fava/templates/_context.html
+++ b/src/fava/templates/_context.html
@@ -1,3 +1,6 @@
+{% import 'macros/_commodity_macros.html' as commodity_macros %}
+
+
 <p>
 {{ _('Location') }}: <code><a href="{{ url_for_source(file_path=entry.meta.filename, line=entry.meta.lineno) }}" title="{{ _('Show source %(file)s:%(lineno)s', file=entry.meta.filename, lineno=entry.meta.lineno) }}">{{ entry.meta.filename }}:{{ entry.meta.lineno }}</a></code>
 </p>
@@ -19,7 +22,7 @@
           <td><a href="{{ url_for('account', name=account) }}">{{ account }}</a></td>
           <td>
             {% for position in inventory %}
-            <span class="num">{{ position.units|format_amount }}</span>
+              {{ commodity_macros.render_amount(ledger, position.units) }}
             {% if not loop.last %}<br>{% endif %}
             {% endfor %}
           </td>
@@ -39,7 +42,7 @@
           <td><a href="{{ url_for('account', name=account) }}">{{ account }}</a></td>
           <td>
             {% for position in inventory %}
-            <span class="num">{{ position.units|format_amount }}</span>
+              {{ commodity_macros.render_amount(ledger, position.units) }}
             {% if not loop.last %}<br>{% endif %}
             {% endfor %}
           </td>

--- a/src/fava/templates/_journal_table.html
+++ b/src/fava/templates/_journal_table.html
@@ -1,3 +1,6 @@
+{% import 'macros/_commodity_macros.html' as commodity_macros %}
+
+
 {% set entry_types = ['open', 'close', 'transaction', 'balance', 'note', 'document', 'pad', 'query', 'custom'] %}
 {% set sub_types = {
   'custom': (
@@ -127,7 +130,7 @@
           <strong>{{ entry.type }}</strong>
           {%- for value in entry['values'] -%}
             &nbsp;{% if value.dtype|string == "<AccountDummy>" %}{{ account_link(value.value) }}
-            {%- elif value.dtype|string == "<class 'beancount.core.amount.Amount'>" %}<span class="num">{{ value.value|format_amount }}</span>
+            {%- elif value.dtype|string == "<class 'beancount.core.amount.Amount'>" %}{{ commodity_macros.render_amount(ledger, value.value) }}
             {%- elif value.dtype|string == "<class 'str'>" %}"{{ value.value }}"
             {%- elif value.dtype|string == "<class 'bool'>" %}{{ value.value }}
             {%- elif value.dtype|string == "<class 'datetime.date'>" %}{{ value.value }}{% endif -%}
@@ -155,11 +158,21 @@
           {% endfor %}
         </span>
         {% if type == 'balance' %}
-          <span class="num bal {{ ' pending' if entry.diff_amount else '' }}">{{ entry.amount|format_amount }}</span>
+          {{ commodity_macros.render_amount(ledger, entry.amount, 'num bal' + (' pending' if entry.diff_amount else '')) }}
         {% endif %}
         {% if show_change_and_balance %}
-            <span class="change num">{% for pos in change|cost_or_value(entry.date) %}{{ pos.units|format_amount }}<br>{% endfor %}</span>
-            <span class="num">{% for pos in balance|cost_or_value(entry.date) %}{{ pos.units|format_amount }}<br>{% endfor %}</span>
+          <span class="change num">
+          {% for pos in change|cost_or_value(entry.date) %}
+            {{ commodity_macros.render_amount(ledger, pos.units) }}
+            <br>
+          {% endfor %}
+          </span>
+          <span class="num">
+          {% for pos in balance|cost_or_value(entry.date) %}
+            {{ commodity_macros.render_amount(ledger, pos.units) }}
+            <br>
+          {% endfor %}
+          </span>
         </p>
         {% endif %}
         {{ render_metadata(metadata, entry_hash) }}
@@ -174,7 +187,7 @@
                 {# We want the output these amounts with the same precision as in the input file.
                    For computed values this might give a lot of digits, so format the price using the DisplayContext for now.#}
                 <span class="num">{{ posting.units or '' }}</span>
-                <span class="num">{{ posting.price|format_amount }}</span>
+                {{ commodity_macros.render_amount(ledger, posting.price) }}
                 <span class="num">{{ posting.cost.number }} {{ posting.cost.currency }}
                     {{- ', {}'.format(posting.cost.date) if posting.cost.date else '' }}
                     {{- ', "{}"'.format(posting.cost.label) if posting.cost.label else '' }}</span>

--- a/src/fava/templates/_query_table.html
+++ b/src/fava/templates/_query_table.html
@@ -1,21 +1,25 @@
+{% import 'macros/_account_macros.html' as account_macros %}
+{% import 'macros/_commodity_macros.html' as commodity_macros %}
+
+
 {% set sort_type = {
     "<class 'decimal.Decimal'>": 'num',
     "<class 'cdecimal.Decimal'>": 'num',
     "<class 'int'>": 'num',
 } %}
 
-{% macro querycell(name, value, type_) %}
+{% macro querycell(ledger, name, value, type_) %}
 {% set type = type_|string %}
 {% if type == "<class 'beancount.core.inventory.Inventory'>" %}
 <td class="num">
   {% for position in value|sort(attribute='units.currency') %}
-  {{ position.units|format_amount }}<br>
+    {{ commodity_macros.render_amount(ledger, position.units) }}<br>
   {% endfor %}
 </td>
 {% elif type == "<class 'str'>" %}
 <td>
   {% if name == "account" %}
-  <a href="{{ url_for('account', name=value) }}">{{ value }}</a>
+    {{ account_macros.account_name(ledger, value) }}
   {% elif name == "id" %}
   <a href="#context-{{ value }}">{{ value }}</a>
   {% else %}
@@ -25,7 +29,9 @@
 {% elif type == "<class 'decimal.Decimal'>" or type == "<class 'cdecimal.Decimal'>" %}
 <td class="num" data-sort-value="{{ value or 0 }}">{{ value|format_currency }}</td>
 {% elif type == "<class 'beancount.core.amount.Amount'>" %}
-<td class="num" data-sort-value="{{ value.number or 0 }}">{{ value|format_amount }}</td>
+<td class="num" data-sort-value="{{ value.number or 0 }}">
+  {{ commodity_macros.render_amount(ledger, value.units) }}
+</td>
 {% elif type == "<class 'bool'>" %}
 <td>{{ value|upper }}</td>
 {% elif type == "<class 'int'>" %}
@@ -35,13 +41,13 @@
 {% elif type == "<class 'datetime.date'>" %}
 <td>{{ value or '' }}</td>
 {% elif type == "<class 'beancount.core.position.Position'>" %}
-<td class="num">{{ value.units|format_amount }}</td>
+<td class="num">{{ commodity_macros.render_amount(ledger, value.units) }}</td>
 {% else %}
 <td class="query-error" title="Type {{ type|string }} not recognized">{{ value }}</td>
 {% endif %}
 {% endmacro %}
 
-{% macro querytable(contents, types, rows, filter_empty=None, footer=None) %}
+{% macro querytable(ledger, contents, types, rows, filter_empty=None, footer=None) %}
 {% if contents %}
 <pre><code>{{ contents }}</code></pre>
 {% elif types %}
@@ -57,7 +63,7 @@
     {% for row in rows if filter_empty == None or not row[filter_empty].is_empty() %}
     <tr>
       {% for name, type in types %}
-      {{ querycell(name, row[name], type)  }}
+      {{ querycell(ledger, name, row[name], type)  }}
       {% endfor %}
     </tr>
     {% endfor %}
@@ -66,7 +72,7 @@
   <tfoot>
     <tr>
       {% for type, value in footer %}
-        {{ querycell('', value, type)  }}
+        {{ querycell(ledger, '', value, type)  }}
       {% endfor %}
     </tr>
   </tfoot>

--- a/src/fava/templates/_tree_table.html
+++ b/src/fava/templates/_tree_table.html
@@ -1,4 +1,5 @@
 {% import 'macros/_account_macros.html' as account_macros %}
+{% import 'macros/_commodity_macros.html' as commodity_macros %}
 
 {% macro render_diff_and_number(balance, cost, currency) %}
   {% set num = balance.pop(currency, 0) %}
@@ -46,12 +47,12 @@ Hold Ctrl or Cmd while clicking to expand one level.') }}">
     <span class="num other">
       <span class="balance">
         {% for currency in balance.keys()|sort %}
-        {{ render_diff_and_number(balance, cost, currency) }} {{ currency }}<br>
+        {{ render_diff_and_number(balance, cost, currency) }} {{ commodity_macros.render_currency(ledger, currency) }}<br>
         {% endfor %}
       </span>
       <span class="balance-children">
         {% for currency in balance_children.keys()|sort %}
-        {{ render_diff_and_number(balance_children, cost_children, currency) }} {{ currency }}<br>
+        {{ render_diff_and_number(balance_children, cost_children, currency) }} {{ commodity_macros.render_currency(ledger, currency) }}<br>
         {% endfor %}
       </span>
     </span>
@@ -113,7 +114,7 @@ Hold Ctrl or Cmd while clicking to expand one level.') }}">
             {% for pos in balance %}
                 <span class="balance">
                     {{ render_budget(budget, pos.units.currency, pos.units.number) }}
-                    <span class="number">{{ pos.units|format_amount }}</span>
+                    {{ commodity_macros.render_amount(ledger, pos.units, 'number') }}
                 </span>
             {% endfor %}
             {% for currency, number in budget.items() if currency not in balance.currencies() %}
@@ -124,7 +125,7 @@ Hold Ctrl or Cmd while clicking to expand one level.') }}">
             {% for pos in balance_children %}
                 <span class="balance-children">
                     {{ render_budget(budget_children, pos.units.currency, pos.units.number) }}
-                    <span class="number">{{ pos.units|format_amount }}</span>
+                    {{ commodity_macros.render_amount(ledger, pos.units, 'number') }}
                 </span>
             {% endfor %}
             {% for currency, number in budget_children.items() if currency not in balance_children.currencies() %}

--- a/src/fava/templates/holdings.html
+++ b/src/fava/templates/holdings.html
@@ -53,4 +53,4 @@
 {{ querytable.download_links(query_string) }}
 </p>
 {% set contents, result_types, result_rows = ledger.query_shell.execute_query(query_string) %}
-{{ querytable.querytable(contents, result_types, result_rows, filter_empty=units_column.get(aggregation_key, 1)) }}
+{{ querytable.querytable(ledger, contents, result_types, result_rows, filter_empty=units_column.get(aggregation_key, 1)) }}

--- a/src/fava/templates/macros/_commodity_macros.html
+++ b/src/fava/templates/macros/_commodity_macros.html
@@ -1,0 +1,13 @@
+{% macro render_currency(ledger, currency) %}
+<span title="{{ ledger.commodity_name(currency) | default(currency) }}">{{ currency }}</span>
+{% endmacro %}
+
+{% macro render_amount(ledger, amount, class="num") %}
+{% if amount is none or amount.number is none %}
+  <span class="{{ class }}"><span>
+{% else %}
+  <span class="{{ class }}" title="{{ ledger.commodity_name(amount.currency) }}">
+    {{ amount.number | format_currency(amount.currency, True) }} {{ amount.currency }}
+  </span>
+{% endif %}
+{% endmacro %}

--- a/src/fava/templates/statistics.html
+++ b/src/fava/templates/statistics.html
@@ -1,4 +1,5 @@
 {% import 'macros/_account_macros.html' as account_macros %}
+{% import 'macros/_commodity_macros.html' as commodity_macros %}
 {% import '_query_table.html' as querytable %}
 
 {% macro copy_balance_directives_text() -%}
@@ -18,7 +19,7 @@
     (<a href={{ url_for('report', report_name='query', query_string=postings_per_account) }}>Query</a>)
   </h3>
   {% set contents, result_types, result_rows = ledger.query_shell.execute_query(postings_per_account) %}
-  {{ querytable.querytable(contents, result_types, result_rows) }}
+  {{ querytable.querytable(ledger, contents, result_types, result_rows) }}
 </div>
 
 {% set status_sortorder = { 'red': 5, 'yellow': 4, 'green': 3, '': 2 } %}
@@ -53,7 +54,7 @@
         <td><a href="#context-{{ last_entry|hash_entry }}">{{ last_entry.date }}</a></td>
         <td class="num">
           {%- for position in (ledger.root_account|get_or_create(account)).balance|units -%}
-          {{ position.units|format_amount }}<br>
+          {{ commodity_macros.render_amount(ledger, position.units) }}<br>
           {% endfor -%}
         </td>
       </tr>

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -73,3 +73,9 @@ def test_account_uptodate_status(example_ledger: FavaLedger) -> None:
     assert func("Assets:US:BofA") is None
     assert func("Assets:US:BofA:Checking") == "yellow"
     assert func("Liabilities:US:Chase:Slate") == "green"
+
+
+def test_commodities(example_ledger: FavaLedger) -> None:
+    assert len(example_ledger.commodities) == 10
+    usd = example_ledger.commodities["USD"]
+    assert usd.meta["export"] == "CASH"

--- a/tests/test_template_commodity_macros.py
+++ b/tests/test_template_commodity_macros.py
@@ -1,0 +1,24 @@
+# pylint: disable=missing-docstring
+from beancount.core.data import Transaction
+from flask import g
+from flask import get_template_attribute
+
+
+COMMODITY_MACROS_PATH = "macros/_commodity_macros.html"
+
+
+def test_render_currency(app, example_ledger) -> None:
+    with app.test_request_context(""):
+        macro = get_template_attribute(
+            COMMODITY_MACROS_PATH, "render_currency"
+        )
+        assert "US Dollar" in macro(example_ledger, "USD")
+
+
+def test_render_amount(app, example_ledger) -> None:
+    with app.test_request_context(""):
+        macro = get_template_attribute(COMMODITY_MACROS_PATH, "render_amount")
+        g.ledger = example_ledger
+        transaction = example_ledger.all_entries_by_type[Transaction][0]
+        amount = transaction.postings[0].units
+        assert "US Dollar" in macro(example_ledger, amount)


### PR DESCRIPTION
For the US markets, it's easy to memorize the mapping between commodity (AAPL) and the company (Apple Inc.). But it's hard for most Asian markets as tickers are just numbers. This PR is created for solving this issue.

After this PR, commodities and accounts with `name` will display the name accordingly. Commodities without `name` will not changed.

```
2021-01-01 commodity AAPL
  name: "Apple Inc."

2021-01-01 commodity CN_600519
  name: "Kweichow Moutai"

2021-01-01 open Assets:Stock:IB:Positions USD, HKD
  name: "Interactive Brokers Positions"
```

Please let me know what you guys think about it. Thanks and happy new year!