### PR TITLE
add extension hook after entry modification

### DIFF
--- a/src/fava/core/file.py
+++ b/src/fava/core/file.py
@@ -163,7 +163,14 @@ class FileModule(FavaModule):
         """
         with self.lock:
             entry = self.ledger.get_entry(entry_hash)
-            return save_entry_slice(entry, source_slice, sha256sum)
+            ret = save_entry_slice(entry, source_slice, sha256sum)
+
+            self.ledger.extensions.run_hook(
+                "after_entry_modified", entry, source_slice
+            )
+
+            return ret
+
 
     def insert_entries(self, entries: Entries) -> None:
         """Insert entries.

--- a/src/fava/core/file.py
+++ b/src/fava/core/file.py
@@ -171,7 +171,6 @@ class FileModule(FavaModule):
 
             return ret
 
-
     def insert_entries(self, entries: Entries) -> None:
         """Insert entries.
 

--- a/src/fava/ext/auto_commit.py
+++ b/src/fava/ext/auto_commit.py
@@ -28,3 +28,7 @@ class AutoCommit(FavaExtensionBase):
     def after_insert_entry(self, entry):
         message = f"autocommit: entry on {entry.date}"
         self._run(["git", "commit", "-am", message])
+
+    def after_entry_modified(self, entry, _):
+        message = f"autocommit: modified entry on {entry.date}"
+        self._run(["git", "commit", "-am", message])

--- a/src/fava/help/extensions.md
+++ b/src/fava/help/extensions.md
@@ -63,6 +63,12 @@ Called after an `entry` has been inserted.
 
 ---
 
+### `after_entry_modified(entry, new_lines: str)`
+
+Called after an `entry` modified via the context popup.
+
+---
+
 ## Extension attributes
 
 ### `report_title`


### PR DESCRIPTION
There are hooks currently when new entry are inserted, file is saved, or metadata is added, but no hook when an entry is modified in the context popup.