### PR TITLE
Use parent font-family in chart axes

### DIFF
--- a/frontend/css/charts.css
+++ b/frontend/css/charts.css
@@ -41,6 +41,7 @@
 
 svg text {
   fill: var(--color-text-lightest);
+  font-family: var(--font-family);
 }
 
 svg .axis path,

--- a/frontend/css/charts.css
+++ b/frontend/css/charts.css
@@ -40,8 +40,8 @@
 }
 
 svg text {
-  fill: var(--color-text-lightest);
   font-family: var(--font-family);
+  fill: var(--color-text-lightest);
 }
 
 svg .axis path,


### PR DESCRIPTION
This style adds a `font-family` property to `text` elements in `svg`s, so that axes use the same typeface as the surrounding body text (instead of the default `sans-serif`).