### PR TITLE
fix editor z-index position

### DIFF
--- a/frontend/css/editor.css
+++ b/frontend/css/editor.css
@@ -10,7 +10,7 @@
 }
 
 .CodeMirror.CodeMirror {
-  z-index: 0;
+  z-index: var(--z-index-editor);
   margin-bottom: 1em;
   font: 13px var(--font-family-editor);
   border: 1px solid var(--color-sidebar-border);

--- a/frontend/css/editor.css
+++ b/frontend/css/editor.css
@@ -10,6 +10,7 @@
 }
 
 .CodeMirror.CodeMirror {
+  z-index: 0;
   margin-bottom: 1em;
   font: 13px var(--font-family-editor);
   border: 1px solid var(--color-sidebar-border);

--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -3,6 +3,7 @@
   --font-family-alternative: "Source Serif Pro", sans-serif;
   --font-family-monospaced: "Fira Mono", monospace;
   --font-family-editor: "Source Code Pro", monospace;
+  --z-index-editor: 0;
   --z-index-aside: 1;
   --z-index-header: 2;
   --z-index-floating-ui: 3;


### PR DESCRIPTION
The editor is positioned on top of floating components, which is especially visible on help pages, and on the query or editor page when the header overlays (file selector, filters...) are active. This style sets the editor `z-index` to `0`.

![image](https://user-images.githubusercontent.com/940567/104660495-f5115800-56c6-11eb-89ab-897571e7163f.png)
