### PR TITLE
Display files with importers at top of import page

### DIFF
--- a/frontend/src/import/FileList.svelte
+++ b/frontend/src/import/FileList.svelte
@@ -1,0 +1,106 @@
+<script>
+  import { createEventDispatcher } from "svelte";
+  import { _ } from "../i18n";
+
+  import AccountInput from "../entry-forms/AccountInput.svelte";
+
+  /** @type {import("./helpers").ProcessedImportableFiles} */
+  export let files;
+
+  /** @type {Map<string,import('../entries').Entry[]>} */
+  export let extractCache;
+
+  /** @type {string|null} */
+  export let selected;
+
+  const dispatch = createEventDispatcher();
+
+  /** @param {string} filename */
+  function remove(filename) {
+    dispatch("removeFile", filename);
+  }
+
+  /** @param {import('./helpers').MoveFileArgs} args */
+  function move(args) {
+    dispatch("moveFile", args);
+  }
+
+  /** @param {import('./helpers').ExtractFileArgs} args */
+  function extract(args) {
+    dispatch("extractFile", args);
+  }
+</script>
+
+{#each files as file}
+  <div
+    class="header"
+    title={file.name}
+    on:click|self={() => {
+      selected = selected === file.name ? null : file.name;
+    }}
+  >
+    {file.basename}
+    <button
+      class="round"
+      on:click={() => remove(file.name)}
+      type="button"
+      title={_("Delete")}
+      tabindex={-1}
+    >
+      ×
+    </button>
+  </div>
+  {#each file.importers as info}
+    <div class="flex-row">
+      <AccountInput bind:value={info.account} />
+      <input size={40} bind:value={info.newName} />
+      <button
+        type="button"
+        on:click={() =>
+          move({
+            filename: file.name,
+            account: info.account,
+            newName: info.newName,
+          })}
+      >
+        {"Move"}
+      </button>
+      {#if info.importer_name}
+        <button
+          type="button"
+          title="{_('Extract')} with importer {info.importer_name}"
+          on:click={() =>
+            extract({ filename: file.name, importer: info.importer_name })}
+        >
+          {extractCache.get(`${file.name}:${info.importer_name}`)
+            ? _("Continue")
+            : _("Extract")}
+        </button>
+        {#if extractCache.get(`${file.name}:${info.importer_name}`)}
+          <button
+            type="button"
+            on:click={() => {
+              extractCache.delete(`${file.name}:${info.importer_name}`);
+              extractCache = extractCache;
+            }}
+          >
+            {_("Clear")}
+          </button>
+        {/if}
+        {info.importer_name}
+      {:else}{_("No importer matched this file.")}{/if}
+    </div>
+  {/each}
+{/each}
+
+<style>
+  .header {
+    padding: 0.5rem;
+    margin: 0.5rem 0;
+    cursor: pointer;
+    background-color: var(--color-table-header-background);
+  }
+  .header button {
+    float: right;
+  }
+</style>

--- a/frontend/src/import/FileList.svelte
+++ b/frontend/src/import/FileList.svelte
@@ -1,5 +1,4 @@
 <script>
-  import { createEventDispatcher } from "svelte";
   import { _ } from "../i18n";
 
   import AccountInput from "../entry-forms/AccountInput.svelte";
@@ -13,22 +12,14 @@
   /** @type {string|null} */
   export let selected;
 
-  const dispatch = createEventDispatcher();
+  /** @type {function(string)} */
+  export let removeFile;
 
-  /** @param {string} filename */
-  function remove(filename) {
-    dispatch("removeFile", filename);
-  }
+  /** @type {function(string, string, string)} */
+  export let moveFile;
 
-  /** @param {import('./helpers').MoveFileArgs} args */
-  function move(args) {
-    dispatch("moveFile", args);
-  }
-
-  /** @param {import('./helpers').ExtractFileArgs} args */
-  function extract(args) {
-    dispatch("extractFile", args);
-  }
+  /** @type {function(string, string)} */
+  export let extract;
 </script>
 
 {#each files as file}
@@ -42,7 +33,7 @@
     {file.basename}
     <button
       class="round"
-      on:click={() => remove(file.name)}
+      on:click={() => removeFile(file.name)}
       type="button"
       title={_("Delete")}
       tabindex={-1}
@@ -56,12 +47,7 @@
       <input size={40} bind:value={info.newName} />
       <button
         type="button"
-        on:click={() =>
-          move({
-            filename: file.name,
-            account: info.account,
-            newName: info.newName,
-          })}
+        on:click={() => moveFile(file.name, info.account, info.newName)}
       >
         {"Move"}
       </button>
@@ -69,8 +55,7 @@
         <button
           type="button"
           title="{_('Extract')} with importer {info.importer_name}"
-          on:click={() =>
-            extract({ filename: file.name, importer: info.importer_name })}
+          on:click={() => extract(file.name, info.importer_name)}
         >
           {extractCache.get(`${file.name}:${info.importer_name}`)
             ? _("Continue")

--- a/frontend/src/import/Import.svelte
+++ b/frontend/src/import/Import.svelte
@@ -7,7 +7,7 @@
   import { preprocessData, isDuplicate } from "./helpers";
 
   import Extract from "./Extract.svelte";
-  import AccountInput from "../entry-forms/AccountInput.svelte";
+  import FileList from "./FileList.svelte";
   import { notify } from "../notifications";
   import DocumentPreview from "../documents/DocumentPreview.svelte";
 
@@ -26,6 +26,11 @@
   /** @type {Map<string,import('../entries').Entry[]>} */
   let extractCache = new Map();
 
+  $: importableFiles = preprocessedData.filter(i => i.importers[0].importer_name !== "");
+  $: nonImportableFiles = preprocessedData.filter(i => i.importers[0].importer_name === "");
+  // open the <details> when these are the only files remaining
+  $: nonImportableOpen = nonImportableFiles.length > 0 && importableFiles.length === 0;
+
   function preventNavigation() {
     return extractCache.size > 0
       ? "There are unfinished imports, are you sure you want to continue?"
@@ -43,11 +48,10 @@
 
   /**
    * Move the given file to the new file name (and remove from the list).
-   * @param {string} filename
-   * @param {string} account
-   * @param {string} newName
+   * @param {import('./helpers').MoveFileArgs} args
    */
-  async function move(filename, account, newName) {
+  async function move(args) {
+    let {filename, account, newName} = args;
     const moved = await moveDocument(filename, account, newName);
     if (moved) {
       preprocessedData = preprocessedData.filter(
@@ -71,10 +75,10 @@
 
   /**
    * Open the extract dialog for the given file/importer combination.
-   * @param {string} filename
-   * @param {string} importer
+   * @param {import('./helpers').ExtractFileArgs} args
    */
-  async function extract(filename, importer) {
+  async function extract(args) {
+    let {filename, importer} = args;
     const extractCacheKey = `${filename}:${importer}`;
     let cached = extractCache.get(extractCacheKey);
     if (!cached) {
@@ -113,61 +117,38 @@
 />
 <div class="fixed-fullsize-container">
   <div class="filelist">
-    {#each preprocessedData as file}
-      <div
-        class="header"
-        title={file.name}
-        on:click|self={() => {
-          selected = selected === file.name ? null : file.name;
-        }}
-      >
-        {file.basename}
-        <button
-          class="round"
-          on:click={() => remove(file.name)}
-          type="button"
-          title={_("Delete")}
-          tabindex={-1}
-        >
-          ×
-        </button>
+    {#if preprocessedData.length === 0}
+      <p>{_("No files were found for import.")}</p>
+    {/if}
+    {#if importableFiles.length > 0}
+      <div class="importableFiles">
+        <h2>{_("Importable Files")}</h2>
+        <FileList
+          files={importableFiles}
+          {extractCache}
+          bind:selected
+          on:moveFile={(e) => move(e.detail)}
+          on:removeFile={(e) => remove(e.detail)}
+          on:extractFile={(e) => extract(e.detail)}
+        />
       </div>
-      {#each file.importers as info}
-        <div class="flex-row">
-          <AccountInput bind:value={info.account} />
-          <input size={40} bind:value={info.newName} />
-          <button
-            type="button"
-            on:click={() => move(file.name, info.account, info.newName)}
-          >
-            {"Move"}
-          </button>
-          {#if info.importer_name}
-            <button
-              type="button"
-              title="{_('Extract')} with importer {info.importer_name}"
-              on:click={() => extract(file.name, info.importer_name)}
-            >
-              {extractCache.get(`${file.name}:${info.importer_name}`)
-                ? _("Continue")
-                : _("Extract")}
-            </button>
-            {#if extractCache.get(`${file.name}:${info.importer_name}`)}
-              <button
-                type="button"
-                on:click={() => {
-                  extractCache.delete(`${file.name}:${info.importer_name}`);
-                  extractCache = extractCache;
-                }}
-              >
-                {_("Clear")}
-              </button>
-            {/if}
-            {info.importer_name}
-          {:else}{_("No importer matched this file.")}{/if}
-        </div>
-      {/each}
-    {/each}
+      <hr />
+    {/if}
+    {#if nonImportableFiles.length > 0}
+      <details open={nonImportableOpen}>
+        <summary>
+          <strong>{_("Non-importable Files")}</strong>
+        </summary>
+        <FileList
+          files={nonImportableFiles}
+          {extractCache}
+          bind:selected
+          on:moveFile={(e) => move(e.detail)}
+          on:removeFile={(e) => remove(e.detail)}
+          on:extractFile={(e) => extract(e.detail)}
+        />
+      </details>
+    {/if}
   </div>
   {#if selected}
     <div>
@@ -177,15 +158,6 @@
 </div>
 
 <style>
-  .header {
-    padding: 0.5rem;
-    margin: 0.5rem 0;
-    cursor: pointer;
-    background-color: var(--color-table-header-background);
-  }
-  .header button {
-    float: right;
-  }
   .fixed-fullsize-container {
     display: flex;
     align-items: stretch;
@@ -196,5 +168,8 @@
   }
   .filelist {
     padding: 1rem;
+  }
+  .importableFiles {
+    padding-bottom: 0.8rem;
   }
 </style>

--- a/frontend/src/import/Import.svelte
+++ b/frontend/src/import/Import.svelte
@@ -53,13 +53,15 @@
 
   /**
    * Move the given file to the new file name (and remove from the list).
-   * @param {import('./helpers').MoveFileArgs} args
+   * @param {string} filename
+   * @param {string} account
+   * @param {string} newName
    */
-  async function move(args) {
-    const moved = await moveDocument(args.filename, args.account, args.newName);
+  async function move(filename, account, newName) {
+    const moved = await moveDocument(filename, account, newName);
     if (moved) {
       preprocessedData = preprocessedData.filter(
-        (item) => item.name !== args.filename
+        (item) => item.name !== filename
       );
     }
   }
@@ -79,16 +81,14 @@
 
   /**
    * Open the extract dialog for the given file/importer combination.
-   * @param {import('./helpers').ExtractFileArgs} args
+   * @param {string} filename
+   * @param {string} importer
    */
-  async function extract(args) {
-    const extractCacheKey = `${args.filename}:${args.importer}`;
+  async function extract(filename, importer) {
+    const extractCacheKey = `${filename}:${importer}`;
     let cached = extractCache.get(extractCacheKey);
     if (!cached) {
-      cached = await get("extract", {
-        filename: args.filename,
-        importer: args.importer,
-      });
+      cached = await get("extract", { filename, importer });
       if (!cached.length) {
         notify("No entries to import from this file.", "warning");
         return;
@@ -133,9 +133,9 @@
           files={importableFiles}
           {extractCache}
           bind:selected
-          on:moveFile={(e) => move(e.detail)}
-          on:removeFile={(e) => remove(e.detail)}
-          on:extractFile={(e) => extract(e.detail)}
+          moveFile={move}
+          removeFile={remove}
+          {extract}
         />
       </div>
       <hr />
@@ -149,9 +149,9 @@
           files={nonImportableFiles}
           {extractCache}
           bind:selected
-          on:moveFile={(e) => move(e.detail)}
-          on:removeFile={(e) => remove(e.detail)}
-          on:extractFile={(e) => extract(e.detail)}
+          moveFile={move}
+          removeFile={remove}
+          {extract}
         />
       </details>
     {/if}

--- a/frontend/src/import/Import.svelte
+++ b/frontend/src/import/Import.svelte
@@ -26,10 +26,15 @@
   /** @type {Map<string,import('../entries').Entry[]>} */
   let extractCache = new Map();
 
-  $: importableFiles = preprocessedData.filter(i => i.importers[0].importer_name !== "");
-  $: nonImportableFiles = preprocessedData.filter(i => i.importers[0].importer_name === "");
+  $: importableFiles = preprocessedData.filter(
+    (i) => i.importers[0].importer_name !== ""
+  );
+  $: nonImportableFiles = preprocessedData.filter(
+    (i) => i.importers[0].importer_name === ""
+  );
   // open the <details> when these are the only files remaining
-  $: nonImportableOpen = nonImportableFiles.length > 0 && importableFiles.length === 0;
+  $: nonImportableOpen =
+    nonImportableFiles.length > 0 && importableFiles.length === 0;
 
   function preventNavigation() {
     return extractCache.size > 0
@@ -51,11 +56,10 @@
    * @param {import('./helpers').MoveFileArgs} args
    */
   async function move(args) {
-    let {filename, account, newName} = args;
-    const moved = await moveDocument(filename, account, newName);
+    const moved = await moveDocument(args.filename, args.account, args.newName);
     if (moved) {
       preprocessedData = preprocessedData.filter(
-        (item) => item.name !== filename
+        (item) => item.name !== args.filename
       );
     }
   }
@@ -78,11 +82,13 @@
    * @param {import('./helpers').ExtractFileArgs} args
    */
   async function extract(args) {
-    let {filename, importer} = args;
-    const extractCacheKey = `${filename}:${importer}`;
+    const extractCacheKey = `${args.filename}:${args.importer}`;
     let cached = extractCache.get(extractCacheKey);
     if (!cached) {
-      cached = await get("extract", { filename, importer });
+      cached = await get("extract", {
+        filename: args.filename,
+        importer: args.importer,
+      });
       if (!cached.length) {
         notify("No entries to import from this file.", "warning");
         return;

--- a/frontend/src/import/helpers.ts
+++ b/frontend/src/import/helpers.ts
@@ -62,3 +62,14 @@ export function preprocessData(arr: ImportableFiles): ProcessedImportableFiles {
     return { ...file, importers };
   });
 }
+
+export interface MoveFileArgs {
+  filename: string;
+  account: string;
+  newName: string;
+}
+
+export interface ExtractFileArgs {
+  filename: string;
+  importer: string;
+}

--- a/frontend/src/import/helpers.ts
+++ b/frontend/src/import/helpers.ts
@@ -62,14 +62,3 @@ export function preprocessData(arr: ImportableFiles): ProcessedImportableFiles {
     return { ...file, importers };
   });
 }
-
-export interface MoveFileArgs {
-  filename: string;
-  account: string;
-  newName: string;
-}
-
-export interface ExtractFileArgs {
-  filename: string;
-  importer: string;
-}


### PR DESCRIPTION
Fixing #1224 by breaking the list of files into two: one of the files that have importers, and one of the other files found in the import directories. This second list is hidden behind a `<details>` tag that is automatically expanded if there are no files in the first list. Here's an example of what the page would look like on first load if there are importable files available:
![Screen Shot 2021-01-30 at 2 52 44 PM](https://user-images.githubusercontent.com/4411471/106368078-fb354480-6314-11eb-85c0-3e2750f3ee0b.png)

This is accomplished by extracting a common `FileList` component. This is my first time using Svelte, so apologies if it's not quite idiomatic on the first cut. Thanks!