### PR TITLE
Add dark mode

### DIFF
--- a/frontend/css/base.css
+++ b/frontend/css/base.css
@@ -36,7 +36,7 @@ pre {
   font-family: var(--font-family-monospaced);
   white-space: pre;
   background-color: var(--color-code-background);
-  border: 1px solid var(--color-background-darker);
+  border: 1px solid var(--color-code-border);
   border-radius: 3px;
 }
 
@@ -345,12 +345,12 @@ kbd {
   padding: 3px 6px;
   margin: 0 1px;
   font: 0.8em var(--font-family-monospaced);
-  color: var(--color-text-lighter);
-  background-color: var(--color-background);
-  border: solid 1px var(--color-background-darker);
-  border-bottom-color: var(--color-background-darkest);
+  color: var(--color-kbd-text);
+  background-color: var(--color-kbd-background);
+  border: solid 1px var(--color-kbd-border);
+  border-bottom-color: var(--color-kbd-shadow);
   border-radius: 3px;
-  box-shadow: inset 0 -1px 0 var(--color-background-darkest);
+  box-shadow: inset 0 -1px 0 var(--color-kbd-shadow);
 }
 
 .keyboard-tooltip {

--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -25,6 +25,11 @@
   --color-error: hsl(0, 100%, 30%);
   --color-warning: hsl(52, 84%, 56%);
   --color-code-background: #f8f8f8;
+  --color-code-border: var(--color-background-darker);
+  --color-kbd-background: var(--color-background);
+  --color-kbd-border: var(--color-background-darker);
+  --color-kbd-shadow: var(--color-background-darkest);
+  --color-kbd-text: var(--color-text-lighter);
   --color-sidebar-text: #444;
   --color-sidebar-text-hover: var(--color-links);
   --color-sidebar-background: hsl(0, 0%, 96%);
@@ -67,6 +72,30 @@
   --color-placeholder: var(--color-text-lightest);
   --background-placeholder: var(--color-background);
   --overlay-wrapper-background: rgba(0, 0, 0, 0.5);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --color-header: var(--color-background-darker);
+    --color-headings: #f0f6fc;
+    --color-header-text: var(--color-headings);
+    --color-text: #c9d1d9;
+    --color-links: #58a6ff;
+    --color-code-background: rgba(240, 246, 252, 0.15);
+    --color-code-border: rgba(255, 255, 255, 0.3);
+    --color-background: #0d1117;
+    --color-background-darker: #161b22;
+    --color-background-darkest: #06090f;
+    --color-sidebar-background: var(--color-background-darkest);
+    --color-sidebar-text: var(--color-text);
+    --color-sidebar-border: #21262d;
+    --color-help-sidebar: var(--color-background-darkest);
+    --color-help-sidebar-border: var(--color-sidebar-border);
+    --color-kbd-background: #0d1117;
+    --color-kbd-border: #6e7681;
+    --color-kbd-shadow: #6e7681;
+    --color-kbd-text: #b1bac4;
+  }
 }
 
 .journal .balance {

--- a/frontend/src/header/FilterForm.svelte
+++ b/frontend/src/header/FilterForm.svelte
@@ -90,9 +90,13 @@
     padding-top: 7px;
     margin: 0;
     color: var(--color-text);
+  }
 
-    --color-placeholder: var(--color-header-tinted);
-    --background-placeholder: var(--color-header-light);
+  @media (prefers-color-scheme: light) {
+    form {
+      --color-placeholder: var(--color-header-tinted);
+      --background-placeholder: var(--color-header-light);
+    }
   }
 
   form > :global(span) {


### PR DESCRIPTION
Resolves #1084 

I've only made a few changes so that I can create a draft PR and start a discussion. I'm still unsure of what color palette to use, where to place the theme switch option, and other relevant information. For starters, I used the colors from GitHub's dark theme, since most of us are already accustomed to it. As already mentioned in #1084, I'm using `prefers-color-scheme` to detect the theme preference of the user (you can use Dev Tools from the browser to simulate the theme preference for now). You can see a sample screenshot below.

Discussion & feedback very much welcome!

**Note:** I've never contributed to open source repositories before and also, I'm somewhat a beginner. So, please feel free to point out if I do something wrong.

![fava-dark-mode-initial-scrot-1](https://user-images.githubusercontent.com/20590666/109387237-359afd00-7926-11eb-82fc-41914f967f66.png)
