### PR TITLE
Fix trailing '/' in url navigation

### DIFF
--- a/frontend/src/charts/Sunburst.svelte
+++ b/frontend/src/charts/Sunburst.svelte
@@ -61,7 +61,7 @@
   <text class="balance" dy="1.2em" text-anchor="middle">{currentBalance}</text>
   {#each leaves as d}
     <path
-      on:click={() => router.navigate(urlFor(`account/${d.data.account}`))}
+      on:click={() => router.navigate(urlFor(`account/${d.data.account}/`))}
       on:mouseover={() => {
         current = d;
       }}

--- a/frontend/src/charts/Treemap.svelte
+++ b/frontend/src/charts/Treemap.svelte
@@ -61,7 +61,7 @@
       <rect fill={fill(d)} width={d.x1 - d.x0} height={d.y1 - d.y0} />
       <text
         use:setOpacity={d}
-        on:click={() => router.navigate(urlFor(`account/${d.data.account}`))}
+        on:click={() => router.navigate(urlFor(`account/${d.data.account}/`))}
         dy=".5em"
         x={(d.x1 - d.x0) / 2}
         y={(d.y1 - d.y0) / 2}

--- a/frontend/src/editor/EditorMenu.svelte
+++ b/frontend/src/editor/EditorMenu.svelte
@@ -23,7 +23,7 @@
   $: insertEntryOptions = $favaOptions["insert-entry"];
 
   function goToFileAndLine(filename: string, line?: number) {
-    const url = urlFor("editor", { file_path: filename, line });
+    const url = urlFor("editor/", { file_path: filename, line });
     const shouldLoad = filename !== file_path;
     router.navigate(url, shouldLoad);
     if (!shouldLoad && line) {

--- a/frontend/src/sidebar/AccountSelector.svelte
+++ b/frontend/src/sidebar/AccountSelector.svelte
@@ -9,7 +9,7 @@
 
   function select(ev: CustomEvent<HTMLInputElement>) {
     if (value) {
-      router.navigate(urlFor(`account/${value}`));
+      router.navigate(urlFor(`account/${value}/`));
       ev.detail.blur();
       value = "";
     }


### PR DESCRIPTION
This fixes the problem in #1243 

I think what happens is
- The Flask route are like `account/<name>/` with a trailing slash
- If we request an url without trailing slash, Flask ends up doing a redirect
- I happen to have a weird deployment setup (Google App Engine with IAP) that has some trouble with making sure that https is reflected through all the redirection
- Page failed to load because browser see that a `https` request is returning back at `http` location

The redirection weirdness isn't fava's fault, but it makes sense that we don't need the redirect in the first place if we request the right URL with trailing slashes.