### PR TITLE
make the conversion selector component available for use in plugin

### DIFF
--- a/frontend/src/svelte-custom-elements.ts
+++ b/frontend/src/svelte-custom-elements.ts
@@ -5,6 +5,7 @@
 import type { SvelteComponent } from "svelte";
 
 import ChartSwitcher from "./charts/ChartSwitcher.svelte";
+import ConversionAndInterval from "./charts/ConversionAndInterval.svelte";
 import Documents from "./documents/Documents.svelte";
 import SourceEditor from "./editor/SourceEditor.svelte";
 import FilterForm from "./header/FilterForm.svelte";
@@ -22,6 +23,7 @@ const components = new Map([
   ["account-selector", AccountSelector],
   ["filter-form", FilterForm],
   ["modals", Modals],
+  ["conversion-and-interval", ConversionAndInterval],
 ]);
 
 /**

--- a/src/fava/templates/_query_table.html
+++ b/src/fava/templates/_query_table.html
@@ -30,7 +30,7 @@
 <td class="num" data-sort-value="{{ value or 0 }}">{{ value|format_currency }}</td>
 {% elif type == "<class 'beancount.core.amount.Amount'>" %}
 <td class="num" data-sort-value="{{ value.number or 0 }}">
-  {{ commodity_macros.render_amount(ledger, value.units) }}
+  {{ commodity_macros.render_amount(ledger, value) }}
 </td>
 {% elif type == "<class 'bool'>" %}
 <td>{{ value|upper }}</td>


### PR DESCRIPTION
The conversion selector can be helpful in plugin, especially if the plugin uses the querytable 
![image](https://user-images.githubusercontent.com/9114601/113692116-70612500-968a-11eb-8de0-0576f748ae63.png)

Also fix a bug introduced in #1207 where query table crashes when displaying the "Amount" type
