### PR TITLE
fix browser back button not updating filter input

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -41,7 +41,7 @@ import { getScriptTagJSON } from "./lib/dom";
 import { object, string } from "./lib/validation";
 import { log_error } from "./log";
 import { notify } from "./notifications";
-import router, { initSyncedStoreValues } from "./router";
+import router, { initSyncedStoreValues, setStoreValueFromUrl } from "./router";
 import { initSidebar, updateSidebar } from "./sidebar";
 import { SortableTable } from "./sort";
 import { errorCount, favaOptions, ledgerData, rawLedgerData } from "./stores";
@@ -110,6 +110,7 @@ function init(): void {
   rawLedgerData.set(document.getElementById("ledger-data")?.innerHTML ?? "");
 
   router.init();
+  setStoreValueFromUrl();
   initSyncedStoreValues();
   initSidebar();
   initGlobalKeyboardShortcuts();


### PR DESCRIPTION
This is a buggy behavior currently. To reproduce:
- Go to, say, an account page
- Add a filter in any of the filter input boxes
- Page updates and filters correctly
- Use the "back" button in browser
- Page updates and filters correctly, but the filter boxes still have the filter string even though the page content doesn't reflect the filter string any more

This PR fixes this by making sure that on `popstate` event, the state in the URL is written back to the store which updates the filter input boxes correctly.