### PR TITLE
Remove interval and conversion options

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,7 +4,8 @@ Changelog
 Unreleased
 ----------
 
-Nothing yet.
+The `conversion` and `interval` options have been removed. Their functionality
+can be achieved with the new `default-page` option.
 
 v1.18 (2021-01-16)
 ------------------

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -522,9 +522,9 @@
       }
     },
     "node_modules/@codemirror/gutter": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/gutter/-/gutter-0.18.0.tgz",
-      "integrity": "sha512-9hcKzBM5EjhWwrau5Xiv0ll/yOvkgiyLnH7DTsjFCUvuyfbS45WVEMhQ6C+HfsoRVR4TJqRVLJjaIktZqaAqnw==",
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/gutter/-/gutter-0.18.1.tgz",
+      "integrity": "sha512-OJXT3giUPtMOLKmr3hHoLekEUHjLoGFA+1fIQUw7/39t4UZJr3S/1EQGI3NEPhyCg4+NCEHZJWS33x6dz5oOiA==",
       "dependencies": {
         "@codemirror/rangeset": "^0.18.0",
         "@codemirror/state": "^0.18.0",
@@ -566,9 +566,9 @@
       }
     },
     "node_modules/@codemirror/lint": {
-      "version": "0.18.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-0.18.1.tgz",
-      "integrity": "sha512-2Ueg/ojU56vF5thxMdS67XQzvHNcBnPKw2zgbDVmL/Z+84SMjP7EKvHV5FlbrKFNGZiwnaAKk5MZRYUwBY3f0g==",
+      "version": "0.18.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-0.18.2.tgz",
+      "integrity": "sha512-WUZdlWNqwF6OIJFD/n3Pfsi1R3eIYrAmnnFhfEBUI/ftBh8RqjqOoPJvctHm++re85cwWzXSSZgSWxzse11PSA==",
       "dependencies": {
         "@codemirror/panel": "^0.18.1",
         "@codemirror/state": "^0.18.0",
@@ -629,17 +629,17 @@
       }
     },
     "node_modules/@codemirror/state": {
-      "version": "0.18.5",
-      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-0.18.5.tgz",
-      "integrity": "sha512-lHR+yE08jEz7MqA5hgNvK4/ksF2mQsJJ/pedKKfB94CUobMX20tsFQ27lZbXCxZDQcz5lO0AZuFuRqrbDlRtKA==",
+      "version": "0.18.6",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-0.18.6.tgz",
+      "integrity": "sha512-jBY4KFY6RGPkuRUFXSZtgxpKebju8CJq7SkKYf+NsD8OZzDSauxPPYAL7V2z8ubvw74qLPIKIX2hERvY6WBdbg==",
       "dependencies": {
         "@codemirror/text": "^0.18.0"
       }
     },
     "node_modules/@codemirror/stream-parser": {
-      "version": "0.18.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/stream-parser/-/stream-parser-0.18.1.tgz",
-      "integrity": "sha512-Q7HXbZRbAg5SboM0/3Hw9bKX7UxRWVsrtFjeQXzti2be/VHfMUAykidqWwWHe1SSn3Me3izpw9vLNEoGCm7tBw==",
+      "version": "0.18.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/stream-parser/-/stream-parser-0.18.2.tgz",
+      "integrity": "sha512-3RTRmhIixcC2ps/G8So+BL0qJkwaspjyYt4smVYlSn4eNbxGK9K2RCnSmOPRv0SkuQMu3oUFbprFI/SbtZrPKg==",
       "dependencies": {
         "@codemirror/highlight": "^0.18.0",
         "@codemirror/language": "^0.18.0",
@@ -664,9 +664,9 @@
       }
     },
     "node_modules/@codemirror/view": {
-      "version": "0.18.6",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-0.18.6.tgz",
-      "integrity": "sha512-j0TtJbV+41g/0eGH7Pgx9wtO7Y3Rg0s9shLFGvUtJ4jMIimkCelQsEBtUmfEbNxAVXOsN+CbmsKg8M9p0ISeCA==",
+      "version": "0.18.7",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-0.18.7.tgz",
+      "integrity": "sha512-klUW15Z74JXA9Njli1bwNyLQroC3OWHYKcAaHO1WUChhxVVx6eC1EbSlkuXpIqYmXFuo3f4iFGcwM2RkuLJ4Iw==",
       "dependencies": {
         "@codemirror/rangeset": "^0.18.0",
         "@codemirror/state": "^0.18.0",
@@ -952,9 +952,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "14.14.37",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.37.tgz",
-      "integrity": "sha512-XYmBiy+ohOR4Lh5jE379fV2IU+6Jn4g5qASinhitfyO71b/sCo6MKsMLF5tc7Zf2CE8hViVQyYSobJNke8OvUw==",
+      "version": "14.14.41",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.41.tgz",
+      "integrity": "sha512-dueRKfaJL4RTtSa7bWeTK1M+VH+Gns73oCgzvYfHZywRCoPSd8EkXBL0mZ9unPTveBn+D9phZBaxuzpwjWkW0g==",
       "dev": true
     },
     "node_modules/@types/normalize-package-data": {
@@ -976,13 +976,13 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "4.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.21.0.tgz",
-      "integrity": "sha512-FPUyCPKZbVGexmbCFI3EQHzCZdy2/5f+jv6k2EDljGdXSRc0cKvbndd2nHZkSLqCNOPk0jB6lGzwIkglXcYVsQ==",
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.22.0.tgz",
+      "integrity": "sha512-U8SP9VOs275iDXaL08Ln1Fa/wLXfj5aTr/1c0t0j6CdbOnxh+TruXu1p4I0NAvdPBQgoPjHsgKn28mOi0FzfoA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/experimental-utils": "4.21.0",
-        "@typescript-eslint/scope-manager": "4.21.0",
+        "@typescript-eslint/experimental-utils": "4.22.0",
+        "@typescript-eslint/scope-manager": "4.22.0",
         "debug": "^4.1.1",
         "functional-red-black-tree": "^1.0.1",
         "lodash": "^4.17.15",
@@ -1008,15 +1008,15 @@
       }
     },
     "node_modules/@typescript-eslint/experimental-utils": {
-      "version": "4.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.21.0.tgz",
-      "integrity": "sha512-cEbgosW/tUFvKmkg3cU7LBoZhvUs+ZPVM9alb25XvR0dal4qHL3SiUqHNrzoWSxaXA9gsifrYrS1xdDV6w/gIA==",
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.22.0.tgz",
+      "integrity": "sha512-xJXHHl6TuAxB5AWiVrGhvbGL8/hbiCQ8FiWwObO3r0fnvBdrbWEDy1hlvGQOAWc6qsCWuWMKdVWlLAEMpxnddg==",
       "dev": true,
       "dependencies": {
         "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/scope-manager": "4.21.0",
-        "@typescript-eslint/types": "4.21.0",
-        "@typescript-eslint/typescript-estree": "4.21.0",
+        "@typescript-eslint/scope-manager": "4.22.0",
+        "@typescript-eslint/types": "4.22.0",
+        "@typescript-eslint/typescript-estree": "4.22.0",
         "eslint-scope": "^5.0.0",
         "eslint-utils": "^2.0.0"
       },
@@ -1032,14 +1032,14 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "4.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.21.0.tgz",
-      "integrity": "sha512-eyNf7QmE5O/l1smaQgN0Lj2M/1jOuNg2NrBm1dqqQN0sVngTLyw8tdCbih96ixlhbF1oINoN8fDCyEH9SjLeIA==",
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.22.0.tgz",
+      "integrity": "sha512-z/bGdBJJZJN76nvAY9DkJANYgK3nlRstRRi74WHm3jjgf2I8AglrSY+6l7ogxOmn55YJ6oKZCLLy+6PW70z15Q==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "4.21.0",
-        "@typescript-eslint/types": "4.21.0",
-        "@typescript-eslint/typescript-estree": "4.21.0",
+        "@typescript-eslint/scope-manager": "4.22.0",
+        "@typescript-eslint/types": "4.22.0",
+        "@typescript-eslint/typescript-estree": "4.22.0",
         "debug": "^4.1.1"
       },
       "engines": {
@@ -1059,13 +1059,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "4.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.21.0.tgz",
-      "integrity": "sha512-kfOjF0w1Ix7+a5T1knOw00f7uAP9Gx44+OEsNQi0PvvTPLYeXJlsCJ4tYnDj5PQEYfpcgOH5yBlw7K+UEI9Agw==",
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.22.0.tgz",
+      "integrity": "sha512-OcCO7LTdk6ukawUM40wo61WdeoA7NM/zaoq1/2cs13M7GyiF+T4rxuA4xM+6LeHWjWbss7hkGXjFDRcKD4O04Q==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "4.21.0",
-        "@typescript-eslint/visitor-keys": "4.21.0"
+        "@typescript-eslint/types": "4.22.0",
+        "@typescript-eslint/visitor-keys": "4.22.0"
       },
       "engines": {
         "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
@@ -1076,9 +1076,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "4.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.21.0.tgz",
-      "integrity": "sha512-+OQaupjGVVc8iXbt6M1oZMwyKQNehAfLYJJ3SdvnofK2qcjfor9pEM62rVjBknhowTkh+2HF+/KdRAc/wGBN2w==",
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.22.0.tgz",
+      "integrity": "sha512-sW/BiXmmyMqDPO2kpOhSy2Py5w6KvRRsKZnV0c4+0nr4GIcedJwXAq+RHNK4lLVEZAJYFltnnk1tJSlbeS9lYA==",
       "dev": true,
       "engines": {
         "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
@@ -1089,13 +1089,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "4.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.21.0.tgz",
-      "integrity": "sha512-ZD3M7yLaVGVYLw4nkkoGKumb7Rog7QID9YOWobFDMQKNl+vPxqVIW/uDk+MDeGc+OHcoG2nJ2HphwiPNajKw3w==",
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.22.0.tgz",
+      "integrity": "sha512-TkIFeu5JEeSs5ze/4NID+PIcVjgoU3cUQUIZnH3Sb1cEn1lBo7StSV5bwPuJQuoxKXlzAObjYTilOEKRuhR5yg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "4.21.0",
-        "@typescript-eslint/visitor-keys": "4.21.0",
+        "@typescript-eslint/types": "4.22.0",
+        "@typescript-eslint/visitor-keys": "4.22.0",
         "debug": "^4.1.1",
         "globby": "^11.0.1",
         "is-glob": "^4.0.1",
@@ -1116,12 +1116,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "4.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.21.0.tgz",
-      "integrity": "sha512-dH22dROWGi5Z6p+Igc8bLVLmwy7vEe8r+8c+raPQU0LxgogPUrRAtRGtvBWmlr9waTu3n+QLt/qrS/hWzk1x5w==",
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.22.0.tgz",
+      "integrity": "sha512-nnMu4F+s4o0sll6cBSsTeVsT4cwxB7zECK3dFxzEjPBii9xLpq4yqqsy/FU5zMfan6G60DKZSCXAa3sHJZrcYw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "4.21.0",
+        "@typescript-eslint/types": "4.22.0",
         "eslint-visitor-keys": "^2.0.0"
       },
       "engines": {
@@ -1138,9 +1138,9 @@
       "integrity": "sha512-3MoJcrgrLWsVZIP9Jl1+82ZtXxi0BTmuBOZXDOti2Mu6/zjhVjOvCUscYkh9uGa9v/lg292imFgJ35Sd2nKF0A=="
     },
     "node_modules/acorn": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.1.0.tgz",
-      "integrity": "sha512-LWCF/Wn0nfHOmJ9rzQApGnxnvgfROzGilS8936rqN/lfcYkY9MYZzdMqN+2NJ4SlTc+m5HiSa+kNfDtI64dwUA==",
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.1.1.tgz",
+      "integrity": "sha512-xYiIVjNuqtKXMxlRMDc6mZUhXehod4a3gbZ1qRlM7icK4EbxUFNLhWoPblCvFtB2Y9CIqHP3CF/rdxLItaQv8g==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -1662,16 +1662,16 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.16.3",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.3.tgz",
-      "integrity": "sha512-vIyhWmIkULaq04Gt93txdh+j02yX/JzlyhLYbV3YQCn/zvES3JnY7TifHHvvr1w5hTDluNKMkV05cs4vy8Q7sw==",
+      "version": "4.16.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.4.tgz",
+      "integrity": "sha512-d7rCxYV8I9kj41RH8UKYnvDYCRENUlHRgyXy/Rhr/1BaeLGfiCptEdFE8MIrvGfWbBFNjVYx76SQWvNX1j+/cQ==",
       "dev": true,
       "dependencies": {
-        "caniuse-lite": "^1.0.30001181",
-        "colorette": "^1.2.1",
-        "electron-to-chromium": "^1.3.649",
+        "caniuse-lite": "^1.0.30001208",
+        "colorette": "^1.2.2",
+        "electron-to-chromium": "^1.3.712",
         "escalade": "^3.1.1",
-        "node-releases": "^1.1.70"
+        "node-releases": "^1.1.71"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -1805,9 +1805,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001208",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001208.tgz",
-      "integrity": "sha512-OE5UE4+nBOro8Dyvv0lfx+SRtfVIOM9uhKqFmJeUbGriqhhStgp1A0OyBpgy3OUF8AhYCT+PVwPC1gMl2ZcQMA==",
+      "version": "1.0.30001209",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001209.tgz",
+      "integrity": "sha512-2Ktt4OeRM7EM/JaOZjuLzPYAIqmbwQMNnYbgooT+icoRGrKOyAxA1xhlnotBD1KArRSPsuJp3TdYcZYrL7qNxA==",
       "dev": true
     },
     "node_modules/chalk": {
@@ -2307,14 +2307,14 @@
       "integrity": "sha512-b0Ed2t1UUalJpc3qXzKi+cPGxeXRr4KU9YSlocN74aTzp6R/Ud43t79yLLqxHRWZfsvWXmbDWPpoENK1K539xw=="
     },
     "node_modules/d3-scale": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.2.4.tgz",
-      "integrity": "sha512-PG6gtpbPCFqKbvdBEswQcJcTzHC8VEd/XzezF5e68KlkT4/ggELw/nR1tv863jY6ufKTvDlzCMZvhe06codbbA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.3.0.tgz",
+      "integrity": "sha512-1JGp44NQCt5d1g+Yy+GeOnZP7xHo0ii8zsQp6PGzd+C1/dl0KGsp9A7Mxwp+1D1o4unbTTxVdU/ZOIEBoeZPbQ==",
       "dependencies": {
         "d3-array": "^2.3.0",
         "d3-format": "1 - 2",
         "d3-interpolate": "1.2.0 - 2",
-        "d3-time": "1 - 2",
+        "d3-time": "^2.1.1",
         "d3-time-format": "2 - 3"
       }
     },
@@ -2595,9 +2595,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.3.712",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.712.tgz",
-      "integrity": "sha512-3kRVibBeCM4vsgoHHGKHmPocLqtFAGTrebXxxtgKs87hNUzXrX2NuS3jnBys7IozCnw7viQlozxKkmty2KNfrw==",
+      "version": "1.3.717",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.717.tgz",
+      "integrity": "sha512-OfzVPIqD1MkJ7fX+yTl2nKyOE4FReeVfMCzzxQS+Kp43hZYwHwThlGP+EGIZRXJsxCM7dqo8Y65NOX/HP12iXQ==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -2712,9 +2712,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.11.7",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.11.7.tgz",
-      "integrity": "sha512-rY+jA0TiCFVLcvxUbbp+yQ9EEBXDsfIU4rsY7RKJEsx/fjjRFjyGnamRCBwUZQspK37G9We6xAkX7IibGA24AA==",
+      "version": "0.11.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.11.12.tgz",
+      "integrity": "sha512-c8cso/1RwVj+fbDvLtUgSG4ZJQ0y9Zdrl6Ot/GAjyy4pdMCHaFnDMts5gqFnWRPLajWtEnI+3hlET4R9fVoZng==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
@@ -2865,9 +2865,9 @@
       }
     },
     "node_modules/eslint-config-prettier": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.1.0.tgz",
-      "integrity": "sha512-oKMhGv3ihGbCIimCAjqkdzx2Q+jthoqnXSP+d86M9tptwugycmTFdVR4IpLgq2c4SHifbwO90z2fQ8/Aio73yw==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.2.0.tgz",
+      "integrity": "sha512-dWV9EVeSo2qodOPi1iBYU/x6F6diHv8uujxbxr77xExs3zTAlNXvVZKiyLsQGNz7yPV2K49JY5WjPzNIuDc2Bw==",
       "dev": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
@@ -3962,9 +3962,9 @@
       "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="
     },
     "node_modules/irregular-plurals": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-3.2.0.tgz",
-      "integrity": "sha512-YqTdPLfwP7YFN0SsD3QUVCkm9ZG2VzOXv3DOrw5G5mkMbVwptTwVcFv7/C0vOpBmgTxAeTG19XpUs1E522LW9Q==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-3.3.0.tgz",
+      "integrity": "sha512-MVBLKUTangM3EfRPFROhmWQQKRDsrgI83J8GS3jXy+OwYqiR2/aoWndYQ5416jLE3uaGgLH7ncme3X9y09gZ3g==",
       "dev": true,
       "engines": {
         "node": ">=8"
@@ -5188,9 +5188,9 @@
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
-      "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==",
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.2.tgz",
+      "integrity": "sha512-gz58rdPpadwztRrPjZE9DZLOABUpTGdcANUgOwBFO1C+HZZhePoP83M65WGDmbpwFYJSWqavbl4SgDn4k8RYTA==",
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -7068,9 +7068,9 @@
       }
     },
     "node_modules/sucrase": {
-      "version": "3.17.1",
-      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.17.1.tgz",
-      "integrity": "sha512-04cNLFAhS4NBG2Z/MTkLY6HdoBsqErv3wCncymFlfFtnpMthurlWYML2RlID4M2BbiJSu1eZdQnE8Lcz4PCe2g==",
+      "version": "3.18.1",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.18.1.tgz",
+      "integrity": "sha512-TRyO38wwOPhLLlM8QLOG3TgMj0FKk+arlTrS9pRAanF8cAcHvgRPKIYWGO25mPSp/Rj87zMMTjFfkqIZGI6ZdA==",
       "dev": true,
       "dependencies": {
         "commander": "^4.0.0",
@@ -7153,9 +7153,9 @@
       "dev": true
     },
     "node_modules/table": {
-      "version": "6.0.9",
-      "resolved": "https://registry.npmjs.org/table/-/table-6.0.9.tgz",
-      "integrity": "sha512-F3cLs9a3hL1Z7N4+EkSscsel3z55XT950AvB05bwayrNg5T1/gykXtigioTAjbltvbMSJvvhFCbnf6mX+ntnJQ==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.1.0.tgz",
+      "integrity": "sha512-T4G5KMmqIk6X87gLKWyU5exPpTjLjY5KyrFWaIjv3SvgaIUGXV7UEzGEnZJdTA38/yUS6f9PlKezQ0bYXG3iIQ==",
       "dev": true,
       "dependencies": {
         "ajv": "^8.0.1",
@@ -7173,9 +7173,9 @@
       }
     },
     "node_modules/table/node_modules/ajv": {
-      "version": "8.0.5",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.0.5.tgz",
-      "integrity": "sha512-RkiLa/AeJx7+9OvniQ/qeWu0w74A8DiPPBclQ6ji3ZQkv5KamO+QGpqmi7O4JIw3rHGUXZ6CoP9tsAkn3gyazg==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.1.0.tgz",
+      "integrity": "sha512-B/Sk2Ix7A36fs/ZkuGLIR86EdjbgR6fsAcbx9lOP/QBSXujDNbVmIS/U4Itz5k8fPFDeVZl/zQ/gJW4Jrq6XjQ==",
       "dev": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -8283,9 +8283,9 @@
       }
     },
     "@codemirror/gutter": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/gutter/-/gutter-0.18.0.tgz",
-      "integrity": "sha512-9hcKzBM5EjhWwrau5Xiv0ll/yOvkgiyLnH7DTsjFCUvuyfbS45WVEMhQ6C+HfsoRVR4TJqRVLJjaIktZqaAqnw==",
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/gutter/-/gutter-0.18.1.tgz",
+      "integrity": "sha512-OJXT3giUPtMOLKmr3hHoLekEUHjLoGFA+1fIQUw7/39t4UZJr3S/1EQGI3NEPhyCg4+NCEHZJWS33x6dz5oOiA==",
       "requires": {
         "@codemirror/rangeset": "^0.18.0",
         "@codemirror/state": "^0.18.0",
@@ -8327,9 +8327,9 @@
       }
     },
     "@codemirror/lint": {
-      "version": "0.18.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-0.18.1.tgz",
-      "integrity": "sha512-2Ueg/ojU56vF5thxMdS67XQzvHNcBnPKw2zgbDVmL/Z+84SMjP7EKvHV5FlbrKFNGZiwnaAKk5MZRYUwBY3f0g==",
+      "version": "0.18.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-0.18.2.tgz",
+      "integrity": "sha512-WUZdlWNqwF6OIJFD/n3Pfsi1R3eIYrAmnnFhfEBUI/ftBh8RqjqOoPJvctHm++re85cwWzXSSZgSWxzse11PSA==",
       "requires": {
         "@codemirror/panel": "^0.18.1",
         "@codemirror/state": "^0.18.0",
@@ -8390,17 +8390,17 @@
       }
     },
     "@codemirror/state": {
-      "version": "0.18.5",
-      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-0.18.5.tgz",
-      "integrity": "sha512-lHR+yE08jEz7MqA5hgNvK4/ksF2mQsJJ/pedKKfB94CUobMX20tsFQ27lZbXCxZDQcz5lO0AZuFuRqrbDlRtKA==",
+      "version": "0.18.6",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-0.18.6.tgz",
+      "integrity": "sha512-jBY4KFY6RGPkuRUFXSZtgxpKebju8CJq7SkKYf+NsD8OZzDSauxPPYAL7V2z8ubvw74qLPIKIX2hERvY6WBdbg==",
       "requires": {
         "@codemirror/text": "^0.18.0"
       }
     },
     "@codemirror/stream-parser": {
-      "version": "0.18.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/stream-parser/-/stream-parser-0.18.1.tgz",
-      "integrity": "sha512-Q7HXbZRbAg5SboM0/3Hw9bKX7UxRWVsrtFjeQXzti2be/VHfMUAykidqWwWHe1SSn3Me3izpw9vLNEoGCm7tBw==",
+      "version": "0.18.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/stream-parser/-/stream-parser-0.18.2.tgz",
+      "integrity": "sha512-3RTRmhIixcC2ps/G8So+BL0qJkwaspjyYt4smVYlSn4eNbxGK9K2RCnSmOPRv0SkuQMu3oUFbprFI/SbtZrPKg==",
       "requires": {
         "@codemirror/highlight": "^0.18.0",
         "@codemirror/language": "^0.18.0",
@@ -8425,9 +8425,9 @@
       }
     },
     "@codemirror/view": {
-      "version": "0.18.6",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-0.18.6.tgz",
-      "integrity": "sha512-j0TtJbV+41g/0eGH7Pgx9wtO7Y3Rg0s9shLFGvUtJ4jMIimkCelQsEBtUmfEbNxAVXOsN+CbmsKg8M9p0ISeCA==",
+      "version": "0.18.7",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-0.18.7.tgz",
+      "integrity": "sha512-klUW15Z74JXA9Njli1bwNyLQroC3OWHYKcAaHO1WUChhxVVx6eC1EbSlkuXpIqYmXFuo3f4iFGcwM2RkuLJ4Iw==",
       "requires": {
         "@codemirror/rangeset": "^0.18.0",
         "@codemirror/state": "^0.18.0",
@@ -8676,9 +8676,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.14.37",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.37.tgz",
-      "integrity": "sha512-XYmBiy+ohOR4Lh5jE379fV2IU+6Jn4g5qASinhitfyO71b/sCo6MKsMLF5tc7Zf2CE8hViVQyYSobJNke8OvUw==",
+      "version": "14.14.41",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.41.tgz",
+      "integrity": "sha512-dueRKfaJL4RTtSa7bWeTK1M+VH+Gns73oCgzvYfHZywRCoPSd8EkXBL0mZ9unPTveBn+D9phZBaxuzpwjWkW0g==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -8700,13 +8700,13 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "4.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.21.0.tgz",
-      "integrity": "sha512-FPUyCPKZbVGexmbCFI3EQHzCZdy2/5f+jv6k2EDljGdXSRc0cKvbndd2nHZkSLqCNOPk0jB6lGzwIkglXcYVsQ==",
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.22.0.tgz",
+      "integrity": "sha512-U8SP9VOs275iDXaL08Ln1Fa/wLXfj5aTr/1c0t0j6CdbOnxh+TruXu1p4I0NAvdPBQgoPjHsgKn28mOi0FzfoA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "4.21.0",
-        "@typescript-eslint/scope-manager": "4.21.0",
+        "@typescript-eslint/experimental-utils": "4.22.0",
+        "@typescript-eslint/scope-manager": "4.22.0",
         "debug": "^4.1.1",
         "functional-red-black-tree": "^1.0.1",
         "lodash": "^4.17.15",
@@ -8716,55 +8716,55 @@
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "4.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.21.0.tgz",
-      "integrity": "sha512-cEbgosW/tUFvKmkg3cU7LBoZhvUs+ZPVM9alb25XvR0dal4qHL3SiUqHNrzoWSxaXA9gsifrYrS1xdDV6w/gIA==",
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.22.0.tgz",
+      "integrity": "sha512-xJXHHl6TuAxB5AWiVrGhvbGL8/hbiCQ8FiWwObO3r0fnvBdrbWEDy1hlvGQOAWc6qsCWuWMKdVWlLAEMpxnddg==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/scope-manager": "4.21.0",
-        "@typescript-eslint/types": "4.21.0",
-        "@typescript-eslint/typescript-estree": "4.21.0",
+        "@typescript-eslint/scope-manager": "4.22.0",
+        "@typescript-eslint/types": "4.22.0",
+        "@typescript-eslint/typescript-estree": "4.22.0",
         "eslint-scope": "^5.0.0",
         "eslint-utils": "^2.0.0"
       }
     },
     "@typescript-eslint/parser": {
-      "version": "4.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.21.0.tgz",
-      "integrity": "sha512-eyNf7QmE5O/l1smaQgN0Lj2M/1jOuNg2NrBm1dqqQN0sVngTLyw8tdCbih96ixlhbF1oINoN8fDCyEH9SjLeIA==",
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.22.0.tgz",
+      "integrity": "sha512-z/bGdBJJZJN76nvAY9DkJANYgK3nlRstRRi74WHm3jjgf2I8AglrSY+6l7ogxOmn55YJ6oKZCLLy+6PW70z15Q==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "4.21.0",
-        "@typescript-eslint/types": "4.21.0",
-        "@typescript-eslint/typescript-estree": "4.21.0",
+        "@typescript-eslint/scope-manager": "4.22.0",
+        "@typescript-eslint/types": "4.22.0",
+        "@typescript-eslint/typescript-estree": "4.22.0",
         "debug": "^4.1.1"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "4.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.21.0.tgz",
-      "integrity": "sha512-kfOjF0w1Ix7+a5T1knOw00f7uAP9Gx44+OEsNQi0PvvTPLYeXJlsCJ4tYnDj5PQEYfpcgOH5yBlw7K+UEI9Agw==",
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.22.0.tgz",
+      "integrity": "sha512-OcCO7LTdk6ukawUM40wo61WdeoA7NM/zaoq1/2cs13M7GyiF+T4rxuA4xM+6LeHWjWbss7hkGXjFDRcKD4O04Q==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.21.0",
-        "@typescript-eslint/visitor-keys": "4.21.0"
+        "@typescript-eslint/types": "4.22.0",
+        "@typescript-eslint/visitor-keys": "4.22.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "4.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.21.0.tgz",
-      "integrity": "sha512-+OQaupjGVVc8iXbt6M1oZMwyKQNehAfLYJJ3SdvnofK2qcjfor9pEM62rVjBknhowTkh+2HF+/KdRAc/wGBN2w==",
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.22.0.tgz",
+      "integrity": "sha512-sW/BiXmmyMqDPO2kpOhSy2Py5w6KvRRsKZnV0c4+0nr4GIcedJwXAq+RHNK4lLVEZAJYFltnnk1tJSlbeS9lYA==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "4.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.21.0.tgz",
-      "integrity": "sha512-ZD3M7yLaVGVYLw4nkkoGKumb7Rog7QID9YOWobFDMQKNl+vPxqVIW/uDk+MDeGc+OHcoG2nJ2HphwiPNajKw3w==",
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.22.0.tgz",
+      "integrity": "sha512-TkIFeu5JEeSs5ze/4NID+PIcVjgoU3cUQUIZnH3Sb1cEn1lBo7StSV5bwPuJQuoxKXlzAObjYTilOEKRuhR5yg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.21.0",
-        "@typescript-eslint/visitor-keys": "4.21.0",
+        "@typescript-eslint/types": "4.22.0",
+        "@typescript-eslint/visitor-keys": "4.22.0",
         "debug": "^4.1.1",
         "globby": "^11.0.1",
         "is-glob": "^4.0.1",
@@ -8773,12 +8773,12 @@
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "4.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.21.0.tgz",
-      "integrity": "sha512-dH22dROWGi5Z6p+Igc8bLVLmwy7vEe8r+8c+raPQU0LxgogPUrRAtRGtvBWmlr9waTu3n+QLt/qrS/hWzk1x5w==",
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.22.0.tgz",
+      "integrity": "sha512-nnMu4F+s4o0sll6cBSsTeVsT4cwxB7zECK3dFxzEjPBii9xLpq4yqqsy/FU5zMfan6G60DKZSCXAa3sHJZrcYw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.21.0",
+        "@typescript-eslint/types": "4.22.0",
         "eslint-visitor-keys": "^2.0.0"
       }
     },
@@ -8788,9 +8788,9 @@
       "integrity": "sha512-3MoJcrgrLWsVZIP9Jl1+82ZtXxi0BTmuBOZXDOti2Mu6/zjhVjOvCUscYkh9uGa9v/lg292imFgJ35Sd2nKF0A=="
     },
     "acorn": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.1.0.tgz",
-      "integrity": "sha512-LWCF/Wn0nfHOmJ9rzQApGnxnvgfROzGilS8936rqN/lfcYkY9MYZzdMqN+2NJ4SlTc+m5HiSa+kNfDtI64dwUA==",
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.1.1.tgz",
+      "integrity": "sha512-xYiIVjNuqtKXMxlRMDc6mZUhXehod4a3gbZ1qRlM7icK4EbxUFNLhWoPblCvFtB2Y9CIqHP3CF/rdxLItaQv8g==",
       "dev": true
     },
     "acorn-jsx": {
@@ -9183,16 +9183,16 @@
       }
     },
     "browserslist": {
-      "version": "4.16.3",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.3.tgz",
-      "integrity": "sha512-vIyhWmIkULaq04Gt93txdh+j02yX/JzlyhLYbV3YQCn/zvES3JnY7TifHHvvr1w5hTDluNKMkV05cs4vy8Q7sw==",
+      "version": "4.16.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.4.tgz",
+      "integrity": "sha512-d7rCxYV8I9kj41RH8UKYnvDYCRENUlHRgyXy/Rhr/1BaeLGfiCptEdFE8MIrvGfWbBFNjVYx76SQWvNX1j+/cQ==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001181",
-        "colorette": "^1.2.1",
-        "electron-to-chromium": "^1.3.649",
+        "caniuse-lite": "^1.0.30001208",
+        "colorette": "^1.2.2",
+        "electron-to-chromium": "^1.3.712",
         "escalade": "^3.1.1",
-        "node-releases": "^1.1.70"
+        "node-releases": "^1.1.71"
       }
     },
     "buffer": {
@@ -9277,9 +9277,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001208",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001208.tgz",
-      "integrity": "sha512-OE5UE4+nBOro8Dyvv0lfx+SRtfVIOM9uhKqFmJeUbGriqhhStgp1A0OyBpgy3OUF8AhYCT+PVwPC1gMl2ZcQMA==",
+      "version": "1.0.30001209",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001209.tgz",
+      "integrity": "sha512-2Ktt4OeRM7EM/JaOZjuLzPYAIqmbwQMNnYbgooT+icoRGrKOyAxA1xhlnotBD1KArRSPsuJp3TdYcZYrL7qNxA==",
       "dev": true
     },
     "chalk": {
@@ -9671,14 +9671,14 @@
       "integrity": "sha512-b0Ed2t1UUalJpc3qXzKi+cPGxeXRr4KU9YSlocN74aTzp6R/Ud43t79yLLqxHRWZfsvWXmbDWPpoENK1K539xw=="
     },
     "d3-scale": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.2.4.tgz",
-      "integrity": "sha512-PG6gtpbPCFqKbvdBEswQcJcTzHC8VEd/XzezF5e68KlkT4/ggELw/nR1tv863jY6ufKTvDlzCMZvhe06codbbA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.3.0.tgz",
+      "integrity": "sha512-1JGp44NQCt5d1g+Yy+GeOnZP7xHo0ii8zsQp6PGzd+C1/dl0KGsp9A7Mxwp+1D1o4unbTTxVdU/ZOIEBoeZPbQ==",
       "requires": {
         "d3-array": "^2.3.0",
         "d3-format": "1 - 2",
         "d3-interpolate": "1.2.0 - 2",
-        "d3-time": "1 - 2",
+        "d3-time": "^2.1.1",
         "d3-time-format": "2 - 3"
       }
     },
@@ -9912,9 +9912,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.712",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.712.tgz",
-      "integrity": "sha512-3kRVibBeCM4vsgoHHGKHmPocLqtFAGTrebXxxtgKs87hNUzXrX2NuS3jnBys7IozCnw7viQlozxKkmty2KNfrw==",
+      "version": "1.3.717",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.717.tgz",
+      "integrity": "sha512-OfzVPIqD1MkJ7fX+yTl2nKyOE4FReeVfMCzzxQS+Kp43hZYwHwThlGP+EGIZRXJsxCM7dqo8Y65NOX/HP12iXQ==",
       "dev": true
     },
     "emittery": {
@@ -10005,9 +10005,9 @@
       }
     },
     "esbuild": {
-      "version": "0.11.7",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.11.7.tgz",
-      "integrity": "sha512-rY+jA0TiCFVLcvxUbbp+yQ9EEBXDsfIU4rsY7RKJEsx/fjjRFjyGnamRCBwUZQspK37G9We6xAkX7IibGA24AA==",
+      "version": "0.11.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.11.12.tgz",
+      "integrity": "sha512-c8cso/1RwVj+fbDvLtUgSG4ZJQ0y9Zdrl6Ot/GAjyy4pdMCHaFnDMts5gqFnWRPLajWtEnI+3hlET4R9fVoZng==",
       "dev": true
     },
     "esbuild-svelte": {
@@ -10116,9 +10116,9 @@
       }
     },
     "eslint-config-prettier": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.1.0.tgz",
-      "integrity": "sha512-oKMhGv3ihGbCIimCAjqkdzx2Q+jthoqnXSP+d86M9tptwugycmTFdVR4IpLgq2c4SHifbwO90z2fQ8/Aio73yw==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.2.0.tgz",
+      "integrity": "sha512-dWV9EVeSo2qodOPi1iBYU/x6F6diHv8uujxbxr77xExs3zTAlNXvVZKiyLsQGNz7yPV2K49JY5WjPzNIuDc2Bw==",
       "dev": true,
       "requires": {}
     },
@@ -10956,9 +10956,9 @@
       "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="
     },
     "irregular-plurals": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-3.2.0.tgz",
-      "integrity": "sha512-YqTdPLfwP7YFN0SsD3QUVCkm9ZG2VzOXv3DOrw5G5mkMbVwptTwVcFv7/C0vOpBmgTxAeTG19XpUs1E522LW9Q==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-3.3.0.tgz",
+      "integrity": "sha512-MVBLKUTangM3EfRPFROhmWQQKRDsrgI83J8GS3jXy+OwYqiR2/aoWndYQ5416jLE3uaGgLH7ncme3X9y09gZ3g==",
       "dev": true
     },
     "is-alphabetical": {
@@ -11848,9 +11848,9 @@
       "dev": true
     },
     "object-inspect": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
-      "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==",
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.2.tgz",
+      "integrity": "sha512-gz58rdPpadwztRrPjZE9DZLOABUpTGdcANUgOwBFO1C+HZZhePoP83M65WGDmbpwFYJSWqavbl4SgDn4k8RYTA==",
       "dev": true
     },
     "object-keys": {
@@ -13243,9 +13243,9 @@
       }
     },
     "sucrase": {
-      "version": "3.17.1",
-      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.17.1.tgz",
-      "integrity": "sha512-04cNLFAhS4NBG2Z/MTkLY6HdoBsqErv3wCncymFlfFtnpMthurlWYML2RlID4M2BbiJSu1eZdQnE8Lcz4PCe2g==",
+      "version": "3.18.1",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.18.1.tgz",
+      "integrity": "sha512-TRyO38wwOPhLLlM8QLOG3TgMj0FKk+arlTrS9pRAanF8cAcHvgRPKIYWGO25mPSp/Rj87zMMTjFfkqIZGI6ZdA==",
       "dev": true,
       "requires": {
         "commander": "^4.0.0",
@@ -13306,9 +13306,9 @@
       "dev": true
     },
     "table": {
-      "version": "6.0.9",
-      "resolved": "https://registry.npmjs.org/table/-/table-6.0.9.tgz",
-      "integrity": "sha512-F3cLs9a3hL1Z7N4+EkSscsel3z55XT950AvB05bwayrNg5T1/gykXtigioTAjbltvbMSJvvhFCbnf6mX+ntnJQ==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.1.0.tgz",
+      "integrity": "sha512-T4G5KMmqIk6X87gLKWyU5exPpTjLjY5KyrFWaIjv3SvgaIUGXV7UEzGEnZJdTA38/yUS6f9PlKezQ0bYXG3iIQ==",
       "dev": true,
       "requires": {
         "ajv": "^8.0.1",
@@ -13323,9 +13323,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "8.0.5",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.0.5.tgz",
-          "integrity": "sha512-RkiLa/AeJx7+9OvniQ/qeWu0w74A8DiPPBclQ6ji3ZQkv5KamO+QGpqmi7O4JIw3rHGUXZ6CoP9tsAkn3gyazg==",
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.1.0.tgz",
+          "integrity": "sha512-B/Sk2Ix7A36fs/ZkuGLIR86EdjbgR6fsAcbx9lOP/QBSXujDNbVmIS/U4Itz5k8fPFDeVZl/zQ/gJW4Jrq6XjQ==",
           "dev": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",

--- a/frontend/src/lib/interval.ts
+++ b/frontend/src/lib/interval.ts
@@ -1,0 +1,10 @@
+export type Interval = "year" | "quarter" | "month" | "week" | "day";
+
+export const DEFAULT_INTERVAL: Interval = "month";
+
+export function getInterval(s: string | null): Interval {
+  if (s && ["year", "quarter", "month", "week", "day"].includes(s)) {
+    return s as Interval;
+  }
+  return "month";
+}

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -41,7 +41,7 @@ import { getScriptTagJSON } from "./lib/dom";
 import { object, string } from "./lib/validation";
 import { log_error } from "./log";
 import { notify } from "./notifications";
-import router, { initSyncedStoreValues, setStoreValueFromUrl } from "./router";
+import router, { setStoreValuesFromURL, syncStoreValuesToURL } from "./router";
 import { initSidebar, updateSidebar } from "./sidebar";
 import { SortableTable } from "./sort";
 import { errorCount, favaOptions, ledgerData, rawLedgerData } from "./stores";
@@ -110,8 +110,8 @@ function init(): void {
   rawLedgerData.set(document.getElementById("ledger-data")?.innerHTML ?? "");
 
   router.init();
-  setStoreValueFromUrl();
-  initSyncedStoreValues();
+  setStoreValuesFromURL();
+  syncStoreValuesToURL();
   initSidebar();
   initGlobalKeyboardShortcuts();
   defineCustomElements();

--- a/frontend/src/router.ts
+++ b/frontend/src/router.ts
@@ -6,48 +6,28 @@
  */
 
 import type { Writable } from "svelte/store";
-import { get } from "svelte/store";
 
 import { delegate, Events } from "./lib/events";
 import { fetch, handleText } from "./lib/fetch";
+import { DEFAULT_INTERVAL, getInterval } from "./lib/interval";
 import { log_error } from "./log";
 import { notify } from "./notifications";
-import { conversion, favaOptions, interval, urlHash } from "./stores";
+import { conversion, interval, urlHash } from "./stores";
 import { showCharts } from "./stores/chart";
 import { account_filter, fql_filter, time_filter } from "./stores/filters";
 import { urlSyncedParams } from "./stores/url";
 
 /**
- *
- * Set a store's inital value from the URL
+ * Set a store's inital value from the URL.
  */
-function writeUrlValueToStore<T extends boolean | string>(
-  store: Writable<T>,
-  name: string,
-  defaultValue: T
-): void {
-  let value: T;
+export function setStoreValuesFromURL(): void {
   const params = new URL(window.location.href).searchParams;
-  if (typeof defaultValue === "boolean") {
-    value = (params.get(name) !== "false" && defaultValue) as T;
-  } else {
-    value = (params.get(name) as T) || defaultValue;
-  }
-  store.set(value);
-}
-
-/**
- * Set a store's inital value from the URL
- */
-export function setStoreValueFromUrl(): void {
-  const opts = get(favaOptions);
-
-  writeUrlValueToStore(account_filter, "account", "");
-  writeUrlValueToStore(fql_filter, "filter", "");
-  writeUrlValueToStore(time_filter, "time", "");
-  writeUrlValueToStore(interval, "interval", opts.interval);
-  writeUrlValueToStore(conversion, "conversion", opts.conversion);
-  writeUrlValueToStore(showCharts, "charts", true);
+  account_filter.set(params.get("account") ?? "");
+  fql_filter.set(params.get("filter") ?? "");
+  time_filter.set(params.get("time") ?? "");
+  interval.set(getInterval(params.get("interval")));
+  conversion.set(params.get("conversion") ?? "at_cost");
+  showCharts.set(params.get("charts") !== "false");
 }
 
 class Router extends Events<"page-loaded"> {
@@ -120,7 +100,7 @@ class Router extends Events<"page-loaded"> {
         window.location.search !== this.search
       ) {
         this.loadURL(window.location.href, false).catch(log_error);
-        setStoreValueFromUrl();
+        setStoreValuesFromURL();
       }
     });
 
@@ -271,7 +251,7 @@ export default router;
  *
  * Update and navigate to the URL on store changes.
  */
-function syncStoreValueToUrl<T extends boolean | string>(
+function syncToURL<T extends boolean | string>(
   store: Writable<T>,
   name: string,
   defaultValue: T,
@@ -280,7 +260,7 @@ function syncStoreValueToUrl<T extends boolean | string>(
   store.subscribe((val: T) => {
     const newURL = new URL(window.location.href);
     newURL.searchParams.set(name, val.toString());
-    if (val === defaultValue) {
+    if (val === "" || val === defaultValue) {
       newURL.searchParams.delete(name);
     }
     if (newURL.href !== window.location.href) {
@@ -290,15 +270,13 @@ function syncStoreValueToUrl<T extends boolean | string>(
 }
 
 /**
- * Update URL on store changes
+ * Update URL on store changes.
  */
-export function initSyncedStoreValues(): void {
-  const opts = get(favaOptions);
-
-  syncStoreValueToUrl(account_filter, "account", "");
-  syncStoreValueToUrl(fql_filter, "filter", "");
-  syncStoreValueToUrl(time_filter, "time", "");
-  syncStoreValueToUrl(interval, "interval", opts.interval);
-  syncStoreValueToUrl(conversion, "conversion", opts.conversion);
-  syncStoreValueToUrl(showCharts, "charts", true, false);
+export function syncStoreValuesToURL(): void {
+  syncToURL(account_filter, "account", "");
+  syncToURL(fql_filter, "filter", "");
+  syncToURL(time_filter, "time", "");
+  syncToURL(interval, "interval", DEFAULT_INTERVAL);
+  syncToURL(conversion, "conversion", "at_cost");
+  syncToURL(showCharts, "charts", true, false);
 }

--- a/frontend/src/stores/index.ts
+++ b/frontend/src/stores/index.ts
@@ -1,6 +1,8 @@
 import type { Readable, Writable } from "svelte/store";
 import { derived, writable } from "svelte/store";
 
+import type { Interval } from "../lib/interval";
+import { DEFAULT_INTERVAL } from "../lib/interval";
 import { derived_array } from "../lib/store";
 import {
   array,
@@ -15,8 +17,7 @@ import {
 export const urlHash = writable("");
 
 export const conversion = writable("");
-type Interval = "year" | "quarter" | "month" | "week" | "day";
-export const interval: Writable<Interval> = writable("month");
+export const interval: Writable<Interval> = writable(DEFAULT_INTERVAL);
 
 export const ledgerDataValidator = object({
   accounts: array(string),
@@ -26,9 +27,7 @@ export const ledgerDataValidator = object({
   favaOptions: object({
     "auto-reload": boolean,
     "currency-column": number,
-    conversion: string,
     indent: number,
-    interval: string,
     locale: union(string, constant(null)),
     "insert-entry": array(
       object({ date: string, filename: string, lineno: number, re: string })

--- a/pylintrc
+++ b/pylintrc
@@ -6,3 +6,7 @@ disable = too-few-public-methods,
     isinstance-second-argument-not-valid-type,
     unsubscriptable-object,
     inherit-non-class
+
+[DESIGN]
+# max args for a function / method
+max-args=7

--- a/src/fava/application.py
+++ b/src/fava/application.py
@@ -252,12 +252,8 @@ def _pull_beancount_file(_, values) -> None:
             # one of the file slugs changed, update the mapping
             update_ledger_slugs(app.config["LEDGERS"].values())
         g.ledger = app.config["LEDGERS"][g.beancount_file_slug]
-        g.conversion = request.args.get(
-            "conversion", g.ledger.fava_options["conversion"]
-        )
-        g.interval = Interval.get(
-            request.args.get("interval", g.ledger.fava_options["interval"])
-        )
+        g.conversion = request.args.get("conversion", "at_cost")
+        g.interval = Interval.get(request.args.get("interval", "month"))
 
 
 @app.errorhandler(FavaAPIException)

--- a/src/fava/core/fava_options.py
+++ b/src/fava/core/fava_options.py
@@ -45,7 +45,6 @@ DEFAULTS = {
     "currency-column": 61,
     "collapse-pattern": [],
     "auto-reload": False,
-    "conversion": "at_cost",
     "default-file": None,
     "default-page": "income_statement/",
     "fiscal-year-end": FiscalYearEnd(12, 31),
@@ -53,7 +52,6 @@ DEFAULTS = {
     "import-dirs": [],
     "indent": 2,
     "insert-entry": [],
-    "interval": "month",
     "invert-income-liabilities-equity": False,
     "journal-show": [
         "transaction",
@@ -105,10 +103,8 @@ LIST_OPTS = [
 
 STR_OPTS = [
     "collapse-pattern",
-    "conversion",
     "default-page",
     "import-config",
-    "interval",
     "language",
     "locale",
     "unrealized",

--- a/src/fava/help/options.md
+++ b/src/fava/help/options.md
@@ -3,7 +3,6 @@ following to your Beancount file.
 
 <pre><textarea is="beancount-textarea">
 2016-06-14 custom "fava-option" "default-file"
-2016-06-14 custom "fava-option" "interval" "week"
 2016-04-14 custom "fava-option" "auto-reload" "true"
 2016-04-14 custom "fava-option" "journal-show" "transaction open"
 2016-04-14 custom "fava-option" "currency-column" "100" </textarea></pre>
@@ -69,15 +68,6 @@ your beancount file into this option.
 
 ---
 
-## `interval`
-
-Default: `month`
-
-The default interval that charts and the account reports by interval use. The
-possible options are `day`, `week`, `month`, `quarter`, and `year`.
-
----
-
 ## `fiscal-year-end`
 
 Default: `12-31`
@@ -103,6 +93,8 @@ more examples.
 Default: 2.
 
 The number spaces for indentation.
+
+---
 
 ## `insert-entry`
 
@@ -272,27 +264,6 @@ page for details.
 Default: Not set
 
 Set the directories to be scanned by the Beancount import mechanism.
-
----
-
-## `conversion`
-
-Default: "at_cost"
-
-The default conversion that charts and the account reports use. This option
-takes a string representing the same values available in the conversion
-dropdown.
-
-Examples are:
-
--   `at_cost` - At Cost
--   `at_value` - At Market Value
--   `units` - Units
--   `USD` - Converted to USD
--   `EUR` - Converted to EUR
-
-If this option is not specified or the value is not valid (i.e., a non-existent
-commodity), Fava defaults to "At Cost"
 
 ---
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,5 @@
 # pylint: disable=missing-docstring
 import os
-from copy import deepcopy
 from pathlib import Path
 from pprint import pformat
 from typing import Any
@@ -24,8 +23,6 @@ EXAMPLE_FILE = data_file("long-example.beancount")
 EXTENSION_REPORT_EXAMPLE_FILE = data_file("extension-report-example.beancount")
 
 EXAMPLE_LEDGER = FavaLedger(EXAMPLE_FILE)
-EXAMPLE_LEDGER_OPTIONS = deepcopy(EXAMPLE_LEDGER.options)
-EXAMPLE_LEDGER_FAVA_OPTIONS = deepcopy(EXAMPLE_LEDGER.fava_options)
 
 fava_app.testing = True
 TEST_CLIENT = fava_app.test_client()
@@ -97,8 +94,6 @@ def small_example_ledger():
 @pytest.fixture
 def example_ledger():
     yield EXAMPLE_LEDGER
-    EXAMPLE_LEDGER.options = deepcopy(EXAMPLE_LEDGER_OPTIONS)
-    EXAMPLE_LEDGER.fava_options = deepcopy(EXAMPLE_LEDGER_FAVA_OPTIONS)
     EXAMPLE_LEDGER.filter(account=None, filter=None, time=None)
 
 

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -1,8 +1,9 @@
 """Tests for Fava's main Flask app."""
-import flask
 import pytest
 import werkzeug.routing
 import werkzeug.urls
+from flask import g
+from flask import url_for
 
 from fava.application import REPORTS
 from fava.application import static_url
@@ -26,7 +27,7 @@ def test_reports(app, test_client, report, filters):
     """The standard reports work without error (content isn't checked here)."""
     with app.test_request_context("/long-example/"):
         app.preprocess_request()
-        url = flask.url_for("report", report_name=report, **filters)
+        url = url_for("report", report_name=report, **filters)
 
     result = test_client.get(url)
     assert result.status_code == 200
@@ -38,7 +39,7 @@ def test_account_page(app, test_client, filters):
     for subreport in ["journal", "balances", "changes"]:
         with app.test_request_context("/long-example/"):
             app.preprocess_request()
-            url = flask.url_for(
+            url = url_for(
                 "account",
                 name="Assets:US:BofA:Checking",
                 subreport=subreport,
@@ -97,12 +98,14 @@ def test_urls(test_client, url, return_code):
         ),
     ],
 )
-def test_default_path_redirection(app, test_client, url, option, expect):
+def test_default_path_redirection(
+    app, test_client, url, option, expect, monkeypatch
+):
     """Test that default-page option redirects as expected."""
     with app.test_request_context("/long-example/"):
         app.preprocess_request()
         if option:
-            flask.g.ledger.fava_options["default-page"] = option
+            monkeypatch.setitem(g.ledger.fava_options, "default-page", option)
         result = test_client.get(url)
         get_url = result.headers.get("Location", "")
         expect_url = werkzeug.urls.url_join("http://localhost/", expect)
@@ -139,10 +142,10 @@ def test_help_ages(app, test_client):
     """Help pages."""
     with app.test_request_context("/long-example/"):
         app.preprocess_request()
-        url = flask.url_for("help_page", page_slug="filters")
+        url = url_for("help_page", page_slug="filters")
         result = test_client.get(url)
         assert result.status_code == 200
-        url = flask.url_for("help_page", page_slug="asdfasdf")
+        url = url_for("help_page", page_slug="asdfasdf")
         result = test_client.get(url)
         assert result.status_code == 404
 
@@ -151,7 +154,7 @@ def test_query_download(app, test_client):
     """Download query result."""
     with app.test_request_context("/long-example/"):
         app.preprocess_request()
-        url = flask.url_for(
+        url = url_for(
             "download_query", result_format="csv", query_string="balances"
         )
         result = test_client.get(url)
@@ -163,7 +166,7 @@ def test_incognito(app, test_client):
     app.config["INCOGNITO"] = True
     with app.test_request_context("/long-example/"):
         app.preprocess_request()
-        url = flask.url_for("report", report_name="balance_sheet")
+        url = url_for("report", report_name="balance_sheet")
 
     result = test_client.get(url)
     assert result.status_code == 200
@@ -176,7 +179,7 @@ def test_download_journal(app, test_client, snapshot) -> None:
     """The currently filtered journal can be downloaded."""
     with app.test_request_context("/long-example/"):
         app.preprocess_request()
-        url = flask.url_for("download_journal", time="2016-05-07")
+        url = url_for("download_journal", time="2016-05-07")
     result = test_client.get(url)
     snapshot(result.get_data(True))
     assert result.headers["Content-Disposition"].startswith(
@@ -199,10 +202,10 @@ def test_load_extension_reports(app, test_client):
     """Extension can register reports."""
     with app.test_request_context("/extension-report-beancount-file/"):
         app.preprocess_request()
-        assert flask.g.ledger.extensions.reports == [
+        assert g.ledger.extensions.reports == [
             ("PortfolioList", "Portfolio List")
         ]
 
-        url = flask.url_for("extension_report", report_name="PortfolioList")
+        url = url_for("extension_report", report_name="PortfolioList")
         result = test_client.get(url)
         assert result.status_code == 200

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -20,12 +20,12 @@ def test_attributes(example_ledger: FavaLedger) -> None:
     assert "Assets" not in example_ledger.attributes.accounts
 
 
-def test_paths_to_watch(example_ledger: FavaLedger) -> None:
+def test_paths_to_watch(example_ledger: FavaLedger, monkeypatch) -> None:
     assert example_ledger.paths_to_watch() == (
         [example_ledger.beancount_file_path],
         [],
     )
-    example_ledger.options["documents"] = ["folder"]
+    monkeypatch.setitem(example_ledger.options, "documents", ["folder"])
     base = Path(example_ledger.beancount_file_path).parent / "folder"
     assert example_ledger.paths_to_watch() == (
         [example_ledger.beancount_file_path],

--- a/tests/test_core_documents.py
+++ b/tests/test_core_documents.py
@@ -8,16 +8,16 @@ from fava.core.documents import is_document_or_import_file
 from fava.helpers import FavaAPIException
 
 
-def test_is_document_or_import_file(example_ledger):
-    example_ledger.fava_options["import-dirs"] = ["/test/"]
+def test_is_document_or_import_file(example_ledger, monkeypatch):
+    monkeypatch.setitem(example_ledger.fava_options, "import-dirs", ["/test/"])
     assert not is_document_or_import_file("/asdfasdf", example_ledger)
     assert not is_document_or_import_file("/test/../../err", example_ledger)
     assert is_document_or_import_file("/test/err/../err", example_ledger)
     assert is_document_or_import_file("/test/err/../err", example_ledger)
 
 
-def test_filepath_in_documents_folder(example_ledger):
-    example_ledger.options["documents"] = ["/test"]
+def test_filepath_in_documents_folder(example_ledger, monkeypatch):
+    monkeypatch.setitem(example_ledger.options, "documents", ["/test"])
 
     def _join(start: str, *args) -> str:
         return path.abspath(path.join(start, *args))

--- a/tests/test_core_fava_options.py
+++ b/tests/test_core_fava_options.py
@@ -9,14 +9,12 @@ from fava.core.fava_options import parse_options
 def test_fava_options(load_doc):
     """
     2016-06-14 custom "fava-option" "default-file"
-    2016-06-14 custom "fava-option" "interval" "week"
     2016-04-14 custom "fava-option" "show-closed-accounts" "true"
     2016-04-14 custom "fava-option" "journal-show" "transaction open"
     2016-04-14 custom "fava-option" "currency-column" "10"
     2016-04-14 custom "fava-option" "indent" "4"
     2016-04-14 custom "fava-option" "insert-entry" "Ausgaben:Test"
     2016-04-14 custom "fava-option" "invalid"
-    2016-06-14 custom "fava-option" "conversion" "USD"
     """
 
     entries, _, _ = load_doc
@@ -25,16 +23,14 @@ def test_fava_options(load_doc):
     assert len(errors) == 1
 
     assert options["indent"] == 4
-    assert options["interval"] == "week"
     assert options["insert-entry"] == [
         InsertEntryOption(
             datetime.date(2016, 4, 14),
             re.compile("Ausgaben:Test"),
             "<string>",
-            8,
+            7,
         )
     ]
     assert options["show-closed-accounts"]
     assert options["journal-show"] == ["transaction", "open"]
     assert options["currency-column"] == 10
-    assert options["conversion"] == "USD"

--- a/tests/test_core_number.py
+++ b/tests/test_core_number.py
@@ -10,17 +10,17 @@ def test_format_decimal(example_ledger):
     assert fmt(D("12.333"), None) == "12.33"
 
 
-def test_format_decimal_locale(example_ledger):
+def test_format_decimal_locale(example_ledger, monkeypatch):
     fmt = example_ledger.format_decimal
-    example_ledger.fava_options["locale"] = "en_IN"
+    monkeypatch.setitem(example_ledger.fava_options, "locale", "en_IN")
     fmt.load_file()
     assert fmt(D("1111111.333"), "USD") == "11,11,111.33"
     assert fmt(D("11.333"), "USD") == "11.33"
     assert fmt(D("11.3333"), None) == "11.33"
-    example_ledger.fava_options["locale"] = "de_DE"
+    monkeypatch.setitem(example_ledger.fava_options, "locale", "de_DE")
     fmt.load_file()
     assert fmt(D("1111111.333"), "USD") == "1.111.111,33"
-    example_ledger.fava_options["locale"] = "invalid"
+    monkeypatch.setitem(example_ledger.fava_options, "locale", "invalid")
     fmt.load_file()
     assert fmt(D("1111111.333"), "USD") == "1111111.33"
     fmt.load_file()

--- a/tests/test_json_api.py
+++ b/tests/test_json_api.py
@@ -5,8 +5,9 @@ from pathlib import Path
 from typing import Any
 from typing import Optional
 
-import flask
 import pytest
+from flask import g
+from flask import url_for
 
 from fava.core.charts import dumps
 from fava.core.misc import align
@@ -31,23 +32,23 @@ def assert_api_success(response, data: Optional[Any] = None) -> None:
 def test_api_changed(app, test_client) -> None:
     with app.test_request_context("/long-example/"):
         app.preprocess_request()
-        url = flask.url_for("json_api.changed")
+        url = url_for("json_api.changed")
 
     response = test_client.get(url)
     assert_api_success(response, False)
 
 
-def test_api_add_document(app, test_client, tmp_path) -> None:
+def test_api_add_document(app, test_client, tmp_path, monkeypatch) -> None:
     with app.test_request_context("/long-example/"):
         app.preprocess_request()
-        old_documents = flask.g.ledger.options["documents"]
-        flask.g.ledger.options["documents"] = [str(tmp_path)]
+
+        monkeypatch.setitem(g.ledger.options, "documents", [str(tmp_path)])
         request_data = {
             "folder": str(tmp_path),
             "account": "Expenses:Food:Restaurant",
             "file": (BytesIO(b"asdfasdf"), "2015-12-12 test"),
         }
-        url = flask.url_for("json_api.add_document")
+        url = url_for("json_api.add_document")
 
         response = test_client.put(url)
         assert response.status_code == 400
@@ -63,13 +64,12 @@ def test_api_add_document(app, test_client, tmp_path) -> None:
         request_data["file"] = (BytesIO(b"asdfasdf"), "2015-12-12 test")
         response = test_client.put(url, data=request_data)
         assert_api_error(response, f"{filename} already exists.")
-        flask.g.ledger.options["documents"] = old_documents
 
 
 def test_api_errors(app, test_client) -> None:
     with app.test_request_context("/long-example/"):
         app.preprocess_request()
-        url = flask.url_for("json_api.errors")
+        url = url_for("json_api.errors")
 
     response = test_client.get(url)
     assert_api_success(response, 0)
@@ -78,7 +78,7 @@ def test_api_errors(app, test_client) -> None:
 def test_api_payee_accounts(app, test_client) -> None:
     with app.test_request_context("/long-example/"):
         app.preprocess_request()
-        url = flask.url_for("json_api.payee_accounts", payee="test")
+        url = url_for("json_api.payee_accounts", payee="test")
 
     response = test_client.get(url)
     assert_api_success(response, [])
@@ -87,7 +87,7 @@ def test_api_payee_accounts(app, test_client) -> None:
 def test_api_move(app, test_client) -> None:
     with app.test_request_context("/long-example/"):
         app.preprocess_request()
-        url = flask.url_for("json_api.move")
+        url = url_for("json_api.move")
 
     response = test_client.get(url)
     assert_api_error(response)
@@ -96,8 +96,8 @@ def test_api_move(app, test_client) -> None:
 def test_api_source_put(app, test_client) -> None:
     with app.test_request_context("/long-example/"):
         app.preprocess_request()
-        url = flask.url_for("json_api.source")
-        path = flask.g.ledger.beancount_file_path
+        url = url_for("json_api.source")
+        path = g.ledger.beancount_file_path
 
     # test bad request
     response = test_client.put(url)
@@ -139,8 +139,8 @@ def test_api_source_put(app, test_client) -> None:
 def test_api_format_source(app, test_client) -> None:
     with app.test_request_context("/long-example/"):
         app.preprocess_request()
-        url = flask.url_for("json_api.format_source")
-        path = flask.g.ledger.beancount_file_path
+        url = url_for("json_api.format_source")
+        path = g.ledger.beancount_file_path
 
     payload = open(path, encoding="utf-8").read()
 
@@ -152,15 +152,15 @@ def test_api_format_source(app, test_client) -> None:
     assert_api_success(response, align(payload, 61))
 
 
-def test_api_format_source_options(app, test_client) -> None:
+def test_api_format_source_options(app, test_client, monkeypatch) -> None:
     with app.test_request_context("/long-example/"):
         app.preprocess_request()
-        path = flask.g.ledger.beancount_file_path
+        path = g.ledger.beancount_file_path
         payload = open(path, encoding="utf-8").read()
 
-        url = flask.url_for("json_api.format_source")
-        old_currency_column = flask.g.ledger.fava_options["currency-column"]
-        flask.g.ledger.fava_options["currency-column"] = 90
+        url = url_for("json_api.format_source")
+
+        monkeypatch.setitem(g.ledger.fava_options, "currency-column", 90)
 
         response = test_client.put(
             url,
@@ -169,16 +169,13 @@ def test_api_format_source_options(app, test_client) -> None:
         )
         assert_api_success(response, align(payload, 90))
 
-        flask.g.ledger.fava_options["currency-column"] = old_currency_column
 
-
-def test_api_add_entries(app, test_client, tmp_path):
+def test_api_add_entries(app, test_client, tmp_path, monkeypatch):
     with app.test_request_context("/long-example/"):
         app.preprocess_request()
-        old_beancount_file = flask.g.ledger.beancount_file_path
         test_file = tmp_path / "test_file"
         test_file.open("a")
-        flask.g.ledger.beancount_file_path = str(test_file)
+        monkeypatch.setattr(g.ledger, "beancount_file_path", str(test_file))
 
         data = {
             "entries": [
@@ -229,7 +226,7 @@ def test_api_add_entries(app, test_client, tmp_path):
                 },
             ]
         }
-        url = flask.url_for("json_api.add_entries")
+        url = url_for("json_api.add_entries")
 
         response = test_client.put(
             url, data=dumps(data), content_type="application/json"
@@ -253,8 +250,6 @@ def test_api_add_entries(app, test_client, tmp_path):
 """
         )
 
-        flask.g.ledger.beancount_file_path = old_beancount_file
-
 
 @pytest.mark.parametrize(
     "query_string,result_str",
@@ -267,7 +262,7 @@ def test_api_add_entries(app, test_client, tmp_path):
 def test_api_query_result(query_string, result_str, app, test_client) -> None:
     with app.test_request_context("/long-example/"):
         app.preprocess_request()
-        url = flask.url_for("json_api.query_result", query_string=query_string)
+        url = url_for("json_api.query_result", query_string=query_string)
 
     response = test_client.get(url)
     assert response.status_code == 200

--- a/tests/test_template_filters.py
+++ b/tests/test_template_filters.py
@@ -77,13 +77,18 @@ def test_format_errormsg(app):
         assert format_errormsg("Test: Test") == "Test: Test"
 
 
-def test_collapse_account(app):
+def test_collapse_account(app, monkeypatch):
     with app.test_request_context("/long-example/"):
         app.preprocess_request()
-        g.ledger.fava_options["collapse-pattern"] = [
-            "^Assets:Stock$",
-            "^Assets:Property:.*",
-        ]
+
+        monkeypatch.setitem(
+            g.ledger.fava_options,
+            "collapse-pattern",
+            [
+                "^Assets:Stock$",
+                "^Assets:Property:.*",
+            ],
+        )
         g.ledger.accounts["Assets:Stock"] = AccountData()
         g.ledger.accounts["Assets:Property"] = AccountData()
 


### PR DESCRIPTION
Since the new `default-page` option allows one to achieve the same and is simpler to handle, remove these options.

Also make the tests a bit simpler and more robust by using monkeypatch to set options in the tests.