### PR TITLE
Sort all fields containing value

### DIFF
--- a/src/fava/templates/_query_table.html
+++ b/src/fava/templates/_query_table.html
@@ -55,7 +55,7 @@
   <thead>
     <tr>
       {% for name, type in types %}
-      <th data-sort="{{ sort_type[type|string] or "string" }}">{{ name }}</th>
+      <th data-sort="{% if '_value' in name %}num{% else %}{{ sort_type[type|string] or 'string' }}{% endif %}">{{ name }}</th>
       {% endfor %}
     </tr>
   </thead>


### PR DESCRIPTION
Closes #1256

See linked issue. Tried to make approach as generic as possible, thus checking whether `_value` is included in field name.

A chain like `{{ sort_type[type|string] or sort_type[name|string] or 'string' }}` would also be possible, but requires explicit definition of field names that should be converted to `num` to be defined in `sort_type` dict.