### PR TITLE
Use steps instead of linear interpolation in line and bar charts

### DIFF
--- a/frontend/src/charts/LineChart.svelte
+++ b/frontend/src/charts/LineChart.svelte
@@ -3,7 +3,7 @@
   import { axisBottom, axisLeft } from "d3-axis";
   import { quadtree } from "d3-quadtree";
   import { scaleLinear, scaleUtc } from "d3-scale";
-  import { area, line } from "d3-shape";
+  import { area, line, curveStepAfter } from "d3-shape";
   import { getContext } from "svelte";
   import type { Writable } from "svelte/store";
 
@@ -63,12 +63,14 @@
 
   $: lineShape = line<LineChartDatum>()
     .x((d) => x(d.date))
-    .y((d) => y(d.value));
+    .y((d) => y(d.value))
+    .curve(curveStepAfter);
 
   $: areaShape = area<LineChartDatum>()
     .x((d) => x(d.date))
     .y1((d) => y(d.value))
-    .y0(Math.min(innerHeight, y(0)));
+    .y0(Math.min(innerHeight, y(0)))
+    .curve(curveStepAfter);
 
   // Axes
   $: xAxis = axisBottom(x).tickSizeOuter(0);


### PR DESCRIPTION
Currently, line and bar charts in Fava can be confusing because values are linearly interpolated between each sample. This makes many of the charts difficult for me to read, as the line location is wrong on most dates.

With this pull request, I am suggesting to change from this:
<img width="1042" alt="Screen Shot 2021-05-11 at 10 20 57 PM" src="https://user-images.githubusercontent.com/14618/117922641-a73ce300-b2a7-11eb-9fcf-1957df6f69aa.png">

To this:
<img width="1042" alt="Screen Shot 2021-05-11 at 10 21 20 PM" src="https://user-images.githubusercontent.com/14618/117922663-ad32c400-b2a7-11eb-9217-0537e9a256e6.png">

I appreciate your consideration of this pull request. :)

Jeff