### PR TITLE
Pin Flask, Jinja2 major versions

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -43,14 +43,15 @@ install_requires =
     Babel>=2.6.0
     cheroot
     Flask-Babel>=1.0.0
-    Flask>=0.10.1,<2
-    Jinja2>=2.10,<3
+    Flask>=0.10.1,<2 # See #1266
+    Jinja2>=2.10,<3 # See #1266
     beancount>=2.3.0
     click
     markdown2>=2.3.0
     ply
     simplejson>=3.2.0
-    Werkzeug>=0.15.0
+    Werkzeug>=0.15.0,<2 # See #1266
+    MarkupSafe<2 # See #1266
 
 [options.entry_points]
 console_scripts =

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,8 +43,8 @@ install_requires =
     Babel>=2.6.0
     cheroot
     Flask-Babel>=1.0.0
-    Flask>=0.10.1
-    Jinja2>=2.10
+    Flask>=0.10.1,<2
+    Jinja2>=2.10,<3
     beancount>=2.3.0
     click
     markdown2>=2.3.0


### PR DESCRIPTION
Fava is currently incompatible with recent major releases of Flask
(2.0.0) and Jinja2 (3.0.0), crashing with an error like:

```
Traceback (most recent call last):
  File "/home/foo/./venv/bin/fava", line 5, in <module>
    from fava.cli import main
  File "/home/foo/venv/lib/python3.9/site-packages/fava/cli.py", line 11, in <module>
    from fava.application import app
  File "/home/foo/venv/lib/python3.9/site-packages/fava/application.py", line 67, in <module>
    app.jinja_options["extensions"].append("jinja2.ext.do")
KeyError: 'extensions'
```

This change pins Flask and Jinja2 to the previous major versions until
upgrading can be coordinated.

Closes #1266