### PR TITLE
Ignore file extension case for document preview

### DIFF
--- a/frontend/src/documents/DocumentPreview.svelte
+++ b/frontend/src/documents/DocumentPreview.svelte
@@ -19,7 +19,7 @@
 
   export let filename: string;
 
-  $: extension = ext(filename);
+  $: extension = ext(filename).toLowerCase();
   $: url = `${$baseURL}document/?filename=${filename}`;
 </script>
 


### PR DESCRIPTION
Previously, .CSV files were not rendered while .csv files were. This patch removes the case-sensitivity, so both .csv and .CSV files are rendered as expected.