### PR TITLE
Support rendering qfx documents in editor

### DIFF
--- a/frontend/src/documents/DocumentPreview.svelte
+++ b/frontend/src/documents/DocumentPreview.svelte
@@ -1,4 +1,5 @@
 <script lang="ts" context="module">
+  const plainTextExtensions = ["csv", "txt", "qfx"];
   const imageExtensions = [
     "gif",
     "jpg",
@@ -25,7 +26,7 @@
 
 {#if extension === "pdf"}
   <object title={filename} data={url} />
-{:else if ["csv", "txt", "qfx"].includes(extension)}
+{:else if plainTextExtensions.includes(extension)}
   {#await fetch(url).then(handleText)}
     Loading...
   {:then value}

--- a/frontend/src/documents/DocumentPreview.svelte
+++ b/frontend/src/documents/DocumentPreview.svelte
@@ -25,7 +25,7 @@
 
 {#if extension === "pdf"}
   <object title={filename} data={url} />
-{:else if ["csv", "txt"].includes(extension)}
+{:else if ["csv", "txt", "qfx"].includes(extension)}
   {#await fetch(url).then(handleText)}
     Loading...
   {:then value}


### PR DESCRIPTION
`.qfx` files are plain-text, and therefore can be viewed in the document editor just like `.csv` and `.txt`.