### PR TITLE
Support for <Enter> and <Escape> in rename dialog

### DIFF
--- a/frontend/src/AutocompleteInput.svelte
+++ b/frontend/src/AutocompleteInput.svelte
@@ -74,6 +74,9 @@
     } else if (event.key === " " && event.ctrlKey) {
       hidden = false;
     } else if (event.key === "Escape") {
+      if (!hidden && filteredSuggestions.length > 0) {
+        event.stopPropagation();
+      }
       hidden = true;
     } else if (event.key === "ArrowUp") {
       event.preventDefault();

--- a/frontend/src/documents/Documents.svelte
+++ b/frontend/src/documents/Documents.svelte
@@ -29,7 +29,7 @@
    * Rename the selected document with <F2>.
    */
   function keyup(ev: KeyboardEvent) {
-    if (ev.key === "F2" && selected) {
+    if (ev.key === "F2" && selected && !moving) {
       moving = { ...selected, newName: basename(selected.filename) };
     }
   }
@@ -53,15 +53,15 @@
       moving = null;
     }}
   >
-    <div>
+    <form on:submit|preventDefault={move}>
       <h3>{_("Move or rename document")}</h3>
       <p><code>{moving.filename}</code></p>
       <p>
         <AccountInput bind:value={moving.account} />
         <input size={40} bind:value={moving.newName} />
-        <button type="button" on:click={move}>{"Move"}</button>
+        <button type="submit">{"Move"}</button>
       </p>
-    </div>
+    </form>
   </ModalBase>
 {/if}
 <div class="fixed-fullsize-container">

--- a/frontend/src/modals/ModalBase.svelte
+++ b/frontend/src/modals/ModalBase.svelte
@@ -25,6 +25,9 @@
           ev.preventDefault();
           attemptFocus(first);
         }
+      } else if (ev.key === "Escape") {
+        ev.preventDefault();
+        closeHandler();
       }
     }
     document.addEventListener("keydown", keydown);
@@ -43,11 +46,8 @@
     <div class="background" on:click={closeHandler} aria-hidden="true" />
     <div class="content" use:handleFocus role="dialog" aria-modal="true">
       <slot />
-      <button
-        type="button"
-        class="muted close"
-        on:click={closeHandler}
-        use:keyboardShortcut={"Escape"}>x</button
+      <button type="button" class="muted close" on:click={closeHandler}
+        >x</button
       >
     </div>
   </div>


### PR DESCRIPTION
This commit adds support for `<Enter>` to submit the rename modal dialog, and for `<Escape>` to exit it.