### PR TITLE
Fix Ctrl-S keybinding in #1264

### DIFF
--- a/frontend/src/editor/SliceEditor.svelte
+++ b/frontend/src/editor/SliceEditor.svelte
@@ -16,7 +16,16 @@
     changed = true;
   };
 
-  const [editor, useEditor] = initBeancountEditor(slice, onDocChanges, []);
+  const [editor, useEditor] = initBeancountEditor(slice, onDocChanges, [
+      {
+        key: "Control-s",
+        mac: "Meta-s",
+        run: () => {
+          save(editor);
+          return true;
+        }
+      }
+    ]);
 
   let saving = false;
 


### PR DESCRIPTION
The previous fix wasn't applied to SliceEditor. I copied @yagebu's fix to SliceEditor too and it fixed the issue for me.