### PR TITLE
Fix minor bugs in treemap charts

### DIFF
--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -51,7 +51,6 @@
   --color-budget-negative: #af3d3d;
   --color-budget-positive: #3daf46;
   --color-budget-zero: #ffb900;
-  --color-treemap-text: #fff;
   --color-chart-axis: #999;
   --color-editor-comment: #998;
   --color-editor-trailing-whitespace: rgba(255, 199, 199, 0.5);

--- a/frontend/src/charts/Treemap.svelte
+++ b/frontend/src/charts/Treemap.svelte
@@ -17,7 +17,7 @@
 
   $: height = Math.min(width / 2.5, 400);
 
-  const tree = treemap<AccountHierarchyDatum>().paddingInner(1);
+  const tree = treemap<AccountHierarchyDatum>().paddingInner(2).round(true);
   $: root = tree.size([width, height])(data);
   $: leaves = root.leaves().filter((d) => d.value);
 
@@ -38,14 +38,14 @@
     )})<em>${d.data.account}</em>`;
   }
 
-  function setOpacity(
+  function setVisibility(
     node: SVGTextElement,
     param: HierarchyRectangularNode<AccountHierarchyDatum>
   ) {
     function update(d: HierarchyRectangularNode<AccountHierarchyDatum>) {
       const length = node.getComputedTextLength();
-      node.style.opacity =
-        d.x1 - d.x0 > length + 4 && d.y1 - d.y0 > 14 ? "1" : "0";
+      node.style.visibility =
+        d.x1 - d.x0 > length + 4 && d.y1 - d.y0 > 14 ? "visible" : "hidden";
     }
     update(param);
     return { update };
@@ -60,7 +60,7 @@
     >
       <rect fill={fill(d)} width={d.x1 - d.x0} height={d.y1 - d.y0} />
       <text
-        use:setOpacity={d}
+        use:setVisibility={d}
         on:click={() => router.navigate(urlFor(`account/${d.data.account}/`))}
         dy=".5em"
         x={(d.x1 - d.x0) / 2}
@@ -76,11 +76,6 @@
 <style>
   svg {
     shape-rendering: crispEdges;
-  }
-
-  rect {
-    stroke: var(--color-treemap-text);
-    stroke-width: 2px;
   }
 
   text {


### PR DESCRIPTION
I am fixing two bugs in the treemap viewer with this commit.

The first bug is with tooltip rendering. The existing code uses the `opacity` property to hide text when it is too small to fit, but because the text is still present (just invisible to the user), the tooltip still renders over the entire invisible area of the text. Instead, it should render based on the rectangle region, not the invisible text. The fix for this is simple, change `opacity` to `visibility`.

<img width="108" alt="Screen Shot 2021-05-22 at 3 52 37 PM" src="https://user-images.githubusercontent.com/14618/119242853-4e2a4600-bb16-11eb-9c0e-2a7acade818a.png">

In the above image, the tooltip is showing the text for the thin rectangle on the right, which is an error.

The second bug is caused by the use of strokes on each rectangle. The total height of the columns sometimes varies, so that one column will be an extra pixel taller, as seen on the following image:

<img width="133" alt="Screen Shot 2021-05-22 at 3 52 49 PM" src="https://user-images.githubusercontent.com/14618/119242886-829e0200-bb16-11eb-9556-475ef94cfef9.png">

To resolve this, I use `paddingInternal` to create padding, instead of a stroke. I guess the variable `--color-treemap-text` was originally meant for a different purpose (`text`), but was now being used for the white stroke color. I've removed it.