### PR TITLE
Add non-periodic budgets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /.coverage
 /.eggs
 /.tox
+/.vscode
 /.idea/
 /build/
 /pip-wheel-metadata/
@@ -13,6 +14,7 @@
 /src/fava.egg-info
 /htmlcov
 /venv
+/.venv
 
 node_modules
 *.pyc


### PR DESCRIPTION
Current budgets in fava are great, but have their limits. Specifically, it's not possible for the same category to have overlapping budgets either for different intervals. This is obviously an conscious choice, but this PR attempts to add this capability (to an extent), while maintaining backward compatibility and staying true to fava's budget implementation.

Case in point: I have 2 dogs, and I'm buying them food, which is a great candidate for a monthly budget of the `Expenses:Pets` account. I also have a vet subscription for them, which I renew annually, and would like to budget as well. Currently, fava leaves me with 3 options to deal with this:
1. Create separate sub-accounts - `Expenses:Pets:Food` and `Expenses:Pets:Vet`. Workable in this case, but I can see this getting out of hand:
   ```
   2021-01-01 custom "budget" "Expenses:Pets:Food" "monthly" 100 USD
   2021-06-01 custom "budget" "Expenses:Pets:Vet "yearly" 800 USD
   ```
2. Create an annual budget that's the sum of the expected vet charge + 12 times the monthly expected expense on food. This will work fine for annual views, but will be inaccurately represented in monthly views:
   ```
   2021-01-01 custom "budget" "Expenses:Pets "yearly" 12*100 + 800 USD
   ```
3. Create an extra budget entry for the month on which the vet subscription is renewed. With the current implementation, the user has to calculate the sum of the vet subscription and the food expense for that entry, and add another entry for the next month to reset the budget for food expenses only. Too complicated:
   ```
   2021-01-01 custom "budget" "Expenses:Pets" "monthly" 100 USD
   2021-06-01 custom "budget" "Expenses:Pets" "monthly" 100 + 800 USD
   2021-07-01 custom "budget" "Expenses:Pets" "monthly" 100 USD
   ```

My solution is to introduce  non-periodic budgets. Unlike the regular budgets in fava, these non-periodic budgets are only applied to the period from their start date to the date of the next interval. Furthermore, they are applied on top of the existing budgets (both periodic  and non-periodic), so one-time expenses can be budgeted for without fidgeting with the rest of the budget for the same account:
   ```
   2021-01-01 custom "budget" "Expenses:Pets" "monthly" 100 USD
   2021-06-01 custom "budget" "Expenses:Pets "month" 800 USD
   ```
This will budget 100 USD monthly, and in June the budget will be upped by 800 USD for a single month.

For now, I chose to use `day`, `week`, etc. (in place of `daily`, `weekly`, etc.) to differentiate non-periodic budgets from their periodic counterparts. I'm open to suggestions regarding different naming, or use of an extra argument to the budget entry.