### PR TITLE
Dockerfile: do not pass environment variables to command-line

### DIFF
--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -7,7 +7,6 @@ FROM python:alpine
 
 COPY --from=builder /install /usr/local
 
-ENV BEANCOUNT_FILE ""
-ENV FAVA_OPTIONS ""
+ENV FAVA_HOST "0.0.0.0"
 EXPOSE 5000
-CMD fava --host 0.0.0.0 $FAVA_OPTIONS $BEANCOUNT_FILE
+CMD fava


### PR DESCRIPTION
Since `BEANCOUNT_FILE` (`BEANCOUNT_FILES` as well) and `FAVA_`-prefixed
environment variables will be used, passing them in command-line only creates
duplicates.