### PR TITLE
Ellipsize long narration entries in the journal

### DIFF
--- a/frontend/css/journal-table.css
+++ b/frontend/css/journal-table.css
@@ -159,18 +159,23 @@
 }
 
 .journal .description {
-  display: flex;
   flex: 1;
-  align-items: center;
   padding-left: 8px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
-.journal .description .separator {
-  width: 4px;
-  height: 4px;
+.journal .show-postings .description {
+  white-space: normal;
+}
+
+.journal .description .separator::before {
   padding: 2px;
   margin: 0 6px;
-  background-color: var(--color-text-lighter);
+  font-weight: bold;
+  color: var(--color-text-lighter);
+  content: "•";
 }
 
 .journal .description .num {

--- a/src/fava/templates/_journal_table.html
+++ b/src/fava/templates/_journal_table.html
@@ -146,7 +146,7 @@
             accumulated <span class="num">{{ (entry.amount.number + entry.diff_amount.number)|format_currency(entry.amount.currency, show_if_zero=True) }} {{ entry.amount.currency }}</span>
             {% endif %}
         {% elif type == 'transaction' %}
-            <strong class="payee">{{ entry.payee or '' }}</strong>{% if entry.payee and entry.narration %}<span class="separator"></span> {% endif %}{{ entry.narration or '' }}
+            <strong class="payee">{{ entry.payee or '' }}</strong>{% if entry.payee and entry.narration %}<span class="separator"></span>{% endif %}{{ entry.narration or '' }}
             {{ render_tags_links(entry) }}
         {% endif %}
         </span>


### PR DESCRIPTION
This patch makes all entries in the journal table consistently one line high, and if the payee + narration (+ tags + links) is too long to fit on one line, it is cut off with an ellipsis.  The full narration can be displayed by clicking to show postings/metadata or by clicking the date to show the entry source.