### PR TITLE
Make sidebar query links fill in the full query

### DIFF
--- a/src/fava/templates/_aside.html
+++ b/src/fava/templates/_aside.html
@@ -20,7 +20,7 @@
     {% if id == 'query' and user_queries %}
     <ul class="submenu">
       {% for query in user_queries %}
-      <li><a{% if query.name == name %} class="selected"{% endif %} href="{{ url_for('report', report_name='query', query_string='run "{}"'.format(query.name)) }}">{{ query.name|truncate(25, True, ' …') }}</a></li>
+      <li><a{% if query.name == name %} class="selected"{% endif %} href="{{ url_for('report', report_name='query', query_string=query.query_string) }}">{{ query.name|truncate(25, True, ' …') }}</a></li>
       {% endfor %}
     </ul>
     {% elif id == 'editor' %}


### PR DESCRIPTION
It's handier to fill in the full query instead of `run <queryname>` so the user can see what the query was and edit it.