### PR TITLE
ext: define hooks in base class and use explicitly

### DIFF
--- a/src/fava/core/file.py
+++ b/src/fava/core/file.py
@@ -108,7 +108,7 @@ class FileModule(FavaModule):
             with open(path, "w+b") as file:
                 file.write(contents)
 
-            self.ledger.extensions.run_hook("after_write_source", path, source)
+            self.ledger.extensions.after_write_source(path, source)
             self.ledger.load_file()
 
             return sha256(contents).hexdigest()
@@ -132,9 +132,7 @@ class FileModule(FavaModule):
                 key,
                 value,
             )
-            self.ledger.extensions.run_hook(
-                "after_insert_metadata", entry, key, value
-            )
+            self.ledger.extensions.after_insert_metadata(entry, key, value)
 
     def save_entry_slice(
         self, entry_hash: str, source_slice: str, sha256sum: str
@@ -142,7 +140,7 @@ class FileModule(FavaModule):
         """Save slice of the source file for an entry.
 
         Args:
-            entry: An entry.
+            entry_hash: An entry.
             source_slice: The lines that the entry should be replaced with.
             sha256sum: The sha256sum of the current lines of the entry.
 
@@ -154,11 +152,7 @@ class FileModule(FavaModule):
         with self.lock:
             entry = self.ledger.get_entry(entry_hash)
             ret = save_entry_slice(entry, source_slice, sha256sum)
-
-            self.ledger.extensions.run_hook(
-                "after_entry_modified", entry, source_slice
-            )
-
+            self.ledger.extensions.after_entry_modified(entry, source_slice)
             return ret
 
     def insert_entries(self, entries: Entries) -> None:
@@ -181,7 +175,7 @@ class FileModule(FavaModule):
                     currency_column,
                     indent,
                 )
-                self.ledger.extensions.run_hook("after_insert_entry", entry)
+                self.ledger.extensions.after_insert_entry(entry)
 
     def render_entries(self, entries: Entries) -> Generator[str, None, None]:
         """Return entries in Beancount format.

--- a/src/fava/ext/__init__.py
+++ b/src/fava/ext/__init__.py
@@ -10,6 +10,8 @@ from typing import Tuple
 from typing import Type
 from typing import TYPE_CHECKING
 
+from beancount.core.data import Directive
+
 from fava.helpers import BeancountError
 
 if TYPE_CHECKING:
@@ -49,15 +51,19 @@ class FavaExtensionBase:
             self.config = None
         self.name = self.__class__.__qualname__
 
-    def run_hook(self, event: str, *args: Any) -> None:
-        """Run a hook.
+    def after_entry_modified(self, entry: Directive, new_lines: str) -> None:
+        """Called after an `entry` has been modified."""
 
-        Args:
-            event: One of the possible events.
-        """
-        handler = getattr(self, event, None)
-        if handler is not None:
-            handler(*args)
+    def after_insert_entry(self, entry: Directive) -> None:
+        """Called after an `entry` has been inserted."""
+
+    def after_insert_metadata(
+        self, entry: Directive, key: str, value: str
+    ) -> None:
+        """Called after metadata (key: value) was added to an entry."""
+
+    def after_write_source(self, path: str, source: str) -> None:
+        """Called after `source` has been written to path."""
 
 
 def find_extensions(

--- a/src/fava/help/extensions.md
+++ b/src/fava/help/extensions.md
@@ -64,7 +64,7 @@ Called after an `entry` has been inserted.
 
 ---
 
-### `after_entry_modified(entry: str, new_lines: str)`
+### `after_entry_modified(entry: Directive, new_lines: str)`
 
 Called after an `entry` has been modified, e.g., via the context popup.
 

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -10,3 +10,5 @@ def test_report_page_globals():
     )
     result = extension_report_ledger.extensions.reports
     assert result == [("PortfolioList", "Portfolio List")]
+
+    extension_report_ledger.extensions.after_write_source("test", "test")


### PR DESCRIPTION
While this adds some duplicate code, this allows for better typing of
these hooks and their arguments in both the extensions themselves as
well as in the code using the hooks.