### PR TITLE
Add before_insert_entry hook

### DIFF
--- a/src/fava/core/extensions.py
+++ b/src/fava/core/extensions.py
@@ -93,6 +93,10 @@ class ExtensionModule(FavaModule):
         for ext in self.exts_for_hook("after_entry_modified"):
             ext.after_entry_modified(entry, new_lines)
 
+    def before_insert_entry(self, entry: Directive) -> None:
+        for ext in self.exts_for_hook("before_insert_entry"):
+            ext.before_insert_entry(entry)
+
     def after_insert_entry(self, entry: Directive) -> None:
         for ext in self.exts_for_hook("after_insert_entry"):
             ext.after_insert_entry(entry)

--- a/src/fava/core/file.py
+++ b/src/fava/core/file.py
@@ -168,6 +168,7 @@ class FileModule(FavaModule):
                 insert_options = fava_options["insert-entry"]
                 currency_column = fava_options["currency-column"]
                 indent = fava_options["indent"]
+                self.ledger.extensions.before_insert_entry(entry)
                 fava_options["insert-entry"] = insert_entry(
                     entry,
                     self.ledger.beancount_file_path,

--- a/src/fava/ext/__init__.py
+++ b/src/fava/ext/__init__.py
@@ -51,6 +51,9 @@ class FavaExtensionBase:
             self.config = None
         self.name = self.__class__.__qualname__
 
+    def before_insert_entry(self, entry: Directive) -> None:
+        """Called before an `entry` is inserted."""
+
     def after_entry_modified(self, entry: Directive, new_lines: str) -> None:
         """Called after an `entry` has been modified."""
 

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -12,3 +12,14 @@ def test_report_page_globals():
     assert result == [("PortfolioList", "Portfolio List")]
 
     extension_report_ledger.extensions.after_write_source("test", "test")
+
+
+def test_before_insert_entry():
+    """Extensions provide a before_insert_entry hook method."""
+    hook_ledger = FavaLedger(
+        data_file("extension-report-example.beancount")
+    )
+
+    assert bool(getattr(hook_ledger.extensions, "before_insert_entry"))
+
+    hook_ledger.extensions.before_insert_entry("entry")


### PR DESCRIPTION
This PR provides a hook to process an entry before it is inserted. Extension use cases:
  1. validate/format entry prior to insertion
  2. switch file which stores the entry
  3. etc.

