### PR TITLE
Documents directory structure

### DIFF
--- a/src/fava/core/fava_options.py
+++ b/src/fava/core/fava_options.py
@@ -52,6 +52,7 @@ FavaOptions = TypedDict(
         "auto-reload": bool,
         "default-file": Optional[str],
         "default-page": str,
+        "documents-directory-structure": str,
         "fiscal-year-end": FiscalYearEnd,
         "import-config": Optional[str],
         "import-dirs": List[str],
@@ -82,6 +83,7 @@ DEFAULTS: FavaOptions = {
     "auto-reload": False,
     "default-file": None,
     "default-page": "income_statement/",
+    "documents-directory-structure": "by-account",
     "fiscal-year-end": FiscalYearEnd(12, 31),
     "import-config": None,
     "import-dirs": [],
@@ -139,6 +141,7 @@ LIST_OPTS = [
 STR_OPTS = [
     "collapse-pattern",
     "default-page",
+    "documents-directory-structure",
     "import-config",
     "language",
     "unrealized",

--- a/src/fava/help/options.md
+++ b/src/fava/help/options.md
@@ -76,24 +76,23 @@ Default: `by-account`
 Use this option to specify how to organize the documents that are uploaded by
 drag and drop to a transaction in the journal view. Available options are:
 
-`by-account`: Save documents in a directory structure that resembles the
-hierarchy of the account structure. For example, if the account of the first
-posting is `Expenses:Home:Electricity`, the document will be saved in
-`<documents>/Expenses/Home/Electricity/`.
-
-`by-account-root`: Similar to `by-account`, but use only the root account. For example,
-if the account of the first posting is `Expenses:Home:Electricity`, the document
-will be saved in `<documents>/Expenses/`.
-
-`by-fileprefix`: Derive the directory from the first letters (up to the first
-number or special symbol) of the filename. This can be used to store the documents
-by their type, e.g. the file `IncomingInvoice-Company-A.pdf` will be saved in
-`<documents>/IncomingInvoice/`, the file `OutgoingInvoice-Company-B.pdf` will
-be saved in `<documents>/OutgoingInvoice/`, and the file `AccountStatement-Bank-C.pdf`
-will be saved in `<documents>/AccountStatement/`.
-
-`none`: Save all documents in the directory specified by the beancount option
-`documents` without creating any sub-directories.
+-   `by-account`: Save documents in a directory structure that resembles the
+    hierarchy of the account structure. For example, if the account of the first
+    posting is `Expenses:Home:Electricity`, the document will be saved in
+    `<documents>/Expenses/Home/Electricity/`.
+-   `by-account-root`: Similar to `by-account`, but use only the root account.
+    For example, if the account of the first posting is
+    `Expenses:Home:Electricity`, the document will be saved in
+    `<documents>/Expenses/`.
+-   `by-fileprefix`: Derive the directory from the first letters (up to the
+    first number or special symbol) of the filename. This can be used to store
+    the documents by their type, e.g. the file `IncomingInvoice-Company-A.pdf`
+    will be saved in `<documents>/IncomingInvoice/`, the file
+    `OutgoingInvoice-Company-B.pdf` will be saved in
+    `<documents>/OutgoingInvoice/`, and the file `AccountStatement-Bank-C.pdf`
+    will be saved in `<documents>/AccountStatement/`.
+-   `none`: Save all documents in the directory specified by the beancount
+    option `documents` without creating any sub-directories.
 
 ---
 

--- a/src/fava/help/options.md
+++ b/src/fava/help/options.md
@@ -69,6 +69,34 @@ your beancount file into this option.
 
 ---
 
+## `documents-directory-structure`
+
+Default: `by-account`
+
+Use this option to specify how to organize the documents that are uploaded by
+drag and drop to a transaction in the journal view. Available options are:
+
+`by-account`: Save documents in a directory structure that resembles the
+hierarchy of the account structure. For example, if the account of the first
+posting is `Expenses:Home:Electricity`, the document will be saved in
+`<documents>/Expenses/Home/Electricity/`.
+
+`by-account-root`: Similar to `by-account`, but use only the root account. For example,
+if the account of the first posting is `Expenses:Home:Electricity`, the document
+will be saved in `<documents>/Expenses/`.
+
+`by-fileprefix`: Derive the directory from the first letters (up to the first
+number or special symbol) of the filename. This can be used to store the documents
+by their type, e.g. the file `IncomingInvoice-Company-A.pdf` will be saved in
+`<documents>/IncomingInvoice/`, the file `OutgoingInvoice-Company-B.pdf` will
+be saved in `<documents>/OutgoingInvoice/`, and the file `AccountStatement-Bank-C.pdf`
+will be saved in `<documents>/AccountStatement/`.
+
+`none`: Save all documents in the directory specified by the beancount option
+`documents` without creating any sub-directories.
+
+---
+
 ## `fiscal-year-end`
 
 Default: `12-31`


### PR DESCRIPTION
As mentioned in #1293, it would be nice to have a choice where the uploaded documents are saved. I implemented it by adding the new fava-option "documents-directory-structure". There are four methods so far (by-account, by-account-root, by-fileprefix, none), where "by-account" is the method that was used before and which remains the default method.    
