### PR TITLE
Add flamegraph hierarchy visualisation

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -30,6 +30,7 @@
         "d3-array": "^3.1.1",
         "d3-axis": "^3.0.0",
         "d3-color": "^3.0.0",
+        "d3-flame-graph": "^4.1.3",
         "d3-format": "^3.0.0",
         "d3-hierarchy": "^3.0.0",
         "d3-quadtree": "^3.0.0",
@@ -1209,6 +1210,37 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-flame-graph": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/d3-flame-graph/-/d3-flame-graph-4.1.3.tgz",
+      "integrity": "sha512-NijuhJZhaTMwobVgwGQ67x9PovqMMHXBbs0FMHEGJvsWZGuL4M7OsB03v8mHdyVyHhnQYGsYnb5w021e9+R+RQ==",
+      "dependencies": {
+        "d3-array": "^3.1.1",
+        "d3-dispatch": "^3.0.1",
+        "d3-ease": "^3.0.1",
+        "d3-format": "^3.0.1",
+        "d3-hierarchy": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-selection": "^3.0.0",
+        "d3-transition": "^3.0.1"
+      }
+    },
     "node_modules/d3-format": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.0.1.tgz",
@@ -1306,6 +1338,32 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
       }
     },
     "node_modules/debug": {
@@ -5805,6 +5863,31 @@
       "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.0.1.tgz",
       "integrity": "sha512-6/SlHkDOBLyQSJ1j1Ghs82OIUXpKWlR0hCsw0XrLSQhuUPuCSmLQ1QPH98vpnQxMUQM2/gfAkUEWsupVpd9JGw=="
     },
+    "d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg=="
+    },
+    "d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w=="
+    },
+    "d3-flame-graph": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/d3-flame-graph/-/d3-flame-graph-4.1.3.tgz",
+      "integrity": "sha512-NijuhJZhaTMwobVgwGQ67x9PovqMMHXBbs0FMHEGJvsWZGuL4M7OsB03v8mHdyVyHhnQYGsYnb5w021e9+R+RQ==",
+      "requires": {
+        "d3-array": "^3.1.1",
+        "d3-dispatch": "^3.0.1",
+        "d3-ease": "^3.0.1",
+        "d3-format": "^3.0.1",
+        "d3-hierarchy": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-selection": "^3.0.0",
+        "d3-transition": "^3.0.1"
+      }
+    },
     "d3-format": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.0.1.tgz",
@@ -5872,6 +5955,23 @@
       "integrity": "sha512-nzaCwlj+ZVBIlFuVOT1RmU+6xb/7D5IcnhHzHQcBgS/aTa5K9fWZNN5LCXA27LgF5WxoSNJqKBbLcGMtM6Ca6A==",
       "requires": {
         "d3-time": "1 - 3"
+      }
+    },
+    "d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="
+    },
+    "d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "requires": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
       }
     },
     "debug": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -69,6 +69,7 @@
     "d3-array": "^3.1.1",
     "d3-axis": "^3.0.0",
     "d3-color": "^3.0.0",
+    "d3-flame-graph": "^4.1.3",
     "d3-format": "^3.0.0",
     "d3-hierarchy": "^3.0.0",
     "d3-quadtree": "^3.0.0",

--- a/frontend/src/charts/Chart.svelte
+++ b/frontend/src/charts/Chart.svelte
@@ -57,7 +57,7 @@
     </div>
     <span class="spacer" />
     {#if chart.type === "hierarchy"}
-      {#if $hierarchyChartMode === "treemap"}
+      {#if $hierarchyChartMode === "treemap" || $hierarchyChartMode === "flamegraph"}
         <select bind:value={$chartCurrency}>
           {#each $currencies as currency}
             <option value={currency}>{currency}</option>
@@ -69,6 +69,7 @@
         options={[
           ["treemap", _("Treemap")],
           ["sunburst", _("Sunburst")],
+          ["flamegraph", _("Flamegraph")],
         ]}
       />
     {:else if chart.type === "linechart"}

--- a/frontend/src/charts/Flamegraph.svelte
+++ b/frontend/src/charts/Flamegraph.svelte
@@ -1,0 +1,66 @@
+<script lang="ts">
+  import "d3-flame-graph/dist/d3-flamegraph.css";
+  import type { FlameGraph } from "d3-flame-graph";
+
+  import { flamegraph } from "d3-flame-graph";
+  import { select } from "d3-selection";
+  import { onDestroy, onMount } from "svelte";
+
+  import { ctx, formatPercentage } from "../format";
+
+  import type { AccountHierarchyNode } from "./hierarchy";
+
+  export let data: AccountHierarchyNode;
+  export let width: number;
+  export let currency: string;
+  let details: HTMLDivElement;
+  let container: HTMLDivElement;
+
+  let chart: FlameGraph | null = null;
+  const lastAccount = /(^|:)([^:]*)$/;
+
+  function labelText(d: AccountHierarchyNode) {
+    const val = d.value || 0;
+    const rootValue = data.value || 1;
+
+    return `${$ctx.currency(val)} ${currency} (${formatPercentage(
+      val / rootValue
+    )}) ${d.data.data.account}`;
+  }
+
+  onMount(async () => {
+    chart = flamegraph()
+      .label(labelText)
+      .cellHeight(18)
+      // svelte-ignore
+      .setDetailsElement(details);
+    // Suppress 'getName' property not found error.
+    // Remove the suppression once
+    // https://github.com/spiermar/d3-flame-graph/pull/205
+    // is merged and released.
+    // @ts-ignore
+    chart.getName((d: AccountHierarchyNode) => {
+      const m = lastAccount.exec(d.data.data.account);
+      if (m) {
+        return m[2];
+      }
+      return "";
+    });
+  });
+
+  onDestroy(() => {
+    if (chart) {
+      chart.destroy();
+      chart = null;
+    }
+  });
+
+  $: if (data && chart) {
+    chart.width(width);
+    // Reset the chart legend on chart change.
+    select(container).datum(data).call(chart);
+  }
+</script>
+
+<div bind:this={container} {width} />
+<div bind:this={details} style="height: 1.2em;" />

--- a/frontend/src/charts/HierarchyContainer.svelte
+++ b/frontend/src/charts/HierarchyContainer.svelte
@@ -4,6 +4,7 @@
 
   import { chartCurrency, hierarchyChartMode } from "../stores/chart";
 
+  import Flamegraph from "./Flamegraph.svelte";
   import type { HierarchyChart } from "./hierarchy";
   import Sunburst from "./Sunburst.svelte";
   import Treemap from "./Treemap.svelte";
@@ -17,14 +18,14 @@
   $: currency = $chartCurrency || currencies[0];
   $: context.set(currencies);
 
-  $: treemapData = $hierarchyChartMode === "treemap" && data.get(currency);
+  $: treemapData = data.get(currency);
 </script>
 
 {#if currencies.length === 0}
   <svg {width}>
     <text x={width / 2} y={80} text-anchor="middle">Chart is empty.</text>
   </svg>
-{:else if treemapData}
+{:else if $hierarchyChartMode === "treemap" && treemapData}
   <Treemap data={treemapData} {currency} {width} />
 {:else if $hierarchyChartMode === "sunburst"}
   <svg {width} height={500}>
@@ -39,4 +40,6 @@
       </g>
     {/each}
   </svg>
+{:else if $hierarchyChartMode === "flamegraph" && treemapData}
+  <Flamegraph data={treemapData} {currency} {width} />
 {/if}


### PR DESCRIPTION
Flame Graphs are popular in software performance profiling:
https://queue.acm.org/detail.cfm?id=2927301

But they're generally useful for showing weighted hierarchical data
on one screen.

It's like the 'sunburst' visualisation, but unrolled flat,
so you can put the names of each node in the rectangle.

I'm having some trouble getting the lints to pass, because I'm calling `getName`, which isn't in the type definition for d3-flame-graph yet (I'm adding it here: https://github.com/spiermar/d3-flame-graph/pull/205).

I've tried silencing the error by:
- `// @ts-ignore` (svelte check complains about this)
- `// svelte-ignore` (does nothing?)
- `(chart as any)` (svelte check complains about this)
- casting to an interface (svelte check complains about this)
- 'reopening' the interface for 'augementation' to add a method (only works within a typescript module, that's over my head).

I'd appreciate some suggestions on how to deal with this. How do you silence a warning that you know is OK? :-)

Other problems:
- I'm using `.data.data.` which the type system doesn't seem aware of (and svelte-check fails on). I have to use `.data.data` for the code to work; this tells me maybe the type system is a little off reality? Not sure exactly how though, there's a lot of generics here.