### PR TITLE
allow negative account values in treemap/hierarchy

### DIFF
--- a/frontend/src/charts/Treemap.svelte
+++ b/frontend/src/charts/Treemap.svelte
@@ -31,12 +31,20 @@
     return $treemapScale(node.parent.data.account);
   }
 
+  function mask(d: AccountHierarchyNode) {
+    const node = d.data.dummy && d.parent ? d.parent : d;
+    if (node.data.cumulbalance < 0) {
+        return "url(#treemapHatch-mask)";
+    }
+    return null;
+  }
+
   function tooltipText(d: AccountHierarchyNode) {
-    const val = d.value ?? 0;
-    const rootValue = root.value || 1;
+    const val = d.data.cumulbalance ?? 0;
+    const refValue = root.data.cumulbalance || 1;
 
     return `${$ctx.currency(val)} ${currency} (${formatPercentage(
-      val / rootValue
+      val / refValue
     )})<em>${d.data.account}</em>`;
   }
 
@@ -55,12 +63,26 @@
 </script>
 
 <svg {width} {height}>
+  <defs>
+    <pattern id="treemapHatch" width="10" height="10"
+             stroke="white" stroke-linecap="square" stroke-width="8"
+             patternTransform="rotate(45) scale(1)"
+             patternUnits="userSpaceOnUse">
+      <line x1="0" y1="0" x2="0" y2="10"></line>
+    </pattern>
+    <mask id="treemapHatch-mask" x="0" y="0" width="1" height="1"
+          mask-repeat="repeat">
+      <rect x="0" y="0" width="100%" height="100%" fill="url(#treemapHatch)" />
+    </mask>
+  </defs>
+
   {#each leaves as d}
     <g
       transform={`translate(${d.x0},${d.y0})`}
       use:followingTooltip={() => tooltipText(d)}
     >
-      <rect fill={fill(d)} width={d.x1 - d.x0} height={d.y1 - d.y0} />
+      <rect fill={fill(d)} mask={mask(d)}
+            width={d.x1 - d.x0} height={d.y1 - d.y0} />
       <text
         use:setVisibility={d}
         on:click={() => router.navigate(urlFor(`account/${d.data.account}/`))}


### PR DESCRIPTION
<!--
Hi, thank you for opening a PR!

Please ensure that your change passes tests and the various linters by running
`make test` and `make lint`. If testable, your changes should be covered by
unit tests.

Explain your changes below and link to related issues.
-->

Hi, 

This PR handles negative accounts in the treemap visualization. 

Let me know if you think it's useful, and I can do any extra tidying or add some unit tests, if you can help point me to what is needed. Much appreciated.

## Description of problem this solves: 

The treemap visualization for expense and income (and treemaps in general) can't handle negative values, which can appear in those accounts. That is, it renders n overlapping mess of boxes.

Example of problem:

 * I have accounts `Expenses:Taxes:TY2020` and `Expenses:Taxes:TY2021`
 * I want to visualize a beancount file that only covers transactions in 2021. 
 * In 2021 I payed $1000 of TY2021 taxes in paystubs (`balance Expenses:Taxes:TY2021 1000 USD`, and I got a $200 refund for 2020 taxes (`balance Expenses:Taxes:TY2020 -200 USD`). 
 * This means that the parent node `Expenses:Taxes` has a net balance of `800 USD`. 

So, when d3 draws the treemap it allocates an area of 800 units to cover `Expenses:Taxes`, but within that area it tries to put an area 1000 for `Expenses:Taxes:TY2021`, and it does not show `Expenses:Taxes:TY2020` at all. What ends up happening is the area of size 1000 overflows past the parent box and covers/hides the neighbor areas in the treemap, making the treemap ugly/illegible.

## My proposed fix

Show negative areas in hash coloring. See image where the "Temple" account is negative:

![demo_treemap](https://user-images.githubusercontent.com/9040124/148709023-3b1b3835-2b4f-47d5-9206-7cf31236d579.png)


  * Pro: The treemap has no jumpled overlaps or hidden accounts which made it difficult to read.
  * Con: Negative accounts now add to the total area, which could be confusing. I.e, the percentages in the tooltips no longer add to 1.

I expect that opposite-sign subaccounts for income/expenses are pretty rare/small, so i thought the pro outweighs the con.

## Implementation

This is the first time I've really used typescript and reactjs, and I only vaguely know d3, so suggestions appreciated. I couldn't figure out how to annotate types in the `reduce` calls to satisfy the lint check.

I added and extra "cumulbalance" field to the `AccountHierarchyDatum` object. That seems ugly, but I couldn't figure out a better way to communicate both the "absolute area (value)" and the "net balance" of each account from the hierarchy code to the treemap code.  That is, previously the code just set the node.value field to equal the total account value, but in this PR I needed node.value to equal the absolute-value-sum of all descendant accounts (to use as he box area in treemap), but I still needed to communicate the account net balance to display in the tooltips.

## Alternatives (edit)

A simpler alternative to this PR is to only include positive subaccounts. That's a one-line change, see my alternate branch https://github.com/ahaldane/fava/tree/treemap_positive_only last commit.