### PR TITLE
only include positive accounts in treemap

### DIFF
--- a/frontend/src/charts/hierarchy.ts
+++ b/frontend/src/charts/hierarchy.ts
@@ -60,7 +60,7 @@ export function hierarchy(
 
   currencies.forEach((currency) => {
     const currencyHierarchy = d3Hierarchy(root)
-      .sum((d) => (d.balance[currency] ?? 0) * modifier)
+      .sum((d) => Math.max((d.balance[currency] ?? 0) * modifier, 0))
       .sort((a, b) => (b.value ?? 0) - (a.value ?? 0));
     if (currencyHierarchy.value) {
       data.set(currency, currencyHierarchy);


### PR DESCRIPTION
<!--
Hi, thank you for opening a PR!

Please ensure that your change passes tests and the various linters by running
`make test` and `make lint`. If testable, your changes should be covered by
unit tests.

Explain your changes below and link to related issues.
-->
This is an alternative to #1355. Sorry for double post noise.

Again, the problem it solves is that treemaps can't handle negative sub-balances which  sometimes occur. Unlike the other PR, this one simply removes any negative accounts from the treemap.

After playing with both solutions I actually like this one better, so please close the other PR if you agree.

This solution is both simpler to implement, and also makes the treemap plot less confusing.