### PR TITLE
fava_options: use dataclass

### DIFF
--- a/frontend/src/editor/EditorMenu.svelte
+++ b/frontend/src/editor/EditorMenu.svelte
@@ -20,7 +20,7 @@
     $options.filename,
     ...$options.include.filter((f) => f !== $options.filename),
   ];
-  $: insertEntryOptions = $favaOptions["insert-entry"];
+  $: insertEntryOptions = $favaOptions.insert_entry;
 
   function goToFileAndLine(filename: string, line?: number) {
     const url = urlFor("editor/", { file_path: filename, line });

--- a/frontend/src/editor/SourceEditor.svelte
+++ b/frontend/src/editor/SourceEditor.svelte
@@ -81,7 +81,7 @@
     ];
 
     editor.focus();
-    const opts = $favaOptions["insert-entry"].filter(
+    const opts = $favaOptions.insert_entry.filter(
       (f) => f.filename === data.file_path
     );
     const line = parseInt(

--- a/frontend/src/stores/index.ts
+++ b/frontend/src/stores/index.ts
@@ -26,11 +26,11 @@ export const ledgerDataValidator = object({
   currencies: array(string),
   errors: number,
   favaOptions: object({
-    "auto-reload": boolean,
-    "currency-column": number,
+    auto_reload: boolean,
+    currency_column: number,
     indent: number,
     locale: union(string, constant(null)),
-    "insert-entry": array(
+    insert_entry: array(
       object({ date: string, filename: string, lineno: number, re: string })
     ),
   }),

--- a/src/fava/application.py
+++ b/src/fava/application.py
@@ -131,7 +131,7 @@ def get_locale() -> Optional[str]:
         The locale that should be used for Babel. If not given as an option to
         Fava, guess from browser.
     """
-    lang = g.ledger.fava_options["language"]
+    lang = g.ledger.fava_options.language
     if lang is not None:
         return lang
     return request.accept_languages.best_match(["en"] + LANGUAGES)
@@ -180,7 +180,7 @@ def url_for(endpoint: str, **values: Any) -> str:
 
 def url_for_source(**kwargs: Any) -> str:
     """URL to source file (possibly link to external editor)."""
-    if g.ledger.fava_options["use-external-editor"]:
+    if g.ledger.fava_options.use_external_editor:
         return (
             f"beancount://{kwargs.get('file_path')}"
             + f"?lineno={kwargs.get('line', 1)}"
@@ -276,9 +276,9 @@ def index() -> werkzeug.wrappers.response.Response:
     if not g.beancount_file_slug:
         g.beancount_file_slug = next(iter(app.config["LEDGERS"]))
     index_url = url_for("index")
-    default_path = app.config["LEDGERS"][g.beancount_file_slug].fava_options[
-        "default-page"
-    ]
+    default_path = app.config["LEDGERS"][
+        g.beancount_file_slug
+    ].fava_options.default_page
     return redirect(f"{index_url}{default_path}")
 
 

--- a/src/fava/core/__init__.py
+++ b/src/fava/core/__init__.py
@@ -49,7 +49,6 @@ from fava.core.budgets import BudgetModule
 from fava.core.charts import ChartModule
 from fava.core.entries_by_type import group_entries_by_type
 from fava.core.extensions import ExtensionModule
-from fava.core.fava_options import DEFAULTS
 from fava.core.fava_options import FavaOptions
 from fava.core.fava_options import parse_options
 from fava.core.file import FileModule
@@ -210,7 +209,7 @@ class FavaLedger:
         self.commodities: Dict[str, Commodity] = {}
 
         #: A dict with all of Fava's option values.
-        self.fava_options: FavaOptions = DEFAULTS
+        self.fava_options: FavaOptions = FavaOptions()
 
         self._date_first: Optional[datetime.date] = None
         self._date_last: Optional[datetime.date] = None
@@ -363,7 +362,7 @@ class FavaLedger:
     def root_tree_closed(self) -> Tree:
         """A root tree for the balance sheet."""
         tree = Tree(self.entries)
-        tree.cap(self.options, self.fava_options["unrealized"])
+        tree.cap(self.options, self.fava_options.unrealized)
         return tree
 
     def interval_balances(

--- a/src/fava/core/attributes.py
+++ b/src/fava/core/attributes.py
@@ -62,7 +62,7 @@ class AttributesModule(FavaModule):
         self.links = get_all_links(all_entries)
         self.tags = get_all_tags(all_entries)
         self.years = get_active_years(
-            all_entries, self.ledger.fava_options["fiscal-year-end"]
+            all_entries, self.ledger.fava_options.fiscal_year_end
         )
 
         account_ranker = ExponentialDecayRanker(

--- a/src/fava/core/documents.py
+++ b/src/fava/core/documents.py
@@ -23,7 +23,7 @@ def is_document_or_import_file(filename: str, ledger: "FavaLedger") -> bool:
         document.filename for document in ledger.all_entries_by_type.Document
     ]
     import_directories = [
-        ledger.join_path(d) for d in ledger.fava_options["import-dirs"]
+        ledger.join_path(d) for d in ledger.fava_options.import_dirs
     ]
     if filename in filenames:
         return True

--- a/src/fava/core/file.py
+++ b/src/fava/core/file.py
@@ -124,7 +124,7 @@ class FileModule(FavaModule):
             self.ledger.changed()
             entry: Directive = self.ledger.get_entry(entry_hash)
             key = next_key(basekey, entry.meta)
-            indent = self.ledger.fava_options["indent"]
+            indent = self.ledger.fava_options.indent
             insert_metadata_in_file(
                 entry.meta["filename"],
                 entry.meta["lineno"],
@@ -165,10 +165,10 @@ class FileModule(FavaModule):
             self.ledger.changed()
             fava_options = self.ledger.fava_options
             for entry in sorted(entries, key=incomplete_sortkey):
-                insert_options = fava_options["insert-entry"]
-                currency_column = fava_options["currency-column"]
-                indent = fava_options["indent"]
-                fava_options["insert-entry"] = insert_entry(
+                insert_options = fava_options.insert_entry
+                currency_column = fava_options.currency_column
+                indent = fava_options.indent
+                fava_options.insert_entry = insert_entry(
                     entry,
                     self.ledger.beancount_file_path,
                     insert_options,
@@ -188,7 +188,7 @@ class FileModule(FavaModule):
         Yields:
             The entries rendered in Beancount format.
         """
-        indent = self.ledger.fava_options["indent"]
+        indent = self.ledger.fava_options.indent
         for entry in entries:
             if isinstance(entry, (Balance, Transaction)):
                 if isinstance(entry, Transaction) and entry.flag in EXCL_FLAGS:
@@ -198,7 +198,7 @@ class FileModule(FavaModule):
                 except (KeyError, FileNotFoundError):
                     yield _format_entry(
                         entry,
-                        self.ledger.fava_options["currency-column"],
+                        self.ledger.fava_options.currency_column,
                         indent,
                     )
 

--- a/src/fava/core/filters.py
+++ b/src/fava/core/filters.py
@@ -350,7 +350,7 @@ class TimeFilter(EntryFilter):  # pylint: disable=abstract-method
             return True
 
         self.begin_date, self.end_date = parse_date(
-            self.value, self.fava_options["fiscal-year-end"]
+            self.value, self.fava_options.fiscal_year_end
         )
         if not self.begin_date:
             self.value = None

--- a/src/fava/core/ingest.py
+++ b/src/fava/core/ingest.py
@@ -80,7 +80,7 @@ class IngestModule(FavaModule):
     @property
     def module_path(self) -> Optional[str]:
         """The path to the importer configuration."""
-        config_path = self.ledger.fava_options["import-config"]
+        config_path = self.ledger.fava_options.import_config
         if not config_path:
             return None
         return self.ledger.join_path(config_path)
@@ -134,7 +134,7 @@ class IngestModule(FavaModule):
 
         ret: List[FileImporters] = []
 
-        for directory in self.ledger.fava_options["import-dirs"]:
+        for directory in self.ledger.fava_options.import_dirs:
             full_path = self.ledger.join_path(directory)
             files = list(identify.find_imports(self.config, full_path))
             for (filename, importers) in files:

--- a/src/fava/core/misc.py
+++ b/src/fava/core/misc.py
@@ -40,7 +40,7 @@ class FavaMisc(FavaModule):
 
         self.upcoming_events = upcoming_events(
             self.ledger.all_entries_by_type.Event,
-            self.ledger.fava_options["upcoming-events"],
+            self.ledger.fava_options.upcoming_events,
         )
 
         if not self.ledger.options["operating_currency"]:

--- a/src/fava/core/number.py
+++ b/src/fava/core/number.py
@@ -58,10 +58,10 @@ class DecimalFormatModule(FavaModule):
     def load_file(self) -> None:
         self.locale = None
 
-        locale_option = self.ledger.fava_options["locale"]
+        locale_option = self.ledger.fava_options.locale
         if self.ledger.options["render_commas"] and not locale_option:
             locale_option = "en"
-            self.ledger.fava_options["locale"] = locale_option
+            self.ledger.fava_options.locale = locale_option
 
         if locale_option:
             self.locale = Locale.parse(locale_option)

--- a/src/fava/json_api.py
+++ b/src/fava/json_api.py
@@ -215,9 +215,7 @@ def source_slice(request_data: Dict[str, Any]) -> str:
 @put_api_endpoint
 def format_source(request_data: Dict[str, Any]) -> str:
     """Format beancount file."""
-    return align(
-        request_data["source"], g.ledger.fava_options["currency-column"]
-    )
+    return align(request_data["source"], g.ledger.fava_options.currency_column)
 
 
 @delete_api_endpoint

--- a/src/fava/template_filters.py
+++ b/src/fava/template_filters.py
@@ -116,17 +116,17 @@ def should_show(account: TreeNode) -> bool:
     if account.name not in ledger.accounts:
         return False
     fava_options = ledger.fava_options
-    if not fava_options["show-closed-accounts"] and ledger.account_is_closed(
+    if not fava_options.show_closed_accounts and ledger.account_is_closed(
         account.name
     ):
         return False
     if (
-        not fava_options["show-accounts-with-zero-balance"]
+        not fava_options.show_accounts_with_zero_balance
         and account.balance.is_empty()
     ):
         return False
     if (
-        not fava_options["show-accounts-with-zero-transactions"]
+        not fava_options.show_accounts_with_zero_transactions
         and not account.has_txns
     ):
         return False
@@ -154,7 +154,7 @@ def format_errormsg(message: str) -> str:
 
 def collapse_account(account_name: str) -> bool:
     """Return true if account should be collapsed."""
-    collapse_patterns = g.ledger.fava_options["collapse-pattern"]
+    collapse_patterns = g.ledger.fava_options.collapse_pattern
     return any(pattern.match(account_name) for pattern in collapse_patterns)
 
 

--- a/src/fava/templates/_aside.html
+++ b/src/fava/templates/_aside.html
@@ -1,5 +1,5 @@
 {% import '_globals.html' as globals with context %}
-{% set user_queries = ledger.query_shell.queries[:ledger.fava_options['sidebar-show-queries']] %}
+{% set user_queries = ledger.query_shell.queries[:ledger.fava_options.sidebar_show_queries] %}
 {% if ledger.misc.sidebar_links %}
 <ul class="navigation">
   {% for label, link in ledger.misc.sidebar_links %}

--- a/src/fava/templates/_journal_table.html
+++ b/src/fava/templates/_journal_table.html
@@ -43,7 +43,7 @@
    'open': 'Open',
 } %}
 {% if not request.args.get('show') %}
-{% set journal_show = g.ledger.fava_options['journal-show'] + g.ledger.fava_options['journal-show-transaction'] + g.ledger.fava_options['journal-show-document'] %}
+{% set journal_show = g.ledger.fava_options.journal_show + g.ledger.fava_options.journal_show_transaction + g.ledger.fava_options.journal_show_document %}
 {% else %}
 {% set journal_show = request.args.getlist('show') %}
 {% endif %}

--- a/src/fava/templates/_layout.html
+++ b/src/fava/templates/_layout.html
@@ -58,7 +58,7 @@
         'baseURL': url_for('index'),
         'currencies': ledger.attributes.currencies,
         'errors': ledger.errors|length,
-        'favaOptions': ledger.fava_options,
+        'favaOptions': ledger.fava_options.asdict(),
         'incognito': config.get('INCOGNITO', False),
         'have_excel': config.get('HAVE_EXCEL', False),
         'links': ledger.attributes.links,

--- a/src/fava/templates/account.html
+++ b/src/fava/templates/account.html
@@ -25,7 +25,7 @@
   </div>
 
   {% if journal %}
-  {% set entries = ledger.account_journal(account_name, with_journal_children=ledger.fava_options['account-journal-include-children']) %}
+  {% set entries = ledger.account_journal(account_name, with_journal_children=ledger.fava_options.account_journal_include_children) %}
   {{ journal_table.journal_table(entries, show_change_and_balance=True) }}
   {% else %}
   {% set accumulate = subreport == 'balances' %}

--- a/src/fava/templates/balance_sheet.html
+++ b/src/fava/templates/balance_sheet.html
@@ -6,7 +6,7 @@
 {{ charts.hierarchy(ledger.options['name_equity']) }}
 
 {% set root_tree_closed = ledger.root_tree_closed %}
-{% set invert = ledger.fava_options['invert-income-liabilities-equity'] %}
+{% set invert = ledger.fava_options.invert_income_liabilities_equity %}
 
 <div class="row">
   <div class="column">

--- a/src/fava/templates/editor.html
+++ b/src/fava/templates/editor.html
@@ -1,3 +1,3 @@
-{% set file_path = request.args.get('file_path', ledger.fava_options['default-file'] or ledger.beancount_file_path) %}
+{% set file_path = request.args.get('file_path', ledger.fava_options.default_file or ledger.beancount_file_path) %}
 {% set source, sha256sum = ledger.file.get_source(file_path) %}
 <svelte-component type="editor"><script type="application/json">{{ { 'source': source, 'sha256sum': sha256sum, 'file_path': file_path }|tojson|safe }}</script></svelte-component>

--- a/src/fava/templates/import.html
+++ b/src/fava/templates/import.html
@@ -1,4 +1,4 @@
-{% if not ledger.fava_options['import-config'] %}
+{% if not ledger.fava_options.import_config %}
 <p>
 No importers configured. See <a href="{{ url_for('help_page', page_slug='import') }}">Help (Import)</a> for more information.
 </p>

--- a/src/fava/templates/income_statement.html
+++ b/src/fava/templates/income_statement.html
@@ -1,6 +1,6 @@
 {% import '_tree_table.html' as tree_table with context %}
 
-{% set invert = ledger.fava_options['invert-income-liabilities-equity'] %}
+{% set invert = ledger.fava_options.invert_income_liabilities_equity %}
 
 {{ charts.interval_totals(g.interval, (ledger.options['name_income'], ledger.options['name_expenses']), label=_('Net Profit'), invert=invert) }}
 {{ charts.interval_totals(g.interval, ledger.options['name_income'], label=_('Income'), invert=invert) }}

--- a/src/fava/templates/macros/_account_macros.html
+++ b/src/fava/templates/macros/_account_macros.html
@@ -25,7 +25,7 @@ Click to copy the balance directives to the clipboard:
 {% macro last_account_activity(ledger, account_name) %}
 {% set last_entry = ledger.last_entry(account_name) %}
 {% set last_account_activity = (today() - last_entry.date).days if last_entry else 0 %}
-{% if last_account_activity > ledger.fava_options['uptodate-indicator-grey-lookback-days'] %}
+{% if last_account_activity > ledger.fava_options.uptodate_indicator_grey_lookback_days %}
     <span class="status-indicator status-gray" title="This account has not been updated in a while. ({{ last_account_activity }} days ago)"></span>
 {% endif %}
 {% endmacro %}

--- a/src/fava/templates/options.html
+++ b/src/fava/templates/options.html
@@ -7,9 +7,9 @@
     </tr>
   </thead>
   <tbody>
-    {% for key, value in ledger.fava_options|dictsort %}
+    {% for key, value in ledger.fava_options.asdict()|dictsort %}
     <tr>
-      <td>{{ key }}</td>
+      <td>{{ key|replace('_', '-') }}</td>
       <td><pre>{{ value|pprint }}</pre></td>
     </tr>
     {% endfor %}

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -107,7 +107,7 @@ def test_default_path_redirection(
     with app.test_request_context("/long-example/"):
         app.preprocess_request()
         if option:
-            monkeypatch.setitem(g.ledger.fava_options, "default-page", option)
+            monkeypatch.setattr(g.ledger.fava_options, "default_page", option)
         result = test_client.get(url)
         get_url = result.headers.get("Location", "")
         expect_url = werkzeug.urls.url_join("http://localhost/", expect)

--- a/tests/test_core_documents.py
+++ b/tests/test_core_documents.py
@@ -9,7 +9,7 @@ from fava.helpers import FavaAPIException
 
 
 def test_is_document_or_import_file(example_ledger, monkeypatch):
-    monkeypatch.setitem(example_ledger.fava_options, "import-dirs", ["/test/"])
+    monkeypatch.setattr(example_ledger.fava_options, "import_dirs", ["/test/"])
     assert not is_document_or_import_file("/asdfasdf", example_ledger)
     assert not is_document_or_import_file("/test/../../err", example_ledger)
     assert is_document_or_import_file("/test/err/../err", example_ledger)

--- a/tests/test_core_fava_options.py
+++ b/tests/test_core_fava_options.py
@@ -19,7 +19,7 @@ def test_fava_options(load_doc):
     2016-04-14 custom "fava-option" "locale" "en"
     2016-04-14 custom "fava-option" "locale" "invalid"
     2016-04-14 custom "fava-option" "collapse-pattern" "Account:Name"
-    2016-04-14 custom "fava-option" "collapse-pattern" "(invalid"
+    2016-04-14 custom "fava-option" "collapse_pattern" "(invalid"
     2016-04-14 custom "fava-option" "fiscal-year-end" "01-11"
     """
 
@@ -28,8 +28,8 @@ def test_fava_options(load_doc):
 
     assert len(errors) == 3
 
-    assert options["indent"] == 4
-    assert options["insert-entry"] == [
+    assert options.indent == 4
+    assert options.insert_entry == [
         InsertEntryOption(
             datetime.date(2016, 4, 14),
             re.compile("Ausgaben:Test"),
@@ -37,8 +37,8 @@ def test_fava_options(load_doc):
             7,
         )
     ]
-    assert options["show-closed-accounts"]
-    assert options["journal-show"] == ["transaction", "open"]
-    assert options["currency-column"] == 10
-    assert options["collapse-pattern"] == [re.compile("Account:Name")]
-    assert options["fiscal-year-end"] == FiscalYearEnd(1, 11)
+    assert options.show_closed_accounts
+    assert options.journal_show == ("transaction", "open")
+    assert options.currency_column == 10
+    assert options.collapse_pattern == [re.compile("Account:Name")]
+    assert options.fiscal_year_end == FiscalYearEnd(1, 11)

--- a/tests/test_core_number.py
+++ b/tests/test_core_number.py
@@ -25,13 +25,13 @@ def test_format_decimal(example_ledger) -> None:
 def test_format_decimal_locale(example_ledger, monkeypatch) -> None:
     fmt = example_ledger.format_decimal
 
-    monkeypatch.setitem(example_ledger.fava_options, "locale", "en_IN")
+    monkeypatch.setattr(example_ledger.fava_options, "locale", "en_IN")
     fmt.load_file()
     assert fmt(D("1111111.333"), "USD") == "11,11,111.33"
     assert fmt(D("11.333"), "USD") == "11.33"
     assert fmt(D("11.3333"), None) == "11.33"
 
-    monkeypatch.setitem(example_ledger.fava_options, "locale", "de_DE")
+    monkeypatch.setattr(example_ledger.fava_options, "locale", "de_DE")
     fmt.load_file()
     assert fmt(D("1111111.333"), "USD") == "1.111.111,33"
 

--- a/tests/test_json_api.py
+++ b/tests/test_json_api.py
@@ -170,7 +170,7 @@ def test_api_format_source_options(app, test_client, monkeypatch) -> None:
 
         url = url_for("json_api.format_source")
 
-        monkeypatch.setitem(g.ledger.fava_options, "currency-column", 90)
+        monkeypatch.setattr(g.ledger.fava_options, "currency_column", 90)
 
         response = test_client.put(
             url,

--- a/tests/test_template_filters.py
+++ b/tests/test_template_filters.py
@@ -80,7 +80,7 @@ def test_should_show(app):
         assert should_show(account) is True
     with app.test_request_context("/long-example/income_statement/?time=2100"):
         app.preprocess_request()
-        assert not g.ledger.fava_options["show-accounts-with-zero-balance"]
+        assert not g.ledger.fava_options.show_accounts_with_zero_balance
         assert should_show(g.ledger.root_tree.get("")) is True
         assert should_show(g.ledger.root_tree.get("Expenses")) is False
 
@@ -105,9 +105,9 @@ def test_collapse_account(app, monkeypatch):
     with app.test_request_context("/long-example/"):
         app.preprocess_request()
 
-        monkeypatch.setitem(
+        monkeypatch.setattr(
             g.ledger.fava_options,
-            "collapse-pattern",
+            "collapse_pattern",
             [
                 re.compile("^Assets:Stock$"),
                 re.compile("^Assets:Property:.*"),


### PR DESCRIPTION
Also use underscores in option names internally.This allows using the
option names as variable names (in both Python and Javascript).

<!--
Hi, thank you for opening a PR!

Please ensure that your change passes tests and the various linters by running
`make test` and `make lint`. If testable, your changes should be covered by
unit tests.

Explain your changes below and link to related issues.
-->
