### PR TITLE
Correct HTML in journal table

### DIFF
--- a/src/fava/templates/_journal_table.html
+++ b/src/fava/templates/_journal_table.html
@@ -65,7 +65,6 @@
   {% else %}
     {{ value }}
   {% endif -%}
-    {%- if key.startswith('document') %}</a>{% endif -%}
   </dd>
   {% endfor %}
 </dl>


### PR DESCRIPTION
Fix regression since a06a60d3c2b33e1007ac5ab22497844bba7f5b71, which broke the formatting for metadata key `document`. The generated HTML will have two closing `</a>` tags; this PR fixes that.