### PR TITLE
Add support for the query 'clear' command

### DIFF
--- a/frontend/src/query/Query.svelte
+++ b/frontend/src/query/Query.svelte
@@ -55,7 +55,8 @@
     const query = query_string;
     if (!query) {
       return;
-    } else if (query.trim().toUpperCase() === "CLEAR") {
+    }
+    if (query.trim().toUpperCase() === "CLEAR") {
       clearResults();
       return;
     }

--- a/frontend/src/query/Query.svelte
+++ b/frontend/src/query/Query.svelte
@@ -7,7 +7,11 @@
   import { chartContext } from "../charts/context";
   import { parseQueryChart } from "../charts/query-charts";
   import { getFilterParams } from "../stores/filters";
-  import { addToHistory, query_shell_history } from "../stores/query";
+  import {
+    addToHistory,
+    clearHistory,
+    query_shell_history,
+  } from "../stores/query";
 
   import QueryEditor from "./QueryEditor.svelte";
   import QueryLinks from "./QueryLinks.svelte";
@@ -38,9 +42,21 @@
     resultElems[query].setAttribute("open", "true");
   }
 
+  async function clearResults() {
+    clearHistory();
+    await tick();
+    const url = new URL(window.location.href);
+    query_string = "";
+    url.searchParams.set("query_string", query_string);
+    window.history.replaceState(null, "", url.toString());
+  }
+
   function submit() {
     const query = query_string;
     if (!query) {
+      return;
+    } else if (query.trim().toUpperCase() === "CLEAR") {
+      clearResults();
       return;
     }
     get("query_result", { query_string: query, ...getFilterParams() }).then(

--- a/frontend/src/stores/query.ts
+++ b/frontend/src/stores/query.ts
@@ -17,7 +17,5 @@ export function addToHistory(query: string): void {
 }
 
 export function clearHistory(): void {
-  query_shell_history.update((x) =>
-    return [];
-  );
+  query_shell_history.update((x) => []);
 }

--- a/frontend/src/stores/query.ts
+++ b/frontend/src/stores/query.ts
@@ -17,5 +17,5 @@ export function addToHistory(query: string): void {
 }
 
 export function clearHistory(): void {
-  query_shell_history.update((x) => []);
+  query_shell_history.set([]);
 }

--- a/frontend/src/stores/query.ts
+++ b/frontend/src/stores/query.ts
@@ -17,7 +17,7 @@ export function addToHistory(query: string): void {
 }
 
 export function clearHistory(): void {
-  query_shell_history.update((x) => {
+  query_shell_history.update((x) =>
     return [];
-  });
+  );
 }

--- a/frontend/src/stores/query.ts
+++ b/frontend/src/stores/query.ts
@@ -15,3 +15,9 @@ export function addToHistory(query: string): void {
     });
   }
 }
+
+export function clearHistory(): void {
+  query_shell_history.update((x) => {
+    return [];
+  });
+}


### PR DESCRIPTION
Entering `clear` in the Query page will now clear all query history. This fixes #1365 

I have had trouble with the pre-commit hook on my machine as I am currently stuck with old versions of node/npm, so eslint is not fully operable.