### PR TITLE
fava_options: reverse entries

### DIFF
--- a/src/fava/core/fava_options.py
+++ b/src/fava/core/fava_options.py
@@ -73,6 +73,7 @@ class FavaOptions:
     journal_show_transaction: tuple[str, ...] = ("cleared", "pending")
     language: str | None = None
     locale: str | None = None
+    reverse_entries: bool = True
     show_accounts_with_zero_balance: bool = True
     show_accounts_with_zero_transactions: bool = True
     show_closed_accounts: bool = False

--- a/src/fava/templates/_journal_table.html
+++ b/src/fava/templates/_journal_table.html
@@ -105,7 +105,7 @@
         {% endif %}
         </p>
     </li>
-{% for entry in entries|reverse %}
+    {% for entry in (entries|reverse if g.ledger.fava_options.reverse_entries else entries) %}
     {% if show_change_and_balance %}
         {% set entry, _, change, balance = entry %}
     {% endif %}


### PR DESCRIPTION
I prefer that entries not be reversed, so I added an option to toggle this without the need to resort the table after page is loaded.

usage:
```
2022-01-24 custom "fava-option" "reverse_entries" "false"
```