### PR TITLE
Don't suggest closed accounts

### DIFF
--- a/frontend/src/entry-forms/AccountInput.svelte
+++ b/frontend/src/entry-forms/AccountInput.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
   import AutocompleteInput from "../AutocompleteInput.svelte";
   import { _ } from "../i18n";
-  import { accounts } from "../stores";
+  import { date as validate_date } from "../lib/validation";
+  import { account_details, accounts } from "../stores";
 
   export let value: string;
   export let suggestions: string[] | undefined = undefined;
+  export let date: string | undefined = undefined;
   export let className: string | undefined = undefined;
 
   function checkValidity(val: string) {
@@ -12,6 +14,27 @@
       ? ""
       : _("Should be one of the declared accounts");
   }
+
+  function filterSuggestions(
+    accounts_: string[],
+    date_: string | undefined
+  ): string[] {
+    const res = validate_date(date_);
+    if (!res.success) {
+      return accounts_;
+    }
+    const entry_date = res.value;
+    return accounts_.filter((account) => {
+      const details = $account_details[account];
+      if (!details) {
+        return true;
+      }
+      return details.close_date >= entry_date;
+    });
+  }
+
+  $: account_suggestions = suggestions || $accounts;
+  $: filtered_suggestions = filterSuggestions(account_suggestions, date);
 </script>
 
 <AutocompleteInput
@@ -19,5 +42,5 @@
   bind:value
   {className}
   {checkValidity}
-  suggestions={suggestions || $accounts}
+  suggestions={filtered_suggestions}
 />

--- a/frontend/src/entry-forms/Balance.svelte
+++ b/frontend/src/entry-forms/Balance.svelte
@@ -15,7 +15,11 @@
   <div class="flex-row">
     <input type="date" bind:value={entry.date} required />
     <h4>{_("Balance")}</h4>
-    <AccountInput className="grow" bind:value={entry.account} />
+    <AccountInput
+      className="grow"
+      bind:value={entry.account}
+      date={entry.date}
+    />
     <input
       type="tel"
       pattern="-?[0-9.,]*"

--- a/frontend/src/entry-forms/Note.svelte
+++ b/frontend/src/entry-forms/Note.svelte
@@ -13,7 +13,11 @@
   <div class="flex-row">
     <input type="date" name="date" bind:value={entry.date} required />
     <h4>{_("Note")}</h4>
-    <AccountInput className="grow" bind:value={entry.account} />
+    <AccountInput
+      className="grow"
+      bind:value={entry.account}
+      date={entry.date}
+    />
     <AddMetadataButton bind:meta={entry.meta} />
   </div>
   <textarea name="comment" rows={2} bind:value={entry.comment} />

--- a/frontend/src/entry-forms/Posting.svelte
+++ b/frontend/src/entry-forms/Posting.svelte
@@ -9,6 +9,7 @@
   export let posting: Posting;
   export let index: number;
   export let suggestions: string[] | undefined;
+  export let date: string | undefined;
   export let move: (arg: { from: number; to: number }) => void;
   export let remove: () => void;
   export let add: () => void;
@@ -62,7 +63,12 @@
   >
     ×
   </button>
-  <AccountInput className="grow" bind:value={posting.account} {suggestions} />
+  <AccountInput
+    className="grow"
+    bind:value={posting.account}
+    {suggestions}
+    {date}
+  />
   <AutocompleteInput
     className="amount"
     placeholder={_("Amount")}

--- a/frontend/src/entry-forms/Transaction.svelte
+++ b/frontend/src/entry-forms/Transaction.svelte
@@ -4,14 +4,14 @@
   import { emptyPosting, Transaction } from "../entries";
   import type { Posting } from "../entries";
   import { _ } from "../i18n";
-  import { account_details, accounts, payees } from "../stores";
+  import { payees } from "../stores";
 
   import AddMetadataButton from "./AddMetadataButton.svelte";
   import EntryMetadata from "./EntryMetadata.svelte";
   import PostingSvelte from "./Posting.svelte";
 
   export let entry: Transaction;
-  let suggestions: string[];
+  let suggestions: string[] | undefined;
 
   function removePosting(posting: Posting) {
     entry.postings = entry.postings.filter((p) => p !== posting);
@@ -21,18 +21,12 @@
     entry.postings = entry.postings.concat(emptyPosting());
   }
 
-  $: suggestions = $accounts.filter(
-    (value) => $account_details[value].close_date >= new Date(entry.date)
-  );
-
   $: payee = entry.payee;
   $: if (payee) {
-    suggestions = [];
+    suggestions = undefined;
     if ($payees.includes(payee)) {
       get("payee_accounts", { payee }).then((s) => {
-        suggestions = s.filter(
-          (value) => $account_details[value].close_date >= new Date(entry.date)
-        );
+        suggestions = s;
       });
     }
   }
@@ -98,6 +92,7 @@
       bind:posting
       {index}
       {suggestions}
+      date={entry.date}
       add={addPosting}
       move={movePosting}
       remove={() => removePosting(posting)}

--- a/frontend/src/entry-forms/Transaction.svelte
+++ b/frontend/src/entry-forms/Transaction.svelte
@@ -4,14 +4,14 @@
   import { emptyPosting, Transaction } from "../entries";
   import type { Posting } from "../entries";
   import { _ } from "../i18n";
-  import { payees } from "../stores";
+  import { account_details, accounts, payees } from "../stores";
 
   import AddMetadataButton from "./AddMetadataButton.svelte";
   import EntryMetadata from "./EntryMetadata.svelte";
   import PostingSvelte from "./Posting.svelte";
 
   export let entry: Transaction;
-  let suggestions: string[] | undefined;
+  let suggestions: string[];
 
   function removePosting(posting: Posting) {
     entry.postings = entry.postings.filter((p) => p !== posting);
@@ -21,12 +21,18 @@
     entry.postings = entry.postings.concat(emptyPosting());
   }
 
+  $: suggestions = $accounts.filter(
+    (value) => $account_details[value].close_date >= new Date(entry.date)
+  );
+
   $: payee = entry.payee;
   $: if (payee) {
-    suggestions = undefined;
+    suggestions = [];
     if ($payees.includes(payee)) {
       get("payee_accounts", { payee }).then((s) => {
-        suggestions = s;
+        suggestions = s.filter(
+          (value) => $account_details[value].close_date >= new Date(entry.date)
+        );
       });
     }
   }

--- a/frontend/src/stores/index.ts
+++ b/frontend/src/stores/index.ts
@@ -9,8 +9,10 @@ import {
   array,
   boolean,
   constant,
+  date,
   number,
   object,
+  record,
   string,
   union,
 } from "../lib/validation";
@@ -22,6 +24,11 @@ export const interval: Writable<Interval> = writable(DEFAULT_INTERVAL);
 
 export const ledgerDataValidator = object({
   accounts: array(string),
+  account_details: record(
+    object({
+      close_date: date,
+    })
+  ),
   baseURL: string,
   currencies: array(string),
   errors: number,
@@ -76,7 +83,15 @@ export const incognito = derived(ledgerData, (val) => val.incognito);
 export const baseURL = derived(ledgerData, (val) => val.baseURL);
 
 /** The ranked array of all accounts. */
-export const accounts = derived_array(ledgerData, (val) => val.accounts);
+export const accounts: Readable<string[]> = derived_array(
+  ledgerData,
+  (val) => val.accounts
+);
+
+export const account_details = derived(
+  ledgerData,
+  (val) => val.account_details
+);
 /** The ranked array of all currencies. */
 export const currencies = derived_array(ledgerData, (val) => val.currencies);
 /** The ranked array of all links. */

--- a/frontend/src/stores/index.ts
+++ b/frontend/src/stores/index.ts
@@ -83,10 +83,7 @@ export const incognito = derived(ledgerData, (val) => val.incognito);
 export const baseURL = derived(ledgerData, (val) => val.baseURL);
 
 /** The ranked array of all accounts. */
-export const accounts: Readable<string[]> = derived_array(
-  ledgerData,
-  (val) => val.accounts
-);
+export const accounts = derived_array(ledgerData, (val) => val.accounts);
 
 export const account_details = derived(
   ledgerData,

--- a/src/fava/core/accounts.py
+++ b/src/fava/core/accounts.py
@@ -2,6 +2,8 @@
 from __future__ import annotations
 
 import datetime
+from dataclasses import dataclass
+from dataclasses import field
 from typing import Dict
 
 from beancount.core.account import TYPE as ACCOUNT_TYPE
@@ -12,17 +14,15 @@ from beancount.core.data import Pad
 from beancount.core.data import Transaction
 
 
+@dataclass
 class AccountData:
     """Holds information about an account."""
 
-    __slots__ = ("meta", "close_date")
+    #: The date on which this account is closed (or datetime.date.max).
+    close_date: datetime.date = datetime.date.max
 
-    def __init__(self) -> None:
-        #: The date on which this account is closed (or datetime.date.max).
-        self.close_date = datetime.date.max
-
-        #: The metadata of the Open entry of this account.
-        self.meta: Meta = {}
+    #: The metadata of the Open entry of this account.
+    meta: Meta = field(default_factory=dict)
 
 
 class AccountDict(Dict[str, AccountData]):

--- a/src/fava/core/attributes.py
+++ b/src/fava/core/attributes.py
@@ -9,11 +9,9 @@ from beancount.core.getters import get_active_years as getters_get_active_years
 from beancount.core.getters import get_all_links
 from beancount.core.getters import get_all_tags
 
-from fava.core.accounts import AccountData
 from fava.core.module_base import FavaModule
 from fava.util.date import FiscalYearEnd
 from fava.util.ranking import ExponentialDecayRanker
-
 
 if TYPE_CHECKING:  # pragma: no cover
     from fava.core import FavaLedger
@@ -53,7 +51,6 @@ class AttributesModule(FavaModule):
     def __init__(self, ledger: FavaLedger) -> None:
         super().__init__(ledger)
         self.accounts: list[str] = []
-        self.account_details: dict[str, AccountData] = {}
         self.currencies: list[str] = []
         self.payees: list[str] = []
         self.links: list[str] = []
@@ -73,11 +70,6 @@ class AttributesModule(FavaModule):
         )
         currency_ranker = ExponentialDecayRanker()
         payee_ranker = ExponentialDecayRanker()
-
-        self.account_details = {
-            account: self.ledger.accounts[account]
-            for account in self.ledger.accounts
-        }
 
         transactions = self.ledger.all_entries_by_type.Transaction
         for txn in transactions:

--- a/src/fava/core/attributes.py
+++ b/src/fava/core/attributes.py
@@ -9,9 +9,11 @@ from beancount.core.getters import get_active_years as getters_get_active_years
 from beancount.core.getters import get_all_links
 from beancount.core.getters import get_all_tags
 
+from fava.core.accounts import AccountData
 from fava.core.module_base import FavaModule
 from fava.util.date import FiscalYearEnd
 from fava.util.ranking import ExponentialDecayRanker
+
 
 if TYPE_CHECKING:  # pragma: no cover
     from fava.core import FavaLedger
@@ -51,6 +53,7 @@ class AttributesModule(FavaModule):
     def __init__(self, ledger: FavaLedger) -> None:
         super().__init__(ledger)
         self.accounts: list[str] = []
+        self.account_details: dict[str, AccountData] = {}
         self.currencies: list[str] = []
         self.payees: list[str] = []
         self.links: list[str] = []
@@ -70,6 +73,11 @@ class AttributesModule(FavaModule):
         )
         currency_ranker = ExponentialDecayRanker()
         payee_ranker = ExponentialDecayRanker()
+
+        self.account_details = {
+            account: self.ledger.accounts[account]
+            for account in self.ledger.accounts
+        }
 
         transactions = self.ledger.all_entries_by_type.Transaction
         for txn in transactions:

--- a/src/fava/templates/_layout.html
+++ b/src/fava/templates/_layout.html
@@ -55,6 +55,7 @@
       }|tojson }}</script>
       <script type="application/json" id="ledger-data">{{ {
         'accounts': ledger.attributes.accounts,
+        'account_details': ledger.attributes.account_details,
         'baseURL': url_for('index'),
         'currencies': ledger.attributes.currencies,
         'errors': ledger.errors|length,

--- a/src/fava/templates/_layout.html
+++ b/src/fava/templates/_layout.html
@@ -55,7 +55,7 @@
       }|tojson }}</script>
       <script type="application/json" id="ledger-data">{{ {
         'accounts': ledger.attributes.accounts,
-        'account_details': ledger.attributes.account_details,
+        'account_details': ledger.accounts,
         'baseURL': url_for('index'),
         'currencies': ledger.attributes.currencies,
         'errors': ledger.errors|length,


### PR DESCRIPTION
With this change, closed accounts will not be suggested anymore for transactions.

I hope this is okay, but please tell me if I've made a mistake 🙂
I'm also wondering if it makes sense to have `accounts` and `closing_dates` separately, or if `accounts` should maybe be a dictionary with account info as its value. This way, only one variable would be necessary, and it can easily be extended in the future.

Also, a huge thank you to @yagebu for your help!

Issue: #1377