### PR TITLE
Fix position of </p> in journal table

### DIFF
--- a/src/fava/templates/_journal_table.html
+++ b/src/fava/templates/_journal_table.html
@@ -114,8 +114,8 @@
           <span class="num">
           {%- for pos in balance|cost_or_value(entry.date) %}{{ commodity_macros.render_amount(ledger, pos.units) }}<br>{% endfor -%}
           </span>
-        </p>
         {% endif %}
+        </p>
         {{ render_metadata(metadata, entry_hash) }}
         {% if entry.postings %}
           <ul class="postings">


### PR DESCRIPTION
I believe the `</p>` is misplaced. The corresponding `<p>` seems to start way before the `{% if %}` block, so there is no reason the `</p>` should be inside this block.