### PR TITLE
Adds fava-option to configure number of digits after comma in Fava.

### DIFF
--- a/src/fava/core/fava_options.py
+++ b/src/fava/core/fava_options.py
@@ -70,7 +70,7 @@ class FavaOptions:
     upcoming_events: int = 7
     uptodate_indicator_grey_lookback_days: int = 60
     use_external_editor: bool = False
-    float_point_precision: int = 0 #Equivalent to MOST_COMMON
+    float_point_precision: int = 0  # Equivalent to MOST_COMMON
 
     asdict = asdict
 

--- a/src/fava/core/fava_options.py
+++ b/src/fava/core/fava_options.py
@@ -70,6 +70,7 @@ class FavaOptions:
     upcoming_events: int = 7
     uptodate_indicator_grey_lookback_days: int = 60
     use_external_editor: bool = False
+    float_point_precision: int = 0 #Equivalent to MOST_COMMON
 
     asdict = asdict
 

--- a/src/fava/core/number.py
+++ b/src/fava/core/number.py
@@ -70,7 +70,12 @@ class DecimalFormatModule(FavaModule):
 
         dcontext = self.ledger.options["dcontext"]
         for currency, ccontext in dcontext.ccontexts.items():
-            prec = ccontext.get_fractional(Precision.MOST_COMMON)
+            if self.ledger.fava_options.float_point_precision == 0:
+                prec = ccontext.get_fractional(Precision.MOST_COMMON)
+            elif self.ledger.fava_options.float_point_precision > 0:
+                prec = self.ledger.fava_options.float_point_precision
+            else:
+                prec = ccontext.get_fractional(Precision.MAXIMUM)
             if prec is not None:
                 self.formatters[currency] = get_locale_format(
                     self.locale, prec

--- a/src/fava/help/options.md
+++ b/src/fava/help/options.md
@@ -261,8 +261,9 @@ and the individual account pages are not affected by this configuration option.
 
 Default: `0` (which uses the most common precision)
 
-By default Fava outputs all reports using the most common precision retrieved in the Beancount files.
-This option allows to set a fixed number of digits after the comma, for example: 2. If this value is set
-with a positive number, Fava will use this amount of digits for precision. If the number is set to zero (default),
-Fava will use the most common precision found by Beancount. Set to a negative value, i.e -1, to use Beancount's
-max precision.
+By default Fava outputs all reports using the most common precision retrieved in
+the Beancount files. This option allows to set a fixed number of digits after
+the comma, for example: 2. If this value is set with a positive number, Fava
+will use this amount of digits for precision. If the number is set to zero
+(default), Fava will use the most common precision found by Beancount. Set to a
+negative value, i.e -1, to use Beancount's max precision.

--- a/src/fava/help/options.md
+++ b/src/fava/help/options.md
@@ -256,3 +256,13 @@ if the income is greater than the expenses for a given timespan.
 
 Note: To keep consistency with the internal accounting of beancount, the journal
 and the individual account pages are not affected by this configuration option.
+
+## `float_point_precision`
+
+Default: `0` (which uses the most common precision)
+
+By default Fava outputs all reports using the most common precision retrieved in the Beancount files.
+This option allows to set a fixed number of digits after the comma, for example: 2. If this value is set
+with a positive number, Fava will use this amount of digits for precision. If the number is set to zero (default),
+Fava will use the most common precision found by Beancount. Set to a negative value, i.e -1, to use Beancount's
+max precision.


### PR DESCRIPTION
Adds an option to set the precision display in Fava, keeping the default behavior of using Precision.MOST_COMMON from Beancount.
Related: https://github.com/beancount/fava/issues/1069