### PR TITLE
Fix modal size on mobile

### DIFF
--- a/frontend/src/modals/ModalBase.svelte
+++ b/frontend/src/modals/ModalBase.svelte
@@ -55,6 +55,8 @@
 <style>
   .background {
     position: fixed;
+    top: 0;
+    left: 0;
     width: 100%;
     height: 100%;
     cursor: pointer;
@@ -64,9 +66,9 @@
   .overlay {
     position: fixed;
     top: 0;
-    right: 0;
-    bottom: 0;
     left: 0;
+    width: 100vw;
+    height: 100vh;
     z-index: var(--z-index-overlay);
     display: flex;
     align-items: center;

--- a/frontend/src/modals/ModalBase.svelte
+++ b/frontend/src/modals/ModalBase.svelte
@@ -67,12 +67,12 @@
     position: fixed;
     top: 0;
     left: 0;
-    width: 100vw;
-    height: 100vh;
     z-index: var(--z-index-overlay);
     display: flex;
     align-items: center;
     justify-content: center;
+    width: 100vw;
+    height: 100vh;
   }
 
   .content {


### PR DESCRIPTION
Hey!

With this pull request I propose a fix for #1229.

First of all, I do not understand _why_ the browser behaves as it does.
The modal looks good on desktop and keeps looking good when resizing the browser window to mobile dimensions.
When using the developer tools to test mobile devices, however, you can activate touchscreen emulation, which breaks modals on desktop too.

![Touchscreen Emulation](https://user-images.githubusercontent.com/1913775/174891210-82c9714f-049c-42cd-8384-54a977b3e176.png)

Using viewport units instead of `left: 0;` and `right: 0;` etc. to stretch the `.overlay` to the screen size, seems to be working fine, even on mobile.

I tested the patch on desktop Firefox as well as mobile Chrome and Firefox.