### PR TITLE
explicit filtered ledger

### DIFF
--- a/src/fava/application.py
+++ b/src/fava/application.py
@@ -217,7 +217,7 @@ def _perform_global_filters() -> None:
         if request.blueprint != "json_api":
             ledger.changed()
 
-        ledger.filter(
+        g.filtered = ledger.get_filtered(
             account=request.args.get("account"),
             filter=request.args.get("filter"),
             time=request.args.get("time"),
@@ -354,7 +354,7 @@ def extension_report(report_name: str) -> str:
 def download_query(result_format: str) -> Any:
     """Download a query result."""
     name, data = g.ledger.query_shell.query_to_file(
-        request.args.get("query_string", ""), result_format
+        g.filtered.entries, request.args.get("query_string", ""), result_format
     )
 
     filename = f"{secure_filename(name.strip())}.{result_format}"

--- a/src/fava/context.py
+++ b/src/fava/context.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import flask
 
 from fava.core import FavaLedger
+from fava.core import FilteredLedger
 from fava.util.date import Interval
 
 
@@ -14,6 +15,7 @@ class Context:
     conversion: str
     interval: Interval
     ledger: FavaLedger
+    filtered: FilteredLedger
 
 
 g: Context = flask.g  # type: ignore

--- a/src/fava/core/query_shell.py
+++ b/src/fava/core/query_shell.py
@@ -74,7 +74,7 @@ class QueryShell(BQLShell, FavaModule):
             )
 
     def _loadfun(self) -> None:
-        self.entries = self.ledger.entries
+        self.entries = self.ledger.all_entries
         self.errors = self.ledger.errors
         self.options_map = self.ledger.options
 
@@ -110,7 +110,7 @@ class QueryShell(BQLShell, FavaModule):
 
         self.result = rtypes, rrows
 
-    def execute_query(self, query: str):
+    def execute_query(self, entries: Entries, query: str):
         """Run a query.
 
         Arguments:
@@ -123,6 +123,7 @@ class QueryShell(BQLShell, FavaModule):
             contained in ``contents`` (as a string).
         """
         self._loadfun()
+        self.entries = entries
         with contextlib.redirect_stdout(self.buffer):
             self.onecmd(query)
         contents = self.buffer.getvalue()
@@ -151,7 +152,9 @@ class QueryShell(BQLShell, FavaModule):
                 statement = self.parser.parse(query.query_string)
                 self.dispatch(statement)
 
-    def query_to_file(self, query_string: str, result_format: str):
+    def query_to_file(
+        self, entries: Entries, query_string: str, result_format: str
+    ):
         """Get query result as file.
 
         Arguments:
@@ -187,7 +190,7 @@ class QueryShell(BQLShell, FavaModule):
 
         try:
             types, rows = run_query(
-                self.ledger.entries,
+                entries,
                 self.ledger.options,
                 query_string,
                 numberify=True,

--- a/src/fava/ext/portfolio_list/__init__.py
+++ b/src/fava/ext/portfolio_list/__init__.py
@@ -10,6 +10,7 @@ import re
 from beancount.core.number import Decimal
 from beancount.core.number import ZERO
 
+from fava.context import g
 from fava.ext import FavaExtensionBase
 from fava.helpers import FavaAPIException
 from fava.template_filters import cost_or_value
@@ -22,7 +23,7 @@ class PortfolioList(FavaExtensionBase):  # pragma: no cover
 
     def portfolio_accounts(self):
         """An account tree based on matching regex patterns."""
-        tree = self.ledger.root_tree
+        tree = g.filtered.root_tree
         portfolios = []
 
         for option in self.config:  # pylint: disable=not-an-iterable

--- a/src/fava/json_api.py
+++ b/src/fava/json_api.py
@@ -175,7 +175,9 @@ class QueryResult:
 def get_query_result(query_string: str) -> Any:
     """Render a query result to HTML."""
     table = get_template_attribute("_query_table.html", "querytable")
-    contents, types, rows = g.ledger.query_shell.execute_query(query_string)
+    contents, types, rows = g.ledger.query_shell.execute_query(
+        g.filtered.entries, query_string
+    )
     if contents:
         if "ERROR" in contents:
             raise FavaAPIException(contents)

--- a/src/fava/template_filters.py
+++ b/src/fava/template_filters.py
@@ -119,10 +119,11 @@ def should_show(account: TreeNode) -> bool:
     ):
         return True
     ledger = g.ledger
+    filtered = g.filtered
     if account.name not in ledger.accounts:
         return False
     fava_options = ledger.fava_options
-    if not fava_options.show_closed_accounts and ledger.account_is_closed(
+    if not fava_options.show_closed_accounts and filtered.account_is_closed(
         account.name
     ):
         return False

--- a/src/fava/templates/_charts.html
+++ b/src/fava/templates/_charts.html
@@ -6,7 +6,7 @@
 'label': account_name if not label else label,
 'data': {
   'modifier': ledger.get_account_sign(account_name),
-  'root': ledger.charts.hierarchy(account_name, g.conversion, begin_date, end_date or g.ledger.end_date),
+  'root': ledger.charts.hierarchy(g.filtered, account_name, g.conversion, begin_date, end_date or g.filtered.end_date),
 },
 }) %}
 {% endmacro %}
@@ -15,7 +15,7 @@
 {% do chart_data.append({
 'type': 'bar',
 'label': account_name if not label else label,
-'data': ledger.charts.interval_totals(interval, account_name, g.conversion, invert=invert),
+'data': ledger.charts.interval_totals(g.filtered, interval, account_name, g.conversion, invert=invert),
 }) %}
 {% endmacro %}
 
@@ -31,7 +31,7 @@
 {% do chart_data.append({
 'type': 'balances',
 'label': _('Net Worth'),
-'data': ledger.charts.net_worth(interval, g.conversion),
+'data': ledger.charts.net_worth(g.filtered, interval, g.conversion),
 }) %}
 {% endmacro %}
 
@@ -39,17 +39,17 @@
 {% do chart_data.append({
 'type': 'balances',
 'label': _('Account Balance'),
-'data': ledger.charts.linechart(account_name, g.conversion),
+'data': ledger.charts.linechart(g.filtered, account_name, g.conversion),
 }) %}
 {% endmacro %}
 
 {% macro commodities() %}
-{% for base, quote, prices in ledger.charts.prices() %}
+{% for base, quote, prices in ledger.charts.prices(g.filtered) %}
 {% do chart_data.append({
 'type': 'commodities',
 'label': '{0} / {1}'.format(base, quote),
 'data': {
-  'prices': ledger.prices(base, quote),
+  'prices': g.filtered.prices(base, quote),
   'base': base,
   'quote': quote,
 },

--- a/src/fava/templates/_tree_table.html
+++ b/src/fava/templates/_tree_table.html
@@ -31,9 +31,10 @@ Hold Ctrl or Cmd while clicking to expand one level.') }}">
       <span class="num other">{{ _('Other') }}</span>
     </p>
   </li>
+  {% set end_date = g.filtered.end_date %}
   {% for account in ([account_node] if account_node.name else account_node.children) if account|should_show recursive %}
-  {% set balance = account.balance|cost_or_value(ledger.end_date) %}
-  {% set balance_children = account.balance_children|cost_or_value(ledger.end_date) %}
+  {% set balance = account.balance|cost_or_value(end_date) %}
+  {% set balance_children = account.balance_children|cost_or_value(end_date) %}
   {% set cost = account.balance|cost if g.conversion == 'at_value' else {} %}
   {% set cost_children = account.balance_children|cost if g.conversion == 'at_value' else {} %}
   <li{{ ' class=toggled' if account.name|collapse_account else '' }}>

--- a/src/fava/templates/account.html
+++ b/src/fava/templates/account.html
@@ -25,11 +25,11 @@
   </div>
 
   {% if journal %}
-  {% set entries = ledger.account_journal(account_name, with_journal_children=ledger.fava_options.account_journal_include_children) %}
+  {% set entries = ledger.account_journal(g.filtered, account_name, with_journal_children=ledger.fava_options.account_journal_include_children) %}
   {{ journal_table.journal_table(entries, show_change_and_balance=True) }}
   {% else %}
   {% set accumulate = subreport == 'balances' %}
-  {% set interval_balances, dates = ledger.interval_balances(g.interval, account_name, accumulate) %}
+  {% set interval_balances, dates = ledger.interval_balances(g.filtered, g.interval, account_name, accumulate) %}
   {% if interval_balances %}
   {% for begin_date, end_date in dates[:3] %}
   {{ charts.hierarchy(account_name, begin_date, end_date, label=begin_date|format_date) }}

--- a/src/fava/templates/balance_sheet.html
+++ b/src/fava/templates/balance_sheet.html
@@ -5,7 +5,7 @@
 {{ charts.hierarchy(ledger.options['name_liabilities']) }}
 {{ charts.hierarchy(ledger.options['name_equity']) }}
 
-{% set root_tree_closed = ledger.root_tree_closed %}
+{% set root_tree_closed = g.filtered.root_tree_closed %}
 {% set invert = ledger.fava_options.invert_income_liabilities_equity %}
 
 <div class="row">

--- a/src/fava/templates/beancount_file
+++ b/src/fava/templates/beancount_file
@@ -13,6 +13,6 @@ option "name_income" "{{ ledger.options.name_income }}"
 option "name_expenses" "{{ ledger.options.name_expenses }}"
 plugin "beancount.plugins.auto_accounts"
 
-{% for rendered_entry in ledger.file.render_entries(ledger.entries) %}
+{% for rendered_entry in ledger.file.render_entries(g.filtered.entries) %}
 {{ rendered_entry|safe }}
 {% endfor %}

--- a/src/fava/templates/commodities.html
+++ b/src/fava/templates/commodities.html
@@ -1,7 +1,7 @@
 {{ charts.commodities() }}
 
 {% for commodity_pair in ledger.commodity_pairs() %}
-{% set prices = ledger.prices(*commodity_pair) %}
+{% set prices = g.filtered.prices(*commodity_pair) %}
 {% if prices %}
 <div class="left">
   <h3>{{ commodity_pair.0 }} / {{ commodity_pair.1 }}</h3>

--- a/src/fava/templates/documents.html
+++ b/src/fava/templates/documents.html
@@ -1,1 +1,1 @@
-<svelte-component type="documents"><script type="application/json">{{ ledger.documents|tojson }}</script></svelte-component>
+<svelte-component type="documents"><script type="application/json">{{ g.filtered.documents|tojson }}</script></svelte-component>

--- a/src/fava/templates/events.html
+++ b/src/fava/templates/events.html
@@ -1,4 +1,4 @@
-{% set events = ledger.events() %}
+{% set events = g.filtered.events() %}
 {% if events %}
 {{ charts.events() }}
 {% for group in events|groupby('type') %}

--- a/src/fava/templates/holdings.html
+++ b/src/fava/templates/holdings.html
@@ -52,5 +52,5 @@
 <a href="{{ url_for('report', report_name='query', query_string=query_string) }}">Query</a>
 {{ querytable.download_links(query_string) }}
 </p>
-{% set contents, result_types, result_rows = ledger.query_shell.execute_query(query_string) %}
+{% set contents, result_types, result_rows = ledger.query_shell.execute_query(g.filtered.entries, query_string) %}
 {{ querytable.querytable(ledger, contents, result_types, result_rows, filter_empty=units_column.get(aggregation_key, 1)) }}

--- a/src/fava/templates/income_statement.html
+++ b/src/fava/templates/income_statement.html
@@ -1,22 +1,25 @@
 {% import '_tree_table.html' as tree_table with context %}
 
+{% set root_tree = g.filtered.root_tree %}
+{% set options = ledger.options %}
 {% set invert = ledger.fava_options.invert_income_liabilities_equity %}
 
-{{ charts.interval_totals(g.interval, (ledger.options['name_income'], ledger.options['name_expenses']), label=_('Net Profit'), invert=invert) }}
-{{ charts.interval_totals(g.interval, ledger.options['name_income'], label=_('Income'), invert=invert) }}
-{{ charts.interval_totals(g.interval, ledger.options['name_expenses'], label=_('Expenses')) }}
+{{ charts.interval_totals(g.interval, (options['name_income'], options['name_expenses']), label=_('Net Profit'), invert=invert) }}
+{{ charts.interval_totals(g.interval, options['name_income'], label=_('Income'), invert=invert) }}
+{{ charts.interval_totals(g.interval, options['name_expenses'], label=_('Expenses')) }}
 
-{{ charts.hierarchy(ledger.options['name_income']) }}
-{{ charts.hierarchy(ledger.options['name_expenses']) }}
+{{ charts.hierarchy(options['name_income']) }}
+{{ charts.hierarchy(options['name_expenses']) }}
+
 
 <div class="row">
   <div class="column">
-    {{ tree_table.tree(ledger.root_tree.get(ledger.options['name_income']), invert=invert) }}
+    {{ tree_table.tree(root_tree.get(options['name_income']), invert=invert) }}
   </div>
   <div class="column">
-    {{ tree_table.tree(ledger.root_tree.get(ledger.options['name_expenses'])) }}
+    {{ tree_table.tree(root_tree.get(options['name_expenses'])) }}
   </div>
   <div class="column">
-    {{ tree_table.tree(ledger.root_tree.net_profit(ledger.options, _('Net Profit')), invert=invert) }}
+    {{ tree_table.tree(root_tree.net_profit(options, _('Net Profit')), invert=invert) }}
   </div>
 </div>

--- a/src/fava/templates/journal.html
+++ b/src/fava/templates/journal.html
@@ -1,3 +1,3 @@
 {% import '_journal_table.html' as journal_table with context %}
 
-{{ journal_table.journal_table(ledger.entries) }}
+{{ journal_table.journal_table(g.filtered.entries) }}

--- a/src/fava/templates/statistics.html
+++ b/src/fava/templates/statistics.html
@@ -18,7 +18,7 @@
     {{ _('Postings per Account') }}
     (<a href="{{ url_for('report', report_name='query', query_string=postings_per_account) }}">Query</a>)
   </h3>
-  {% set contents, result_types, result_rows = ledger.query_shell.execute_query(postings_per_account) %}
+  {% set contents, result_types, result_rows = ledger.query_shell.execute_query(g.filtered.entries, postings_per_account) %}
   {{ querytable.querytable(ledger, contents, result_types, result_rows) }}
 </div>
 
@@ -53,7 +53,7 @@
         {% endif %}
         <td><a href="#context-{{ last_entry|hash_entry }}">{{ last_entry.date }}</a></td>
         <td class="num">
-          {%- for position in (ledger.root_account|get_or_create(account)).balance|units -%}
+          {%- for position in (g.filtered.root_account|get_or_create(account)).balance|units -%}
           {{ commodity_macros.render_amount(ledger, position.units) }}<br>
           {% endfor -%}
         </td>
@@ -75,7 +75,7 @@
       </tr>
     </thead>
     <tbody>
-      {% for type, entries in ledger.group_entries_by_type(ledger.entries) %}
+      {% for type, entries in ledger.group_entries_by_type(g.filtered.entries) %}
       <tr>
         <td>{{ type }}</td>
         <td class="num">{{ entries|length }}</td>
@@ -85,7 +85,7 @@
     <tfoot>
       <tr>
         <td>{{ _('Total') }}</td>
-        <td class="num">{{ ledger.entries|length }}</td>
+        <td class="num">{{ g.filtered.entries|length }}</td>
       </tr>
     </tfoot>
   </table>

--- a/src/fava/templates/trial_balance.html
+++ b/src/fava/templates/trial_balance.html
@@ -4,4 +4,4 @@
 {{ charts.hierarchy(ledger.options['name_{}'.format(base_account)]) }}
 {% endfor %}
 
-{{ tree_table.tree(ledger.root_tree.get('')) }}
+{{ tree_table.tree(g.filtered.root_tree.get('')) }}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,6 @@ from pprint import pformat
 from typing import Any
 from typing import Callable
 from typing import Counter
-from typing import Iterable
 from typing import TYPE_CHECKING
 
 import pytest
@@ -122,9 +121,8 @@ def small_example_ledger() -> FavaLedger:
 
 
 @pytest.fixture
-def example_ledger() -> Iterable[FavaLedger]:
-    yield EXAMPLE_LEDGER
-    EXAMPLE_LEDGER.filter(account=None, filter=None, time=None)
+def example_ledger() -> FavaLedger:
+    return EXAMPLE_LEDGER
 
 
 @pytest.fixture

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -9,6 +9,7 @@ from pytest import MonkeyPatch
 
 from fava.core import FavaLedger
 from fava.helpers import FavaAPIException
+from fava.util.date import Interval
 
 if TYPE_CHECKING:
     from fava.util.typing import LoaderResult
@@ -90,3 +91,17 @@ def test_commodity_names(example_ledger: FavaLedger) -> None:
     assert example_ledger.commodity_names.get("USD") == "US Dollar"
     assert example_ledger.commodity_names.get("NOCOMMODITY") is None
     assert example_ledger.commodity_names.get("VMMXX") is None
+
+
+@pytest.mark.filterwarnings("ignore:FavaLedger.*deprecated")
+def test_deprecated_filtered(example_ledger: FavaLedger) -> None:
+    assert example_ledger.all_entries == example_ledger.entries
+    assert example_ledger.all_root_account == example_ledger.root_account
+    assert example_ledger.root_tree
+    assert not example_ledger.filters.time
+    assert not example_ledger.account_is_closed("test")
+    assert example_ledger.end_date is None
+    assert example_ledger.interval_ends(Interval.MONTH)
+    assert example_ledger.documents == []
+    assert example_ledger.events()
+    assert example_ledger.events("test") == []

--- a/tests/test_core_query_shell.py
+++ b/tests/test_core_query_shell.py
@@ -16,7 +16,7 @@ QUERY = LEDGER.query_shell
 
 
 def run(query_string: str) -> Any:
-    return QUERY.execute_query(query_string)
+    return QUERY.execute_query(LEDGER.all_entries, query_string)
 
 
 def run_text(query_string: str) -> str:
@@ -47,7 +47,7 @@ def test_query() -> None:
     assert run("run custom_query") == bal
     assert run("run 'custom query with space'") == bal
     assert run("balances")[1:] == run_query(
-        LEDGER.entries, LEDGER.options, "balances"
+        LEDGER.all_entries, LEDGER.options, "balances"
     )
     assert (
         run_text("asdf")
@@ -56,14 +56,15 @@ def test_query() -> None:
 
 
 def test_query_to_file(snapshot: SnapshotFunc) -> None:
-    name, data = QUERY.query_to_file("run custom_query", "csv")
+    entries = LEDGER.all_entries
+    name, data = QUERY.query_to_file(entries, "run custom_query", "csv")
     assert name == "custom_query"
-    name, data = QUERY.query_to_file("balances", "csv")
+    name, data = QUERY.query_to_file(entries, "balances", "csv")
     assert name == "query_result"
     snapshot(data.getvalue())
 
     with pytest.raises(FavaAPIException):
-        QUERY.query_to_file("select sdf", "csv")
+        QUERY.query_to_file(entries, "select sdf", "csv")
 
     with pytest.raises(FavaAPIException):
-        QUERY.query_to_file("run testsetest", "csv")
+        QUERY.query_to_file(entries, "run testsetest", "csv")

--- a/tests/test_template_filters.py
+++ b/tests/test_template_filters.py
@@ -77,8 +77,8 @@ def test_get_or_create(example_ledger: FavaLedger) -> None:
 def test_should_show(app: Flask) -> None:
     with app.test_request_context("/long-example/"):
         app.preprocess_request()
-        assert should_show(g.ledger.root_tree.get("")) is True
-        assert should_show(g.ledger.root_tree.get("Expenses")) is True
+        assert should_show(g.filtered.root_tree.get("")) is True
+        assert should_show(g.filtered.root_tree.get("Expenses")) is True
 
         account = TreeNode("name")
         assert should_show(account) is False
@@ -87,8 +87,8 @@ def test_should_show(app: Flask) -> None:
     with app.test_request_context("/long-example/income_statement/?time=2100"):
         app.preprocess_request()
         assert not g.ledger.fava_options.show_accounts_with_zero_balance
-        assert should_show(g.ledger.root_tree.get("")) is True
-        assert should_show(g.ledger.root_tree.get("Expenses")) is False
+        assert should_show(g.filtered.root_tree.get("")) is True
+        assert should_show(g.filtered.root_tree.get("Expenses")) is False
 
 
 def test_format_errormsg(app: Flask) -> None:

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ deps =
     pytest
     pytest-cov
 commands =
-    pytest --cov=fava --cov-report=html --cov-fail-under=89 {posargs:tests}
+    pytest --cov=fava --cov-report=html --cov-fail-under=90 {posargs:tests}
 
 [testenv:py]
 extras = excel


### PR DESCRIPTION
The Ledger class, which contains most information about a given
Beancount file was previously always modified in-place to filter for the
currently given filters of the Fava frontend. With multiple requests
coming in, this lead to race conditions which resulted in incorrect data
being returned.

The Ledger class is not modified anymore to filter, but rather a new
class FilteredLedger is created for each requests. By using caching,
this should be more performant than the previous solution.

The attributes on the Ledger class that changed on filtering are now all
deprecated and do no respect the filters anymore. Extensions using them
can be fixed by accessing the attributes of `g.filtered` instead, e.g.,
`g.filtered.entries` instead of `ledger.entries`.

Fixes #1418 
<!--
Hi, thank you for opening a PR!

Please ensure that your change passes tests and the various linters by running
`make test` and `make lint`. If testable, your changes should be covered by
unit tests.

Explain your changes below and link to related issues.
-->
