### PR TITLE
override currency precision via metadata

### DIFF
--- a/frontend/src/charts/Sunburst.svelte
+++ b/frontend/src/charts/Sunburst.svelte
@@ -24,9 +24,7 @@
   function balanceText(d: AccountHierarchyNode): string {
     const val = d.value ?? 0;
     const rootVal = root.value || 1;
-    return `${$ctx.currency(val)} ${currency} (${formatPercentage(
-      val / rootVal
-    )})`;
+    return `${$ctx.amount(val, currency)} (${formatPercentage(val / rootVal)})`;
   }
 
   $: root = partition<AccountHierarchyDatum>()(data);

--- a/frontend/src/charts/Treemap.svelte
+++ b/frontend/src/charts/Treemap.svelte
@@ -35,7 +35,7 @@
     const val = d.value ?? 0;
     const rootValue = root.value || 1;
 
-    return `${$ctx.currency(val)} ${currency} (${formatPercentage(
+    return `${$ctx.amount(val, currency)} (${formatPercentage(
       val / rootValue
     )})<em>${d.data.account}</em>`;
   }

--- a/frontend/src/charts/bar.ts
+++ b/frontend/src/charts/bar.ts
@@ -94,17 +94,17 @@ export function bar(
       let text = "";
       if (e === "") {
         d.values.forEach((a) => {
-          text += `${c.currency(a.value)} ${a.currency}`;
+          text += c.amount(a.value, a.currency);
           if (a.budget) {
-            text += ` / ${c.currency(a.budget)} ${a.currency}`;
+            text += ` / ${c.amount(a.budget, a.currency)}`;
           }
           text += "<br>";
         });
       } else {
         text += `<em>${e}</em>`;
         d.values.forEach((a) => {
-          const value = c.currency(d.account_balances[e]?.[a.currency] ?? 0);
-          text += `${value} ${a.currency}<br>`;
+          const value = d.account_balances[e]?.[a.currency] ?? 0;
+          text += `${c.amount(value, a.currency)}<br>`;
         });
       }
       text += `<em>${d.label}</em>`;

--- a/frontend/src/charts/line.ts
+++ b/frontend/src/charts/line.ts
@@ -58,7 +58,7 @@ export function balances(json: unknown): Result<LineChart, string> {
     type: "linechart" as const,
     data,
     tooltipText: (c, d) =>
-      `${c.currency(d.value)} ${d.name}<em>${day(d.date)}</em>`,
+      `${c.amount(d.value, d.name)}<em>${day(d.date)}</em>`,
   });
 }
 
@@ -83,9 +83,7 @@ export function commodities(
     type: "linechart" as const,
     data: [{ name: label, values }],
     tooltipText(c, d) {
-      return `1 ${base} = ${c.currency(d.value)} ${quote}<em>${day(
-        d.date
-      )}</em>`;
+      return `1 ${base} = ${c.amount(d.value, quote)}<em>${day(d.date)}</em>`;
     },
   });
 }

--- a/frontend/src/stores/index.ts
+++ b/frontend/src/stores/index.ts
@@ -51,6 +51,7 @@ export const ledgerDataValidator = object({
     operating_currency: array(string),
   }),
   payees: array(string),
+  precisions: record(number),
   tags: array(string),
   years: array(string),
 });
@@ -72,6 +73,8 @@ export const ledgerData: Readable<LedgerData> = derived(rawLedgerData, (s) => {
 export const favaOptions = derived(ledgerData, (val) => val.favaOptions);
 /** Beancount's options */
 export const options = derived(ledgerData, (val) => val.options);
+/** Commodity display precisions. */
+export const precisions = derived(ledgerData, (val) => val.precisions);
 /** Whether Fava supports exporting to Excel. */
 export const HAVE_EXCEL = derived(ledgerData, (val) => val.have_excel);
 /** Whether Fava should obscure all numbers. */

--- a/src/fava/core/__init__.py
+++ b/src/fava/core/__init__.py
@@ -50,6 +50,7 @@ from fava.core.accounts import get_entry_accounts
 from fava.core.attributes import AttributesModule
 from fava.core.budgets import BudgetModule
 from fava.core.charts import ChartModule
+from fava.core.commodities import CommoditiesModule
 from fava.core.entries_by_type import group_entries_by_type
 from fava.core.extensions import ExtensionModule
 from fava.core.fava_options import FavaOptions
@@ -133,6 +134,7 @@ MODULES = [
     "attributes",
     "budgets",
     "charts",
+    "commodities",
     "extensions",
     "file",
     "format_decimal",
@@ -273,7 +275,6 @@ class FavaLedger:
         "all_entries_by_type",
         "all_root_account",
         "beancount_file_path",
-        "commodity_names",
         "errors",
         "fava_options",
         "_is_encrypted",
@@ -304,6 +305,9 @@ class FavaLedger:
 
         #: A :class:`.ChartModule` instance.
         self.charts = ChartModule(self)
+
+        #: A :class:`.CommoditiesModule` instance.
+        self.commodities = CommoditiesModule(self)
 
         #: A :class:`.ExtensionModule` instance.
         self.extensions = ExtensionModule(self)
@@ -340,9 +344,6 @@ class FavaLedger:
         #: A dict containing information about the accounts.
         self.accounts = AccountDict()
 
-        #: A dict with commodity names (from the 'name' metadata)
-        self.commodity_names: dict[str, str] = {}
-
         #: A dict with all of Fava's option values.
         self.fava_options: FavaOptions = FavaOptions()
 
@@ -376,12 +377,6 @@ class FavaLedger:
             self.accounts.setdefault(open_entry.account).meta = open_entry.meta
         for close in self.all_entries_by_type.Close:
             self.accounts.setdefault(close.account).close_date = close.date
-
-        self.commodity_names = {}
-        for commodity in self.all_entries_by_type.Commodity:
-            name = commodity.meta.get("name")
-            if name:
-                self.commodity_names[commodity.currency] = name
 
         self.fava_options, errors = parse_options(
             self.all_entries_by_type.Custom

--- a/src/fava/core/commodities.py
+++ b/src/fava/core/commodities.py
@@ -1,0 +1,27 @@
+"""Attributes for auto-completion."""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from fava.core.module_base import FavaModule
+
+if TYPE_CHECKING:  # pragma: no cover
+    from fava.core import FavaLedger
+
+
+class CommoditiesModule(FavaModule):
+    """Details about the currencies and commodities."""
+
+    def __init__(self, ledger: FavaLedger) -> None:
+        super().__init__(ledger)
+        self._commodity_names: dict[str, str] = {}
+
+    def load_file(self) -> None:
+        self._commodity_names = {}
+        for commodity in self.ledger.all_entries_by_type.Commodity:
+            name = commodity.meta.get("name")
+            if name:
+                self._commodity_names[commodity.currency] = name
+
+    def name(self, commodity: str) -> str:
+        return self._commodity_names.get(commodity, commodity)

--- a/src/fava/core/commodities.py
+++ b/src/fava/core/commodities.py
@@ -14,14 +14,24 @@ class CommoditiesModule(FavaModule):
 
     def __init__(self, ledger: FavaLedger) -> None:
         super().__init__(ledger)
-        self._commodity_names: dict[str, str] = {}
+        self._names: dict[str, str] = {}
+        self._precisions: dict[str, int] = {}
 
     def load_file(self) -> None:
-        self._commodity_names = {}
+        self._names = {}
         for commodity in self.ledger.all_entries_by_type.Commodity:
             name = commodity.meta.get("name")
             if name:
-                self._commodity_names[commodity.currency] = name
+                self._names[commodity.currency] = name
+            precision = commodity.meta.get("precision")
+            if precision:
+                try:
+                    self._precisions[commodity.currency] = int(precision)
+                except ValueError:
+                    pass
 
     def name(self, commodity: str) -> str:
-        return self._commodity_names.get(commodity, commodity)
+        return self._names.get(commodity, commodity)
+
+    def precision(self, commodity: str) -> int | None:
+        return self._precisions.get(commodity)

--- a/src/fava/core/commodities.py
+++ b/src/fava/core/commodities.py
@@ -15,10 +15,11 @@ class CommoditiesModule(FavaModule):
     def __init__(self, ledger: FavaLedger) -> None:
         super().__init__(ledger)
         self._names: dict[str, str] = {}
-        self._precisions: dict[str, int] = {}
+        self.precisions: dict[str, int] = {}
 
     def load_file(self) -> None:
         self._names = {}
+        self.precisions = {}
         for commodity in self.ledger.all_entries_by_type.Commodity:
             name = commodity.meta.get("name")
             if name:
@@ -26,7 +27,7 @@ class CommoditiesModule(FavaModule):
             precision = commodity.meta.get("precision")
             if precision:
                 try:
-                    self._precisions[commodity.currency] = int(precision)
+                    self.precisions[commodity.currency] = int(precision)
                 except ValueError:
                     pass
 
@@ -34,4 +35,4 @@ class CommoditiesModule(FavaModule):
         return self._names.get(commodity, commodity)
 
     def precision(self, commodity: str) -> int | None:
-        return self._precisions.get(commodity)
+        return self.precisions.get(commodity)

--- a/src/fava/core/commodities.py
+++ b/src/fava/core/commodities.py
@@ -32,7 +32,5 @@ class CommoditiesModule(FavaModule):
                     pass
 
     def name(self, commodity: str) -> str:
+        """Get the name of a commodity (or the commodity itself if not set)"""
         return self._names.get(commodity, commodity)
-
-    def precision(self, commodity: str) -> int | None:
-        return self.precisions.get(commodity)

--- a/src/fava/core/number.py
+++ b/src/fava/core/number.py
@@ -70,7 +70,9 @@ class DecimalFormatModule(FavaModule):
 
         dcontext = self.ledger.options["dcontext"]
         for currency, ccontext in dcontext.ccontexts.items():
-            prec = ccontext.get_fractional(Precision.MOST_COMMON)
+            prec = self.ledger.commodities.precision(currency)
+            if prec is None:
+                prec = ccontext.get_fractional(Precision.MOST_COMMON)
             if prec is not None:
                 self.formatters[currency] = get_locale_format(
                     self.locale, prec

--- a/src/fava/help/beancount_syntax.md
+++ b/src/fava/help/beancount_syntax.md
@@ -61,11 +61,16 @@ To open or close an account use the `open` and `close` directives:
 ### Commodities
 
 Declaring commodities is optional. Use this if you want to attach metadata by
-currency.
+currency. If you specify a `name` for a currency like below, this name will be
+displayed as a tooltip on hovering over currency names in Fava. Likewise, with
+the `precision` metadata, you can specify the number of decimal digits to show
+in Fava, overriding the precision that is otherwise automatically inferred from
+the input data.
 
 <pre><textarea is="beancount-textarea">
 1998-07-22 commodity AAPL
-  name: "Apple Computer Inc."</textarea></pre>
+  name: "Apple Computer Inc."
+  precision: 3</textarea></pre>
 
 ### Prices
 

--- a/src/fava/templates/_layout.html
+++ b/src/fava/templates/_layout.html
@@ -65,6 +65,7 @@
         'links': ledger.attributes.links,
         'options': ledger.options,
         'payees': ledger.attributes.payees,
+        'precisions': ledger.format_decimal.precisions,
         'tags': ledger.attributes.tags,
         'years': ledger.attributes.years,
       }|tojson }}</script>

--- a/src/fava/templates/macros/_commodity_macros.html
+++ b/src/fava/templates/macros/_commodity_macros.html
@@ -1,12 +1,12 @@
 {% macro render_currency(ledger, currency) -%}
-<span title="{{ ledger.commodity_names.get(currency, currency) }}">{{ currency }}</span>
+<span title="{{ ledger.commodities.name(currency) }}">{{ currency }}</span>
 {%- endmacro %}
 
 {% macro render_amount(ledger, amount, class="num") %}
 {% if amount is none or amount.number is none -%}
   <span class="{{ class }}"></span>
 {%- else -%}
-  <span class="{{ class }}" title="{{ ledger.commodity_names.get(amount.currency, amount.currency) }}">
+  <span class="{{ class }}" title="{{ ledger.commodities.name(amount.currency) }}">
     {{- amount.number | format_currency(amount.currency, True) }} {{ amount.currency -}}
   </span>
 {%- endif %}

--- a/tests/__snapshots__/test_json_api.py-test_api_context
+++ b/tests/__snapshots__/test_json_api.py-test_api_context
@@ -196,7 +196,7 @@
                     'flag': '*',
                     'meta': {'__tolerances__': {'USD': 0.005, 'VBMPX': 0.0005},
                              'filename': 'FAVA_LONG_EXAMPLE_PATH.beancount',
-                             'lineno': 3732},
+                             'lineno': 3735},
                     'narration': 'Investing 40% of cash in VBMPX',
                     'payee': '',
                     'postings': [{'account': 'Assets:US:Vanguard:VBMPX',

--- a/tests/__snapshots__/test_json_api.py-test_api_context-2
+++ b/tests/__snapshots__/test_json_api.py-test_api_context-2
@@ -5,7 +5,7 @@
                     'currencies': None,
                     'date': '1980-05-12',
                     'meta': {'filename': 'FAVA_LONG_EXAMPLE_PATH.beancount',
-                             'lineno': 5052},
+                             'lineno': 5055},
                     'type': 'Open'},
           'sha256sum': '7198a732bba60e03bfebbf4368637a66260d384e80c9af182390e419d4a0bbc8',
           'slice': '1980-05-12 open Expenses:Food:Alcohol'},

--- a/tests/data/long-example.beancount
+++ b/tests/data/long-example.beancount
@@ -22,7 +22,7 @@ option "operating_currency" "USD"
 
 1900-01-01 commodity VMMXX
   export: "MUTF:VMMXX (MONEY:USD)"
-  precision: "2"
+  precision: "4"
 
 1980-05-12 commodity VACHR
   export: "IGNORE"
@@ -31,7 +31,7 @@ option "operating_currency" "USD"
 1980-05-12 commodity IRAUSD
   export: "IGNORE"
   name: "US 401k and IRA Contributions"
-  precision: "gibberish"
+  precision: "NOT-A_NUMBER"
 
 1995-09-18 commodity VBMPX
   export: "MUTF:VBMPX"

--- a/tests/data/long-example.beancount
+++ b/tests/data/long-example.beancount
@@ -18,9 +18,11 @@ option "operating_currency" "USD"
 1792-01-01 commodity USD
   export: "CASH"
   name: "US Dollar"
+  precision: 2
 
 1900-01-01 commodity VMMXX
   export: "MUTF:VMMXX (MONEY:USD)"
+  precision: "2"
 
 1980-05-12 commodity VACHR
   export: "IGNORE"
@@ -29,6 +31,7 @@ option "operating_currency" "USD"
 1980-05-12 commodity IRAUSD
   export: "IGNORE"
   name: "US 401k and IRA Contributions"
+  precision: "gibberish"
 
 1995-09-18 commodity VBMPX
   export: "MUTF:VBMPX"

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -88,9 +88,9 @@ def test_account_uptodate_status(example_ledger: FavaLedger) -> None:
 
 
 def test_commodity_names(example_ledger: FavaLedger) -> None:
-    assert example_ledger.commodity_names.get("USD") == "US Dollar"
-    assert example_ledger.commodity_names.get("NOCOMMODITY") is None
-    assert example_ledger.commodity_names.get("VMMXX") is None
+    assert example_ledger.commodities.name("USD") == "US Dollar"
+    assert example_ledger.commodities.name("NOCOMMODITY") == "NOCOMMODITY"
+    assert example_ledger.commodities.name("VMMXX") == "VMMXX"
 
 
 @pytest.mark.filterwarnings("ignore:FavaLedger.*deprecated")

--- a/tests/test_core_commodities.py
+++ b/tests/test_core_commodities.py
@@ -1,0 +1,17 @@
+# pylint: disable=missing-docstring
+from __future__ import annotations
+
+from fava.core import FavaLedger
+
+
+def test_commodity_names(example_ledger: FavaLedger) -> None:
+    assert example_ledger.commodities.name("USD") == "US Dollar"
+    assert example_ledger.commodities.name("NOCOMMODITY") == "NOCOMMODITY"
+    assert example_ledger.commodities.name("VMMXX") == "VMMXX"
+
+
+def test_commodity_precision(example_ledger: FavaLedger) -> None:
+    assert example_ledger.commodities.precision("USD") == 2
+    assert example_ledger.commodities.precision("VMMXX") == 2
+    assert example_ledger.commodities.precision("IRAUSD") is None
+    assert example_ledger.commodities.precision("NOCOMMODITY") is None

--- a/tests/test_core_commodities.py
+++ b/tests/test_core_commodities.py
@@ -11,7 +11,4 @@ def test_commodity_names(example_ledger: FavaLedger) -> None:
 
 
 def test_commodity_precision(example_ledger: FavaLedger) -> None:
-    assert example_ledger.commodities.precision("USD") == 2
-    assert example_ledger.commodities.precision("VMMXX") == 4
-    assert example_ledger.commodities.precision("IRAUSD") is None
-    assert example_ledger.commodities.precision("NOCOMMODITY") is None
+    assert example_ledger.commodities.precisions == {"USD": 2, "VMMXX": 4}

--- a/tests/test_core_commodities.py
+++ b/tests/test_core_commodities.py
@@ -12,6 +12,6 @@ def test_commodity_names(example_ledger: FavaLedger) -> None:
 
 def test_commodity_precision(example_ledger: FavaLedger) -> None:
     assert example_ledger.commodities.precision("USD") == 2
-    assert example_ledger.commodities.precision("VMMXX") == 2
+    assert example_ledger.commodities.precision("VMMXX") == 4
     assert example_ledger.commodities.precision("IRAUSD") is None
     assert example_ledger.commodities.precision("NOCOMMODITY") is None

--- a/tests/test_core_number.py
+++ b/tests/test_core_number.py
@@ -18,6 +18,24 @@ def test_get_locale_format() -> None:
     assert fmt(dec) == "1,00000000000000"
 
 
+def test_precisions(example_ledger: FavaLedger) -> None:
+    fmt = example_ledger.format_decimal
+    assert fmt.precisions == {
+        "ABC": 0,
+        "GLD": 0,
+        "IRAUSD": 2,
+        "ITOT": 0,
+        "RGAGX": 3,
+        "USD": 2,
+        "VACHR": 0,
+        "VBMPX": 3,
+        "VMMXX": 4,
+        "VEA": 0,
+        "VHT": 0,
+        "XYZ": 0,
+    }
+
+
 def test_format_decimal(example_ledger: FavaLedger) -> None:
     fmt = example_ledger.format_decimal
     assert fmt(D("12.333"), "USD") == "12.33"

--- a/tests/test_json_api.py
+++ b/tests/test_json_api.py
@@ -1,6 +1,7 @@
 # pylint: disable=missing-docstring
 from __future__ import annotations
 
+import datetime
 import hashlib
 from io import BytesIO
 from pathlib import Path
@@ -123,8 +124,9 @@ def test_api_context(
     entry_hash = hash_entry(
         next(
             entry
-            for entry in example_ledger.all_entries
-            if entry.meta["lineno"] == 3732
+            for entry in example_ledger.all_entries_by_type.Transaction
+            if entry.narration == r"Investing 40% of cash in VBMPX"
+            and entry.date == datetime.date(2016, 5, 9)
         )
     )
     response = test_client.get(


### PR DESCRIPTION
- fava.core: add module for commodities
- commodities: allow for precision to be specified explicitly
- commodities: expose precisions on formatter
- frontend: also render numbers according to specified precision
- help: document commodity metadata

<!--
Hi, thank you for opening a PR!

Please ensure that your change passes tests and the various linters by running
`make test` and `make lint`. If testable, your changes should be covered by
unit tests.

Explain your changes below and link to related issues.
-->
