### PR TITLE
Added fava currency_conversion opt

### DIFF
--- a/frontend/src/stores/chart.ts
+++ b/frontend/src/stores/chart.ts
@@ -6,7 +6,11 @@ import iso4217currencies from "../lib/iso4217";
 import { localStorageSyncedStore } from "../lib/store";
 import { constant, union } from "../lib/validation";
 
-import { currencies_sorted, operating_currency } from ".";
+import {
+  conversion_currencies,
+  currencies_sorted,
+  operating_currency,
+} from ".";
 
 export const showCharts = writable(true);
 export const activeChart = writable<NamedChartTypes | undefined>(undefined);
@@ -30,13 +34,21 @@ export const barChartMode = localStorageSyncedStore<"stacked" | "single">(
 export const chartCurrency = writable("");
 
 const currencySuggestions = derived(
-  [operating_currency, currencies_sorted],
-  ([operating_currency_val, currencies_sorted_val]) => [
-    ...operating_currency_val,
-    ...currencies_sorted_val.filter(
-      (c) => !operating_currency_val.includes(c) && iso4217currencies.has(c)
-    ),
-  ]
+  [operating_currency, currencies_sorted, conversion_currencies],
+  ([
+    operating_currency_val,
+    currencies_sorted_val,
+    conversion_currencies_val,
+  ]) =>
+    conversion_currencies_val.length
+      ? conversion_currencies_val
+      : [
+          ...operating_currency_val,
+          ...currencies_sorted_val.filter(
+            (c) =>
+              !operating_currency_val.includes(c) && iso4217currencies.has(c)
+          ),
+        ]
 );
 
 export const conversions = derived(

--- a/frontend/src/stores/index.ts
+++ b/frontend/src/stores/index.ts
@@ -35,6 +35,7 @@ export const ledgerDataValidator = object({
   favaOptions: object({
     auto_reload: boolean,
     currency_column: number,
+    conversion_currencies: array(string),
     indent: number,
     locale: union(string, constant(null)),
     insert_entry: array(
@@ -103,6 +104,11 @@ export const years = derived_array(ledgerData, (val) => val.years);
 /** The sorted array of operating currencies. */
 export const operating_currency = derived_array(ledgerData, (val) =>
   val.options.operating_currency.sort()
+);
+/** The customized currency conversion select list */
+export const conversion_currencies = derived_array(
+  ledgerData,
+  (val) => val.favaOptions.conversion_currencies
 );
 
 /** The sorted array of all used currencies. */

--- a/src/fava/core/fava_options.py
+++ b/src/fava/core/fava_options.py
@@ -52,6 +52,7 @@ class FavaOptions:
     auto_reload: bool = False
     collapse_pattern: list[Pattern[str]] = field(default_factory=list)
     currency_column: int = 61
+    conversion_currencies: tuple[str, ...] = ()
     default_file: str | None = None
     default_page: str = "income_statement/"
     fiscal_year_end: FiscalYearEnd = FiscalYearEnd(12, 31)

--- a/src/fava/help/options.md
+++ b/src/fava/help/options.md
@@ -256,3 +256,13 @@ if the income is greater than the expenses for a given timespan.
 
 Note: To keep consistency with the internal accounting of beancount, the journal
 and the individual account pages are not affected by this configuration option.
+
+---
+
+## `conversion-currencies`
+
+Default: Not set
+
+When set, the currency conversion select dropdown in all charts will show the
+list of currencies specified in this option. By default, Fava lists all
+operating currencies and those currencies that match ISO 4217 currency codes.

--- a/tests/test_core_fava_options.py
+++ b/tests/test_core_fava_options.py
@@ -26,6 +26,7 @@ def test_fava_options(load_doc: LoaderResult) -> None:
     2016-04-14 custom "fava-option" "collapse-pattern" "Account:Name"
     2016-04-14 custom "fava-option" "collapse_pattern" "(invalid"
     2016-04-14 custom "fava-option" "fiscal-year-end" "01-11"
+    2016-04-14 custom "fava-option" "conversion-currencies" "USD EUR HOOLI"
     """
 
     entries, _, _ = load_doc
@@ -46,3 +47,4 @@ def test_fava_options(load_doc: LoaderResult) -> None:
     assert options.currency_column == 10
     assert options.collapse_pattern == [re.compile("Account:Name")]
     assert options.fiscal_year_end == FiscalYearEnd(1, 11)
+    assert options.conversion_currencies == ("USD", "EUR", "HOOLI")


### PR DESCRIPTION
<!--
Hi, thank you for opening a PR!

Please ensure that your change passes tests and the various linters by running
`make test` and `make lint`. If testable, your changes should be covered by
unit tests.

Explain your changes below and link to related issues.
-->

Related to #1436 #1226

Add a new fava opt: `currency_conversion` - feel free to suggest a better name please

If provided, the chart show currency conversion select will use the user provided, otherwise fallback to the current logic.

no validation on the option input, which means user can convert into commodities that are "non-currency".
