### PR TITLE
Bugfix: Mark extension generated content as safe

### DIFF
--- a/src/fava/application.py
+++ b/src/fava/application.py
@@ -345,7 +345,9 @@ def extension_report(report_name: str) -> str:
         )
         content = render_template_string(template, extension=extension)
         return render_template(
-            "_layout.html", content=Markup(content), page_title=extension.report_title
+            "_layout.html",
+            content=Markup(content),
+            page_title=extension.report_title,
         )
     except LookupError:
         return abort(404)

--- a/src/fava/application.py
+++ b/src/fava/application.py
@@ -345,7 +345,7 @@ def extension_report(report_name: str) -> str:
         )
         content = render_template_string(template, extension=extension)
         return render_template(
-            "_layout.html", content=content, page_title=extension.report_title
+            "_layout.html", content=Markup(content), page_title=extension.report_title
         )
     except LookupError:
         return abort(404)


### PR DESCRIPTION
<!--
Hi, thank you for opening a PR!

Please ensure that your change passes tests and the various linters by running
`make test` and `make lint`. If testable, your changes should be covered by
unit tests.

Explain your changes below and link to related issues.
-->

I run Fava with a custom extension for my own reports. After the recent commit ca9e3882, it looks like the HTML generated by the extension's template is being escaped. 

This commit adds wraps the content with `Markup()` , similar to how [Help HTML](https://github.com/beancount/fava/blob/ca9e3882c7b5fbf5273ba52340b9fea6a99f3711/src/fava/application.py#L388) was explicitly marked safe. 
