### PR TITLE
context: allow all types of entries

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,5 +1,5 @@
 import type { Entry } from "./entries";
-import { entryValidator, Transaction } from "./entries";
+import { entryBaseValidator, entryValidator, Transaction } from "./entries";
 import { urlFor } from "./helpers";
 import { fetchJSON } from "./lib/fetch";
 import type { ValidationT } from "./lib/validation";
@@ -33,6 +33,7 @@ interface PutAPIInputs {
  * @param endpoint - the endpoint to fetch
  * @param body - either a FormData instance or an object that will be converted
  *               to JSON.
+ * @returns the response message string
  */
 export async function put<T extends keyof PutAPIInputs>(
   endpoint: T,
@@ -58,7 +59,7 @@ export async function put<T extends keyof PutAPIInputs>(
 const getAPIValidators = {
   changed: boolean,
   context: object({
-    entry: entryValidator,
+    entry: entryBaseValidator,
     balances_before: optional(record(array(string))),
     balances_after: optional(record(array(string))),
     sha256sum: string,
@@ -88,6 +89,7 @@ interface GetAPIParams {
  * Fetch an API endpoint and convert the JSON data to an object.
  * @param endpoint - the endpoint to fetch
  * @param params - a string to append as params or an object.
+ * @returns the validated response returned by the endpoint.
  */
 export async function get<T extends keyof GetAPIParams>(
   endpoint: T,
@@ -107,6 +109,9 @@ export async function get<T extends keyof GetAPIParams>(
 
 /**
  * Move a file, either in an import directory or a document.
+ * @param filename - the current name of the file.
+ * @param account - account to move the file to.
+ * @param new_name - the new filename.
  * @returns whether the file was moved successfully.
  */
 export async function moveDocument(
@@ -129,6 +134,7 @@ export async function moveDocument(
 
 /**
  * Delete a file, either in an import directory or a document.
+ * @param filename - the filename of the file to delete.
  * @returns whether the file was deleted successfully.
  */
 export async function deleteDocument(filename: string): Promise<boolean> {
@@ -149,6 +155,7 @@ export async function deleteDocument(filename: string): Promise<boolean> {
 
 /**
  * Save an array of entries.
+ * @param entries - an array of entries to save to the Beancount file.
  */
 export async function saveEntries(entries: Entry[]): Promise<void> {
   if (!entries.length) {

--- a/frontend/src/entries.ts
+++ b/frontend/src/entries.ts
@@ -38,6 +38,21 @@ export function emptyPosting(): Posting {
 export type EntryMetadata = Record<string, string | boolean | number>;
 export type EntryTypeName = "Balance" | "Note" | "Transaction";
 
+const validatorBase = {
+  type: string,
+  date: string,
+  meta: record(
+    defaultValue(union(boolean, number, string), "Unsupported metadata value")
+  ),
+};
+
+export const entryBaseValidator = object(validatorBase);
+export type EntryBaseAttributes = {
+  type: string;
+  date: string;
+  meta: EntryMetadata;
+};
+
 abstract class EntryBase {
   type: EntryTypeName;
 
@@ -51,14 +66,6 @@ abstract class EntryBase {
     this.date = todayAsString();
   }
 }
-
-const validatorBase = {
-  type: string,
-  date: string,
-  meta: record(
-    defaultValue(union(boolean, number, string), "Unsupported metadata value")
-  ),
-};
 
 export class Balance extends EntryBase {
   account: string;

--- a/frontend/src/helpers.ts
+++ b/frontend/src/helpers.ts
@@ -1,6 +1,6 @@
 import { get } from "svelte/store";
 
-import type { Entry } from "./entries";
+import type { EntryBaseAttributes } from "./entries";
 import { baseURL } from "./stores";
 import { urlSyncedParams } from "./stores/url";
 
@@ -35,7 +35,7 @@ export function urlFor(
 }
 
 /** URL for the editor to the source location of an entry. */
-export function urlForSource(entry: Entry): string {
+export function urlForSource(entry: EntryBaseAttributes): string {
   const file_path = entry.meta.filename.toString();
   const line = entry.meta.lineno.toString();
   return urlFor("editor/", { file_path, line });

--- a/frontend/src/lib/validation.ts
+++ b/frontend/src/lib/validation.ts
@@ -103,8 +103,9 @@ export function union<T extends unknown[]>(
 /**
  * Validator for an object that might be undefined.
  */
-export function optional<T>(validator: Validator<T>): Validator<T | undefined> {
-  return (json) => (json === undefined ? ok(undefined) : validator(json));
+export function optional<T>(validator: Validator<T>): Validator<T | null> {
+  return (json) =>
+    json === undefined || json === null ? ok(null) : validator(json);
 }
 
 /**

--- a/frontend/src/modals/EntryContext.svelte
+++ b/frontend/src/modals/EntryContext.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
-  import type { Entry } from "../entries";
+  import type { EntryBaseAttributes } from "../entries";
   import { urlForAccount, urlForSource } from "../helpers";
   import { _ } from "../i18n";
 
   type ContextBalance = Record<string, string[]>;
-  export let entry: Entry;
-  export let balances_before: ContextBalance | undefined;
-  export let balances_after: ContextBalance | undefined;
+  export let entry: EntryBaseAttributes;
+  export let balances_before: ContextBalance | null;
+  export let balances_after: ContextBalance | null;
 </script>
 
 <p>


### PR DESCRIPTION
We only need the attributes that all entries have, so only do the
validation for this simpler type.

Fix #1420 
<!--
Hi, thank you for opening a PR!

Please ensure that your change passes tests and the various linters by running
`make test` and `make lint`. If testable, your changes should be covered by
unit tests.

Explain your changes below and link to related issues.
-->
