### PR TITLE
Fix i18n files of msgid "Converted to %(currency)s"

### DIFF
--- a/src/fava/translations/zh/LC_MESSAGES/messages.po
+++ b/src/fava/translations/zh/LC_MESSAGES/messages.po
@@ -592,7 +592,7 @@ msgstr "切换 %(type)s 条目"
 
 #: frontend/src/stores/chart.ts:50
 msgid "Converted to %(currency)s"
-msgstr "转换为 %(currency)"
+msgstr "转换为 %(currency)s"
 
 #: frontend/src/charts/Chart.svelte:87
 msgid "Stacked Bars"

--- a/src/fava/translations/zh_Hant_TW/LC_MESSAGES/messages.po
+++ b/src/fava/translations/zh_Hant_TW/LC_MESSAGES/messages.po
@@ -594,7 +594,7 @@ msgstr "切換 %(type) 條目"
 
 #: frontend/src/stores/chart.ts:50
 msgid "Converted to %(currency)s"
-msgstr "轉為 %(currency)"
+msgstr "轉為 %(currency)s"
 
 #: frontend/src/charts/Chart.svelte:87
 msgid "Stacked Bars"


### PR DESCRIPTION
<!--
Hi, thank you for opening a PR!

Please ensure that your change passes tests and the various linters by running
`make test` and `make lint`. If testable, your changes should be covered by
unit tests.

Explain your changes below and link to related issues.
-->
Without current fix, when config `fava` with `1900-01-01 custom "fava-option" "language" "zh_CN"` or `1900-01-01 custom "fava-option" "language" "zh_Hant_TW"` will cause format error like this:
<img width="368" alt="image" src="https://user-images.githubusercontent.com/3318872/178165481-6fd01909-b0da-4a69-92e3-d63bf08e667b.png">

OR

<img width="388" alt="image" src="https://user-images.githubusercontent.com/3318872/178165424-39d90ef8-3647-4f4b-a882-80e30bff3f4b.png">

should be:
<img width="378" alt="image" src="https://user-images.githubusercontent.com/3318872/178165465-00e0dfa5-6ef7-4f84-a783-f759211723a1.png">

OR

<img width="368" alt="image" src="https://user-images.githubusercontent.com/3318872/178165561-f60c8b85-6aa5-4cf2-84af-35c9ec520663.png">
