### PR TITLE
Allow extensions flexibility in chart placement

### DIFF
--- a/src/fava/templates/_layout.html
+++ b/src/fava/templates/_layout.html
@@ -40,11 +40,11 @@
     <aside>{% include "_aside.html" %}</aside>
     <article>
       {%- endif %}
-      <svelte-component type="charts"></svelte-component>
       {% block content %}
       {% if content %}
       {{ content }}
       {% else %}
+      <svelte-component type="charts"></svelte-component>
       {% include active_page + '.html' %}
       {% endif %}
       {% endblock %}


### PR DESCRIPTION
<!--
Hi, thank you for opening a PR!

Please ensure that your change passes tests and the various linters by running
`make test` and `make lint`. If testable, your changes should be covered by
unit tests.

Explain your changes below and link to related issues.
-->

Currently, the chart is a part of `_layout.html`. This means extensions like https://github.com/redstreet/fava_investor/ cannot place a menu bar above the chart. With this patch, extensions can place the chart as they see fit in their own templates. 