### PR TITLE
Sort amount/inventory/position in query table as number, not string

### DIFF
--- a/src/fava/templates/_query_table.html
+++ b/src/fava/templates/_query_table.html
@@ -5,6 +5,9 @@
     "<class 'decimal.Decimal'>": 'num',
     "<class 'cdecimal.Decimal'>": 'num',
     "<class 'int'>": 'num',
+    "<class 'beancount.core.amount.Amount'>": 'num',
+    "<class 'beancount.core.inventory.Inventory'>": 'num',
+    "<class 'beancount.core.position.Position'>": 'num',
 } %}
 
 {% macro querycell(ledger, name, value, type_) %}


### PR DESCRIPTION
<!--
Hi, thank you for opening a PR!

Please ensure that your change passes tests and the various linters by running
`make test` and `make lint`. If testable, your changes should be covered by
unit tests.

Explain your changes below and link to related issues.
-->

The query table currently sorts amount, inventory and position types as strings (for example, see https://fava.pythonanywhere.com/example-beancount-file/holdings/ when sorting by the 5th column)
<img width="850" alt="image" src="https://user-images.githubusercontent.com/9114601/194677004-625c1cb1-720b-4913-b97a-2ff55f605101.png">

This PR makes columns of these types sort numerically instead. Obv. with these quantities that comes with a unit, it isn't  always directly comparable numerically without some conversion, but I think the numerical sort is at least more useable over string sort, especially when the column is of the same currency (which is not uncommon).

