### PR TITLE
charts: use svelte-component to explicitly add charts

### DIFF
--- a/frontend/src/charts/ChartSwitcher.svelte
+++ b/frontend/src/charts/ChartSwitcher.svelte
@@ -2,38 +2,64 @@
   import { onMount } from "svelte";
 
   import { bindKey } from "../keyboard-shortcuts";
+  import { getScriptTagValue } from "../lib/dom";
   import { log_error } from "../log";
-  import { activeChart, showCharts } from "../stores/chart";
+  import { notify } from "../notifications";
+  import { lastActiveChartName, showCharts } from "../stores/chart";
 
   import Chart from "./Chart.svelte";
   import { chartContext } from "./context";
   import ConversionAndInterval from "./ConversionAndInterval.svelte";
 
-  import { parseChartData } from ".";
+  import { chart_data_validator, parseChartData } from ".";
   import type { NamedChartTypes } from ".";
 
+  export let data: unknown;
+
   let charts: NamedChartTypes[] = [];
+  let active_chart: NamedChartTypes | null = null;
+
+  $: if (active_chart) {
+    $lastActiveChartName = active_chart.name;
+  }
 
   onMount(() => {
-    const res = parseChartData($chartContext);
+    const chartData = data
+      ? chart_data_validator(data)
+      : getScriptTagValue("#chart-data", chart_data_validator);
+
+    if (!data && chartData.success && chartData.value.length) {
+      notify(
+        "This page adds charts using a deprecated method which will be removed soon.",
+        "warning"
+      );
+    }
+
+    const res = parseChartData(chartData, $chartContext);
     if (res.success) {
       charts = res.value;
     } else {
       log_error(res.value);
     }
-    $activeChart = charts.length
-      ? charts.find((c) => c.name === $activeChart?.name) || charts[0]
-      : undefined;
+    active_chart = charts.length
+      ? charts.find((c) => c.name === $lastActiveChartName) || charts[0]
+      : null;
+
+    if (!active_chart) {
+      return () => {
+        // noop
+      };
+    }
 
     const unbind = [
       bindKey("c", () => {
-        const currentIndex = charts.findIndex((e) => e === $activeChart);
-        $activeChart =
+        const currentIndex = charts.findIndex((e) => e === active_chart);
+        active_chart =
           charts[(currentIndex + 1 + charts.length) % charts.length];
       }),
       bindKey("C", () => {
-        const currentIndex = charts.findIndex((e) => e === $activeChart);
-        $activeChart =
+        const currentIndex = charts.findIndex((e) => e === active_chart);
+        active_chart =
           charts[(currentIndex - 1 + charts.length) % charts.length];
       }),
     ];
@@ -44,17 +70,17 @@
   });
 </script>
 
-{#if $activeChart}
-  <Chart chart={$activeChart}>
+{#if charts.length > 0 && active_chart}
+  <Chart chart={active_chart}>
     <ConversionAndInterval />
   </Chart>
   <div hidden={!$showCharts}>
     {#each charts as chart}
       <button
         type="button"
-        class:selected={chart === $activeChart}
+        class:selected={chart === active_chart}
         on:click={() => {
-          $activeChart = chart;
+          active_chart = chart;
         }}
       >
         {chart.name}

--- a/frontend/src/charts/index.ts
+++ b/frontend/src/charts/index.ts
@@ -4,7 +4,6 @@
  * The charts heavily use d3 libraries.
  */
 
-import { getScriptTagValue } from "../lib/dom";
 import type { Result } from "../lib/result";
 import { ok } from "../lib/result";
 import { array, object, string, unknown } from "../lib/validation";
@@ -39,14 +38,14 @@ const parsers: Partial<
 export type ChartTypes = HierarchyChart | BarChart | ScatterPlot | LineChart;
 export type NamedChartTypes = ChartTypes & { name?: string };
 
-const chart_data_validator = array(
+export const chart_data_validator = array(
   object({ label: string, type: string, data: unknown })
 );
 
 export function parseChartData(
+  res: ReturnType<typeof chart_data_validator>,
   ctx: ChartContext
 ): Result<NamedChartTypes[], string> {
-  const res = getScriptTagValue("#chart-data", chart_data_validator);
   if (!res.success) {
     return res;
   }

--- a/frontend/src/stores/chart.ts
+++ b/frontend/src/stores/chart.ts
@@ -1,6 +1,5 @@
 import { derived, writable } from "svelte/store";
 
-import type { NamedChartTypes } from "../charts";
 import { _, format } from "../i18n";
 import iso4217currencies from "../lib/iso4217";
 import { localStorageSyncedStore } from "../lib/store";
@@ -12,8 +11,10 @@ import {
   operating_currency,
 } from ".";
 
+/** Whether the charts should be shown - this applies globally to all charts. */
 export const showCharts = writable(true);
-export const activeChart = writable<NamedChartTypes | undefined>(undefined);
+/** This store is used to switch to the same chart (as identified by name) on navigation. */
+export const lastActiveChartName = writable<string | undefined>(undefined);
 export const hierarchyChartMode = localStorageSyncedStore<
   "treemap" | "sunburst"
 >(

--- a/frontend/test/end-to-end-validation.test.ts
+++ b/frontend/test/end-to-end-validation.test.ts
@@ -1,0 +1,21 @@
+import { readFile } from "fs/promises";
+import { join } from "path";
+
+import { test } from "uvu";
+import assert from "uvu/assert";
+
+import { ledgerDataValidator } from "../src/stores";
+
+function loadSnapshot(name: string): Promise<string> {
+  const path = join(__dirname, "..", "..", "tests", "__snapshots__", name);
+  return readFile(path, "utf8");
+}
+
+test("validate ledger data", async () => {
+  const data = await loadSnapshot("test_internal_api.py-test_get_ledger_data");
+  const res = ledgerDataValidator(JSON.parse(data));
+  assert.ok(res.success);
+  assert.equal(res.value.accounts[0], "Liabilities:US:Chase:Slate");
+});
+
+test.run();

--- a/src/fava/application.py
+++ b/src/fava/application.py
@@ -50,6 +50,7 @@ from fava.core.charts import setup_json_for_app
 from fava.core.documents import is_document_or_import_file
 from fava.help import HELP_PAGES
 from fava.helpers import FavaAPIException
+from fava.internal_api import ChartApi
 from fava.internal_api import get_ledger_data
 from fava.json_api import json_api
 from fava.serialisation import serialise
@@ -216,9 +217,9 @@ app.add_template_global(get_ledger_data, "get_ledger_data")
 
 
 @app.context_processor
-def template_context() -> dict[str, FavaLedger]:
+def template_context() -> dict[str, Any]:
     """Inject variables into the template context."""
-    return dict(ledger=g.ledger)
+    return dict(ledger=g.ledger, chart_api=ChartApi)
 
 
 @app.before_request

--- a/src/fava/core/__init__.py
+++ b/src/fava/core/__init__.py
@@ -191,13 +191,9 @@ class FilteredLedger:
         """All currently filtered documents."""
         return [e for e in self.entries if isinstance(e, Document)]
 
-    def events(self, event_type: str | None = None) -> list[Event]:
-        """List events (possibly filtered by type)."""
-        events = [e for e in self.entries if isinstance(e, Event)]
-        if event_type:
-            return [event for event in events if event.type == event_type]
-
-        return events
+    def events(self) -> list[Event]:
+        """All currently filtered events."""
+        return [e for e in self.entries if isinstance(e, Event)]
 
     def prices(self, base: str, quote: str) -> list[tuple[date, Decimal]]:
         """List all prices."""

--- a/src/fava/internal_api.py
+++ b/src/fava/internal_api.py
@@ -1,11 +1,20 @@
-"""Internal API."""
+"""Internal API.
+
+This is used to pre-process some data that is used in the templates, allowing
+this part of the functionality to be tested and allowing some end-to-end tests
+for the frontend data validation.
+"""
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import date
+from itertools import groupby
+from operator import attrgetter
 from typing import Any
 
 from flask import current_app
 from flask import url_for
+from flask_babel import gettext  # type: ignore
 
 from fava.context import g
 from fava.core.accounts import AccountDict
@@ -53,3 +62,106 @@ def get_ledger_data() -> LedgerData:
         g.ledger.attributes.tags,
         g.ledger.attributes.years,
     )
+
+
+@dataclass
+class ChartData:
+    """The common data format to pass charts to the frontend."""
+
+    type: str
+    label: str
+    data: Any
+
+
+def _chart_interval_totals(
+    interval: str,
+    account_name: str,
+    label: str | None = None,
+    invert: bool = False,
+) -> ChartData:
+    return ChartData(
+        "bar",
+        label or account_name,
+        g.ledger.charts.interval_totals(
+            g.filtered, interval, account_name, g.conversion, invert
+        ),
+    )
+
+
+def _chart_hierarchy(
+    account_name: str,
+    begin_date: date | None = None,
+    end_date: date | None = None,
+    label: str | None = None,
+) -> ChartData:
+    return ChartData(
+        "hierarchy",
+        label or account_name,
+        {
+            "modifier": g.ledger.get_account_sign(account_name),
+            "root": g.ledger.charts.hierarchy(
+                g.filtered,
+                account_name,
+                g.conversion,
+                begin_date,
+                end_date or g.filtered.end_date,
+            ),
+        },
+    )
+
+
+def _chart_commodities() -> list[ChartData]:
+    return [
+        ChartData(
+            "commodities",
+            f"{base} / {quote}",
+            {
+                "prices": prices,
+                "base": base,
+                "quote": quote,
+            },
+        )
+        for base, quote, prices in g.ledger.charts.prices(g.filtered)
+    ]
+
+
+def _chart_net_worth() -> ChartData:
+    return ChartData(
+        "balances",
+        gettext("Net Worth"),
+        g.ledger.charts.net_worth(g.filtered, g.interval, g.conversion),
+    )
+
+
+def _chart_events() -> list[ChartData]:
+    events = g.filtered.events()
+    charts = [ChartData("scatterplot", gettext("Events"), events)]
+    key = attrgetter("type")
+    for event_type, items in groupby(sorted(events, key=key), key):
+        charts.append(
+            ChartData(
+                "scatterplot",
+                gettext("Event: %(type)s", type=event_type),
+                list(items),
+            )
+        )
+    return charts
+
+
+def _chart_account_balance(account_name: str) -> ChartData:
+    return ChartData(
+        "balances",
+        gettext("Account Balance"),
+        g.ledger.charts.linechart(g.filtered, account_name, g.conversion),
+    )
+
+
+class ChartApi:
+    """Functions to generate chart data."""
+
+    account_balance = _chart_account_balance
+    commodities = _chart_commodities
+    events = _chart_events
+    hierarchy = _chart_hierarchy
+    interval_totals = _chart_interval_totals
+    net_worth = _chart_net_worth

--- a/src/fava/templates/_charts.html
+++ b/src/fava/templates/_charts.html
@@ -1,58 +1,21 @@
 {% set chart_data = [] %}
 
 {% macro hierarchy(account_name, begin_date=None, end_date=None, label=None) %}
-{% do chart_data.append({
-'type': 'hierarchy',
-'label': account_name if not label else label,
-'data': {
-  'modifier': ledger.get_account_sign(account_name),
-  'root': ledger.charts.hierarchy(g.filtered, account_name, g.conversion, begin_date, end_date or g.filtered.end_date),
-},
-}) %}
+{% do chart_data.append(chart_api.hierarchy(account_name, begin_date, end_date, label)) %}
 {% endmacro %}
 
 {% macro interval_totals(interval, account_name, label=None, invert=False) %}
-{% do chart_data.append({
-'type': 'bar',
-'label': account_name if not label else label,
-'data': ledger.charts.interval_totals(g.filtered, interval, account_name, g.conversion, invert=invert),
-}) %}
-{% endmacro %}
-
-{% macro events(event_type=None) %}
-{% do chart_data.append({
-'type': 'scatterplot',
-'label': _('Events') if not event_type else _('Event: %(type)s', type=event_type),
-'data': g.filtered.events(event_type),
-}) %}
+{% do chart_data.append(chart_api.interval_totals(interval, account_name, label, invert)) %}
 {% endmacro %}
 
 {% macro net_worth(interval) %}
-{% do chart_data.append({
-'type': 'balances',
-'label': _('Net Worth'),
-'data': ledger.charts.net_worth(g.filtered, interval, g.conversion),
-}) %}
+{% do chart_data.append(chart_api.net_worth()) %}
 {% endmacro %}
 
 {% macro account_balance(account_name) %}
-{% do chart_data.append({
-'type': 'balances',
-'label': _('Account Balance'),
-'data': ledger.charts.linechart(g.filtered, account_name, g.conversion),
-}) %}
+{% do chart_data.append(chart_api.account_balance(account_name)) %}
 {% endmacro %}
 
 {% macro commodities() %}
-{% for base, quote, prices in ledger.charts.prices(g.filtered) %}
-{% do chart_data.append({
-'type': 'commodities',
-'label': '{0} / {1}'.format(base, quote),
-'data': {
-  'prices': g.filtered.prices(base, quote),
-  'base': base,
-  'quote': quote,
-},
-}) %}
-{% endfor %}
+{% do chart_data.extend(chart_api.commodities()) %}
 {% endmacro %}

--- a/src/fava/templates/account.html
+++ b/src/fava/templates/account.html
@@ -10,14 +10,24 @@
 {% set journal = subreport == 'journal' %}
 
 {% block content %}
+{% set chart_list = [
+  chart_api.account_balance(account_name),
+  chart_api.interval_totals(g.interval, account_name, label=_('Changes')),
+] %}
+{% if not journal %}
+  {% do chart_list.append(chart_api.hierarchy(account_name)) %}
+
+  {% set accumulate = subreport == 'balances' %}
+  {% set interval_balances, dates = ledger.interval_balances(g.filtered, g.interval, account_name, accumulate) %}
+
+  {% for begin_date, end_date in dates[:3] %}
+    {% do chart_list.append(chart_api.hierarchy(account_name, begin_date, end_date, label=begin_date|format_date)) %}
+  {% endfor %}
+{% endif %}
+
+<svelte-component type="charts"><script type="application/json">{{ chart_list|tojson }}</script></svelte-component>
+
 <div class="droptarget" data-account-name="{{ account_name }}">
-  {{ charts.account_balance(account_name) }}
-  {{ charts.interval_totals(g.interval, account_name, label=_('Changes')) }}
-
-  {% if not journal %}
-  {{ charts.hierarchy(account_name) }}
-  {% endif %}
-
   <div class="headerline">
     <h3>{% if not journal %}<a href="{{ url_for('account', name=account_name) }}" title="{{ _('Journal of all entries for this Account and Sub-Accounts') }}">{{ _('Account Journal') }}</a>{% else %}{{ _('Account Journal') }}{% endif %}</h3>
     <h3>{% if subreport != 'changes' %}<a href="{{ url_for('account', name=account_name, subreport='changes') }}">{{ _('Changes') }} ({{ g.interval.label|lower }})</a>{% else %}{{ _('Changes') }} ({{ g.interval.label|lower }}){% endif %}</h3>
@@ -28,12 +38,7 @@
   {% set entries = ledger.account_journal(g.filtered, account_name, with_journal_children=ledger.fava_options.account_journal_include_children) %}
   {{ journal_table.journal_table(entries, show_change_and_balance=True) }}
   {% else %}
-  {% set accumulate = subreport == 'balances' %}
-  {% set interval_balances, dates = ledger.interval_balances(g.filtered, g.interval, account_name, accumulate) %}
   {% if interval_balances %}
-  {% for begin_date, end_date in dates[:3] %}
-  {{ charts.hierarchy(account_name, begin_date, end_date, label=begin_date|format_date) }}
-  {% endfor %}
   {{ tree_table.account_tree(account_name, interval_balances, dates, accumulate) }}
   {% endif %}
   {% endif %}

--- a/src/fava/templates/balance_sheet.html
+++ b/src/fava/templates/balance_sheet.html
@@ -1,9 +1,13 @@
 {% import '_tree_table.html' as tree_table with context %}
 
-{{ charts.net_worth(g.interval) }}
-{{ charts.hierarchy(ledger.options['name_assets']) }}
-{{ charts.hierarchy(ledger.options['name_liabilities']) }}
-{{ charts.hierarchy(ledger.options['name_equity']) }}
+<svelte-component type="charts"><script type="application/json">{{
+  [
+    chart_api.net_worth(),
+    chart_api.hierarchy(ledger.options['name_assets']),
+    chart_api.hierarchy(ledger.options['name_liabilities']),
+    chart_api.hierarchy(ledger.options['name_equity']),
+  ]|tojson
+}}</script></svelte-component>
 
 {% set root_tree_closed = g.filtered.root_tree_closed %}
 {% set invert = ledger.fava_options.invert_income_liabilities_equity %}

--- a/src/fava/templates/commodities.html
+++ b/src/fava/templates/commodities.html
@@ -1,4 +1,6 @@
-{{ charts.commodities() }}
+<svelte-component type="charts"><script type="application/json">{{
+  chart_api.commodities()|tojson
+}}</script></svelte-component>
 
 {% for commodity_pair in ledger.commodity_pairs() %}
 {% set prices = g.filtered.prices(*commodity_pair) %}

--- a/src/fava/templates/events.html
+++ b/src/fava/templates/events.html
@@ -1,9 +1,12 @@
 {% set events = g.filtered.events() %}
+
 {% if events %}
-{{ charts.events() }}
-{% for group in events|groupby('type') %}
+<svelte-component type="charts"><script type="application/json">{{
+  chart_api.events()|tojson
+}}</script></svelte-component>
+
+{% for group in  events|groupby('type')  %}
 <div class="left">
-  {{ charts.events(group.grouper) }}
   <h3>{{ _('Event') + ': ' + group.grouper }}</h3>
   <table is="sortable-table">
     <thead>

--- a/src/fava/templates/income_statement.html
+++ b/src/fava/templates/income_statement.html
@@ -4,13 +4,15 @@
 {% set options = ledger.options %}
 {% set invert = ledger.fava_options.invert_income_liabilities_equity %}
 
-{{ charts.interval_totals(g.interval, (options['name_income'], options['name_expenses']), label=_('Net Profit'), invert=invert) }}
-{{ charts.interval_totals(g.interval, options['name_income'], label=_('Income'), invert=invert) }}
-{{ charts.interval_totals(g.interval, options['name_expenses'], label=_('Expenses')) }}
-
-{{ charts.hierarchy(options['name_income']) }}
-{{ charts.hierarchy(options['name_expenses']) }}
-
+<svelte-component type="charts"><script type="application/json">{{
+  [
+    chart_api.interval_totals(g.interval, (options['name_income'], options['name_expenses']), label=_('Net Profit'), invert=invert),
+    chart_api.interval_totals(g.interval, options['name_income'], label=_('Income'), invert=invert),
+    chart_api.interval_totals(g.interval, options['name_expenses'], label=_('Expenses')),
+    chart_api.hierarchy(options['name_income']),
+    chart_api.hierarchy(options['name_expenses']),
+  ]|tojson
+}}</script></svelte-component>
 
 <div class="row">
   <div class="column">

--- a/src/fava/templates/trial_balance.html
+++ b/src/fava/templates/trial_balance.html
@@ -1,7 +1,13 @@
 {% import '_tree_table.html' as tree_table with context %}
 
-{% for base_account in ['expenses', 'income', 'assets', 'equity', 'liabilities'] %}
-{{ charts.hierarchy(ledger.options['name_{}'.format(base_account)]) }}
-{% endfor %}
+<svelte-component type="charts"><script type="application/json">{{
+  [
+    chart_api.hierarchy(ledger.options['name_expenses']),
+    chart_api.hierarchy(ledger.options['name_income']),
+    chart_api.hierarchy(ledger.options['name_assets']),
+    chart_api.hierarchy(ledger.options['name_liabilities']),
+    chart_api.hierarchy(ledger.options['name_equity']),
+  ]|tojson
+}}</script></svelte-component>
 
 {{ tree_table.tree(g.filtered.root_tree.get('')) }}


### PR DESCRIPTION
Previously, there could only be one ChartSwitcher component on the page
since the charts were pushed to a global list.

This now adds an explicit component to render the charts.

<!--
Hi, thank you for opening a PR!

Please ensure that your change passes tests and the various linters by running
`make test` and `make lint`. If testable, your changes should be covered by
unit tests.

Explain your changes below and link to related issues.
-->
