### PR TITLE
Income statement graphs: re-add name of interval to graph labels

### DIFF
--- a/src/fava/templates/income_statement.html
+++ b/src/fava/templates/income_statement.html
@@ -7,8 +7,8 @@
 <svelte-component type="charts"><script type="application/json">{{
   [
     chart_api.interval_totals(g.interval, (options['name_income'], options['name_expenses']), label=_('Net Profit'), invert=invert),
-    chart_api.interval_totals(g.interval, options['name_income'], label=_('Income'), invert=invert),
-    chart_api.interval_totals(g.interval, options['name_expenses'], label=_('Expenses')),
+    chart_api.interval_totals(g.interval, options['name_income'], label='{} ({})'.format(_('Income'), g.interval.label), invert=invert),
+    chart_api.interval_totals(g.interval, options['name_expenses'], label='{} ({})'.format(_('Expenses'), g.interval.label)),
     chart_api.hierarchy(options['name_income']),
     chart_api.hierarchy(options['name_expenses']),
   ]|tojson


### PR DESCRIPTION
Currently, the labels below the income statement graphs are pretty confusing, because there are two graphs labeled "Income" and two labeled "Expenses". This was not always so: The current screenshot at [1] shows the graphs usefully labeled as "Income" vs. "Monthly Income" (ditto for Expenses). However, this seems to have been lost in commit a80ede86.

This time, I chose "Income (Monthly)" instead of "Monthly Income" because it makes translations easier. In German, for example, "Monatlich Einkommen" would be ungrammatical.

[1] https://beancount.github.io/fava/index.html