### PR TITLE
extensions: allow extensions to include script tags

### DIFF
--- a/frontend/src/helpers.ts
+++ b/frontend/src/helpers.ts
@@ -44,3 +44,27 @@ export function urlForSource(file_path: string, line: string): string {
 export function urlForAccount(account: string): string {
   return urlFor(`account/${account}/`);
 }
+
+/*
+ * Set the inner HTML of an element in a way that will execute the contents of any script tags.
+ *
+ * Adapted from https://stackoverflow.com/a/47614491
+ */
+export function setInnerHTML(elm: HTMLElement, html: string) {
+  elm.innerHTML = html;
+
+  Array.from(elm.querySelectorAll("script")).forEach((oldScriptEl) => {
+    const newScriptEl = document.createElement("script");
+
+    Array.from(oldScriptEl.attributes).forEach((attr) => {
+      newScriptEl.setAttribute(attr.name, attr.value);
+    });
+
+    const scriptText = document.createTextNode(oldScriptEl.innerHTML);
+    newScriptEl.appendChild(scriptText);
+
+    if (oldScriptEl.parentNode !== null) {
+      oldScriptEl.parentNode.replaceChild(newScriptEl, oldScriptEl);
+    }
+  });
+}

--- a/frontend/src/router.ts
+++ b/frontend/src/router.ts
@@ -9,6 +9,7 @@ import type { SvelteComponent } from "svelte";
 import type { Readable, Writable } from "svelte/store";
 import { writable } from "svelte/store";
 
+import { setInnerHTML } from "./helpers";
 import { delegate, Events } from "./lib/events";
 import { fetch, handleText } from "./lib/fetch";
 import { DEFAULT_INTERVAL, getInterval } from "./lib/interval";
@@ -208,7 +209,7 @@ class Router extends Events<"page-loaded"> {
           window.scroll(0, 0);
         }
         this.updateState();
-        this.article.innerHTML = content;
+        setInnerHTML(this.article, content);
       } else {
         if (historyState) {
           window.history.pushState(null, "", url);


### PR DESCRIPTION
Currently extensions that include javascript in script tags in the html have an issue where the scripts are only run some of the time (script doesn't run on a partial load but does run on a full refresh). This fixes makes the scripts run on both partial and full loads.