### PR TITLE
Create a read-only mode

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ disable = [
 
 [tool.pylint.design]
 # max args for a function / method
-max-args = 8
+max-args = 9
 
 [tool.pylint.similarities]
 ignore-imports = true
@@ -80,7 +80,7 @@ known-first-party = ["fava"]
 required-imports = ["from __future__ import annotations"]
 
 [tool.ruff.pylint]
-max-args = 8
+max-args = 9
 
 [tool.ruff.per-file-ignores]
 "contrib/**" = ["D"]

--- a/src/fava/application.py
+++ b/src/fava/application.py
@@ -255,6 +255,13 @@ def _incognito(
     return response
 
 
+@app.before_request
+def _read_only_mode() -> None:
+    """Prevent any request that isn't a GET if read-only mode is active."""
+    if app.config.get("READ_ONLY") and request.method != "GET":
+        abort(401)
+
+
 @app.url_value_preprocessor
 def _pull_beancount_file(_: str | None, values: dict[str, str] | None) -> None:
     g.beancount_file_slug = values.pop("bfile", None) if values else None

--- a/src/fava/cli.py
+++ b/src/fava/cli.py
@@ -44,6 +44,11 @@ from fava.util import simple_wsgi
     is_flag=True,
     help="Run in incognito mode and obscure all numbers.",
 )
+@click.option(
+    "--read-only",
+    is_flag=True,
+    help="Run in read-only mode, disabling any change through UI/API",
+)
 @click.option("-d", "--debug", is_flag=True, help="Turn on debugging.")
 @click.option(
     "--profile", is_flag=True, help="Turn on profiling. Implies --debug."
@@ -60,6 +65,7 @@ def main(
     host: str,
     prefix: str,
     incognito: bool,
+    read_only: bool,
     debug: bool,
     profile: bool,
     profile_dir: str,
@@ -86,6 +92,7 @@ def main(
 
     app.config["BEANCOUNT_FILES"] = all_filenames
     app.config["INCOGNITO"] = incognito
+    app.config["READ_ONLY"] = read_only
 
     if prefix:
         app.wsgi_app = DispatcherMiddleware(  # type: ignore

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -193,6 +193,20 @@ def test_incognito(
     assert "XXX" in result.get_data(True)
 
 
+@pytest.mark.parametrize("method_name", ["delete", "patch", "post", "put"])
+def test_read_only_mode(
+    app: Flask,
+    test_client: FlaskClient,
+    monkeypatch: MonkeyPatch,
+    method_name: str,
+) -> None:
+    """Non GET requests returns 401 in read-only mode"""
+    monkeypatch.setitem(app.config, "READ_ONLY", True)
+    method = getattr(test_client, method_name)
+    result = method("/any/path/")
+    assert result.status_code == 401
+
+
 def test_download_journal(
     app: Flask, test_client: FlaskClient, snapshot: SnapshotFunc
 ) -> None:


### PR DESCRIPTION
Hi! I'm creating a read-only mode to Fava that prevents any non GET http request to be processed. This mode is activated by using `--read-only` flag in Fava CLI.

My use case for this PR is that my org already has a well defined process for editing the .beancount files using only the CLI, and we want to make the data available to a broad audience through Fava's UI.

I considered making the files read-only on the OS level (as suggested in the #1424), but having the `--read-only` flag and returning HTTP 401 seemed more appropriate. If you're ok with the change, I can work on the docs.

- Tests passing
- Lint passing
- Discussion: https://github.com/beancount/fava/issues/1424