### PR TITLE
Update to Python-Babel 3.0.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,7 @@ setup_requires =
     setuptools_scm
 install_requires =
     Babel>=2.7,<3
-    Flask-Babel>=1,<3
+    Flask-Babel>=3
     Flask>=2,<3
     Jinja2>=3,<4
     Werkzeug>=2,<3

--- a/src/fava/application.py
+++ b/src/fava/application.py
@@ -152,8 +152,7 @@ def get_locale() -> str | None:
     return request.accept_languages.best_match(["en", *LANGUAGES])
 
 
-BABEL = Babel(app)
-BABEL.localeselector(get_locale)
+BABEL = Babel(app, locale_selector=get_locale)
 
 
 for function in template_filters.FILTERS:


### PR DESCRIPTION
**A couple of weeks ago, the Python-Babel dependency release version 3.0.0 which contains a breaking change for fava.
This PR changes fava's usage to support the new syntax.**

Fixes #1549 

*I am a small-time contributor who just wants to get this fixed; if you want to add to this PR and/or want me to make modifications, that's all fine*

In version 2.x, Babel stores information only for the most recent app;
this prevents multiple apps from using the same Babel instance (see python-babel/flask-babel#107).
To add support for multiple apps, Babel 3.x moves locale selection into per-app state,
which requires a change from the previous function decoration syntax for selecting locale.

Annoyingly, the new syntax is not supported in any 2.x release, which means that either we'll have to trust that the 3.x babel branch works (all tests pass, so that's good), or we'll have to modify this PR to support 2.x or 3.x based on the installed version.