### PR TITLE
Add support for uploading files for importing directly from the import screen

### DIFF
--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -13,6 +13,7 @@ import { getAPIValidators } from "./validators";
 /** Required arguments for the various PUT API endpoints. */
 interface PutAPIInputs {
   add_document: FormData;
+  upload_import_file: FormData;
   add_entries: { entries: Entry[] };
   attach_document: { filename: string; entry_hash: string };
   format_source: { source: string };

--- a/frontend/src/reports/import/Import.svelte
+++ b/frontend/src/reports/import/Import.svelte
@@ -45,7 +45,14 @@
       : null;
 
   onMount(() => router.addInteruptHandler(preventNavigation));
-  $: files = data;
+  $: {
+    // Since the user can change e.g. account/name for imported files, we only add any new files here.
+    // This avoids overwriting the users changes
+    const existingFileNames = files.map((file) => file.name);
+    files = files.concat(data.filter(
+      (updated) => !existingFileNames.includes(updated.name)
+    ));
+  };
 
   /**
    * Move the given file to the new file name (and remove from the list).

--- a/frontend/src/reports/import/Import.svelte
+++ b/frontend/src/reports/import/Import.svelte
@@ -49,10 +49,10 @@
     // Since the user can change e.g. account/name for imported files, we only add any new files here.
     // This avoids overwriting the users changes
     const existingFileNames = files.map((file) => file.name);
-    files = files.concat(data.filter(
-      (updated) => !existingFileNames.includes(updated.name)
-    ));
-  };
+    files = files.concat(
+      data.filter((updated) => !existingFileNames.includes(updated.name))
+    );
+  }
 
   /**
    * Move the given file to the new file name (and remove from the list).

--- a/src/fava/core/ingest.py
+++ b/src/fava/core/ingest.py
@@ -6,8 +6,11 @@ import sys
 import traceback
 from os import stat
 from os.path import basename
+from os.path import dirname
 from os.path import exists
 from os.path import isdir
+from os.path import join
+from os.path import normpath
 from runpy import run_path
 from typing import Any
 from typing import NamedTuple
@@ -20,6 +23,7 @@ from beancount.ingest import identify
 
 from fava.core.module_base import FavaModule
 from fava.helpers import BeancountError
+from fava.helpers import FavaAPIException
 
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -184,3 +188,28 @@ class IngestModule(FavaModule):
             )
 
         return new_entries_list[0][1]
+
+
+def filepath_in_primary_imports_folder(
+    filename: str, ledger: FavaLedger
+) -> str:
+    """File path for a document to upload to the primary import folder.
+
+    Args:
+        filename: The filename of the document.
+        ledger: The FavaLedger.
+
+    Returns:
+        The path that the document should be saved at.
+    """
+    primary_imports_folder = next(iter(ledger.fava_options.import_dirs), None)
+    if primary_imports_folder is None:
+        raise FavaAPIException("You need to set at least one imports-dir.")
+
+    return normpath(
+        join(
+            dirname(ledger.beancount_file_path),
+            primary_imports_folder,
+            filename,
+        )
+    )

--- a/src/fava/json_api.py
+++ b/src/fava/json_api.py
@@ -362,9 +362,11 @@ def put_upload_import_file() -> str:
 
     if not upload:
         raise FavaAPIException("No file uploaded.")
+    if not upload.filename:
+        raise FavaAPIException("Uploaded file is missing filename.")
     filepath = filepath_in_primary_imports_folder(upload.filename, g.ledger)
 
-    directory, filename = path.split(filepath)
+    directory = path.dirname(filepath)
 
     if path.exists(filepath):
         raise FavaAPIException(f"{filepath} already exists.")

--- a/src/fava/json_api.py
+++ b/src/fava/json_api.py
@@ -32,6 +32,7 @@ from flask.wrappers import Response
 from fava.context import g
 from fava.core.documents import filepath_in_document_folder
 from fava.core.documents import is_document_or_import_file
+from fava.core.ingest import filepath_in_primary_imports_folder
 from fava.core.misc import align
 from fava.helpers import FavaAPIException
 from fava.internal_api import get_ledger_data
@@ -352,6 +353,28 @@ def put_add_entries(entries: list[Any]) -> str:
     g.ledger.file.insert_entries(entries)
 
     return f"Stored {len(entries)} entries."
+
+
+@api_endpoint
+def put_upload_import_file() -> str:
+    """Upload a file for importing."""
+    upload = request.files.get("file", None)
+
+    if not upload:
+        raise FavaAPIException("No file uploaded.")
+    filepath = filepath_in_primary_imports_folder(upload.filename, g.ledger)
+
+    directory, filename = path.split(filepath)
+
+    if path.exists(filepath):
+        raise FavaAPIException(f"{filepath} already exists.")
+
+    if not path.exists(directory):
+        os.makedirs(directory, exist_ok=True)
+
+    upload.save(filepath)
+
+    return f"Uploaded to {filepath}"
 
 
 ########################################################################


### PR DESCRIPTION
<!--
Hi, thank you for opening a PR!

Please ensure that your change passes tests and the various linters by running
`make test` and `make lint`. If testable, your changes should be covered by
unit tests.

Explain your changes below and link to related issues.
-->
This PR add support for uploading documents directly into the import folder from the import screen, I've used the standard `<input type="file">` element, so this should be usable on mobile/desktop, and supports multiple files.

Fixes: #904

<img width="1513" alt="image" src="https://user-images.githubusercontent.com/678919/220547928-31c07dcf-9360-49a4-8103-95ccc9c7ce23.png">

