### PR TITLE
Make sure that the `beancount-files` dropdown is on top of other elements

### DIFF
--- a/frontend/src/sidebar/Header.svelte
+++ b/frontend/src/sidebar/Header.svelte
@@ -81,6 +81,7 @@
     border-bottom-right-radius: 3px;
     border-bottom-left-radius: 3px;
     box-shadow: 0 3px 6px var(--transparent-black);
+    z-index: 1;
   }
 
   .beancount-files a {

--- a/frontend/src/sidebar/Header.svelte
+++ b/frontend/src/sidebar/Header.svelte
@@ -73,6 +73,7 @@
     position: absolute;
     top: var(--header-height);
     left: 19px;
+    z-index: 1;
     display: none;
     width: 20em;
     color: var(--link-color);
@@ -81,7 +82,6 @@
     border-bottom-right-radius: 3px;
     border-bottom-left-radius: 3px;
     box-shadow: 0 3px 6px var(--transparent-black);
-    z-index: 1;
   }
 
   .beancount-files a {

--- a/frontend/src/sidebar/Header.svelte
+++ b/frontend/src/sidebar/Header.svelte
@@ -73,7 +73,7 @@
     position: absolute;
     top: var(--header-height);
     left: 19px;
-    z-index: 1;
+    z-index: var(--z-index-floating-ui);
     display: none;
     width: 20em;
     color: var(--link-color);


### PR DESCRIPTION
On mobile this is currently obstructed by the time/account/filter fields, this just adds a z-index so that the dropdown is always on top.

NB: After this PR the dropdown is still obstructed by the non-expanded menu, but you can at least see/interact with the elements.

## Current UI
<img width="575" alt="image" src="https://user-images.githubusercontent.com/678919/220606340-92df94f5-a82e-48e0-825c-e81785fde0d6.png">

## With this fix
<img width="575" alt="image" src="https://user-images.githubusercontent.com/678919/220606510-dba7f57b-5f3b-4e09-847e-5383309c94d1.png">
