### PR TITLE
Show `errors` in `Editor`

### DIFF
--- a/frontend/src/api/validators.ts
+++ b/frontend/src/api/validators.ts
@@ -32,7 +32,7 @@ const importable_files_validator: Validator<ImportableFile[]> = array(
 );
 
 /** A Beancount error that should be shown to the user in the list of errors. */
-interface BeancountError {
+export interface BeancountError {
   message: string;
   source: { filename: string; lineno: number } | null;
   entry: EntryBaseAttributes | null;

--- a/frontend/src/codemirror/setup.ts
+++ b/frontend/src/codemirror/setup.ts
@@ -19,7 +19,7 @@ import {
   indentUnit,
   syntaxHighlighting,
 } from "@codemirror/language";
-import { lintKeymap } from "@codemirror/lint";
+import { lintGutter, lintKeymap, setDiagnostics } from "@codemirror/lint";
 import { highlightSelectionMatches, searchKeymap } from "@codemirror/search";
 import type { Extension } from "@codemirror/state";
 import { EditorState } from "@codemirror/state";
@@ -57,6 +57,7 @@ const baseExtensions = [
   rectangularSelection(),
   highlightActiveLine(),
   highlightSelectionMatches(),
+  lintGutter(),
   keymap.of([
     ...closeBracketsKeymap,
     ...defaultKeymap,
@@ -130,6 +131,23 @@ export function initBeancountEditor(
     }),
     baseExtensions,
   ]);
+}
+
+/**
+ * Set errors for in the editor, highlighting them
+ */
+export function setErrors(editor: EditorView, errors: []) {
+  const diagnostics = errors.map((error) => {
+    // Show errors without an attached line on first line
+    let line = editor.state.doc.line(error.source?.lineno ?? 1);
+    return {
+      from: line.from,
+      to: line.to,
+      severity: "error",
+      message: error.message,
+    }
+  });
+  editor.dispatch(setDiagnostics(editor.state, diagnostics));
 }
 
 /**

--- a/frontend/src/codemirror/setup.ts
+++ b/frontend/src/codemirror/setup.ts
@@ -145,7 +145,7 @@ export function setErrors(editor: EditorView, errors: []) {
       to: line.to,
       severity: "error",
       message: error.message,
-    }
+    };
   });
   editor.dispatch(setDiagnostics(editor.state, diagnostics));
 }

--- a/frontend/src/codemirror/setup.ts
+++ b/frontend/src/codemirror/setup.ts
@@ -20,6 +20,7 @@ import {
   syntaxHighlighting,
 } from "@codemirror/language";
 import { lintGutter, lintKeymap, setDiagnostics } from "@codemirror/lint";
+import type { Diagnostic } from "@codemirror/lint";
 import { highlightSelectionMatches, searchKeymap } from "@codemirror/search";
 import type { Extension } from "@codemirror/state";
 import { EditorState } from "@codemirror/state";
@@ -36,6 +37,7 @@ import {
 } from "@codemirror/view";
 import { get } from "svelte/store";
 
+import type { BeancountError } from "../api/validators";
 import { fava_options } from "../stores";
 
 import { beancount } from "./beancount";
@@ -136,10 +138,10 @@ export function initBeancountEditor(
 /**
  * Set errors for in the editor, highlighting them
  */
-export function setErrors(editor: EditorView, errors: []) {
-  const diagnostics = errors.map((error) => {
+export function setErrors(editor: EditorView, errors: BeancountError[]) {
+  const diagnostics: Diagnostic[] = errors.map((error: BeancountError) => {
     // Show errors without an attached line on first line
-    let line = editor.state.doc.line(error.source?.lineno ?? 1);
+    const line = editor.state.doc.line(error.source?.lineno ?? 1);
     return {
       from: line.from,
       to: line.to,

--- a/frontend/src/reports/editor/Editor.svelte
+++ b/frontend/src/reports/editor/Editor.svelte
@@ -98,11 +98,11 @@
   let errors = [];
   // Update diagnostics, showing errors in the editor
   $: {
-    const errorsForFile = errors
-      .filter((error) =>
+    const errorsForFile = errors.filter(
+      (error) =>
         // Only show errors for this file, or general errors (AKA no source)
         error.source === null || error.source.filename == file_path
-      );
+    );
     setErrors(editor, errorsForFile);
   }
 
@@ -113,7 +113,7 @@
 
   onMount(() => router.addInteruptHandler(checkEditorChanges));
 
-  onMount(() => get("errors").then((errs) => errors = errs));
+  onMount(() => get("errors").then((errs) => (errors = errs)));
 
   // keybindings when the focus is outside the editor
   onMount(() =>


### PR DESCRIPTION
This PR add support for showing errors inline in the editor, it uses the [builtin support](https://codemirror.net/examples/lint/) in CodeMirror together with the errors we get from `beancount`.

## UI
<img width="1166" alt="image" src="https://user-images.githubusercontent.com/678919/222804493-3cf13ddc-db5f-46d4-b403-d8be5ac2891e.png">

