### PR TITLE
Add Entry form now presents last-saved date as default for new entries

### DIFF
--- a/frontend/src/entry-forms/Transaction.svelte
+++ b/frontend/src/entry-forms/Transaction.svelte
@@ -11,12 +11,14 @@
   import { _ } from "../i18n";
   import { notify_err } from "../notifications";
   import { payees } from "../stores";
+  import { addEntryLastDate } from "../stores/editor";
 
   import AddMetadataButton from "./AddMetadataButton.svelte";
   import EntryMetadata from "./EntryMetadata.svelte";
   import PostingSvelte from "./Posting.svelte";
 
   export let entry: Transaction;
+  entry.date = $addEntryLastDate;
   let suggestions: string[] | undefined;
 
   function removePosting(posting: Posting) {

--- a/frontend/src/modals/AddEntry.svelte
+++ b/frontend/src/modals/AddEntry.svelte
@@ -5,7 +5,7 @@
   import Entry from "../entry-forms/Entry.svelte";
   import { _ } from "../i18n";
   import { closeOverlay, urlHash } from "../stores";
-  import { addEntryContinue } from "../stores/editor";
+  import { addEntryContinue, addEntryLastDate } from "../stores/editor";
 
   import ModalBase from "./ModalBase.svelte";
 
@@ -19,7 +19,9 @@
 
   async function submit() {
     await saveEntries([entry]);
+    $addEntryLastDate = entry.date;
     entry = create(entry.type);
+    entry.date = $addEntryLastDate;
     if (!$addEntryContinue) {
       closeOverlay();
     }

--- a/frontend/src/stores/editor.ts
+++ b/frontend/src/stores/editor.ts
@@ -1,5 +1,6 @@
+import { todayAsString } from "../format";
 import { localStorageSyncedStore } from "../lib/store";
-import { boolean } from "../lib/validation";
+import { boolean, string } from "../lib/validation";
 
 /** Whether to reload after saving an entry in the slice editor. */
 export const reloadAfterSavingEntrySlice = localStorageSyncedStore(
@@ -13,4 +14,11 @@ export const addEntryContinue = localStorageSyncedStore(
   "add-entry-continue",
   boolean,
   () => false
+);
+
+/** Date of last item added in the AddEntry dialog. */
+export const addEntryLastDate = localStorageSyncedStore(
+  "add-entry-last-date",
+  string,
+  () => todayAsString()
 );


### PR DESCRIPTION
<!--
Hi, thank you for opening a PR!

Please ensure that your change passes tests and the various linters by running
`make test` and `make lint`. If testable, your changes should be covered by
unit tests.

Explain your changes below and link to related issues.
-->

When adding a sequence of transactions, it is likely enough that some subsequences will have the same date. Therefore, the last-entered date is a reasonable default when adding multiple transaction.

With this change, when one adds a second transaction, the default date will be that of the previously entered transaction. If it's the first transaction, the default date will be today.

Functional-tested in my browser. Not aware of appropriate automated testing for this UI tweak.