### PR TITLE
Mobile layout fixes

### DIFF
--- a/frontend/css/layout.css
+++ b/frontend/css/layout.css
@@ -26,6 +26,9 @@ article {
   width: 100%;
   height: 100%;
   padding: 1.5em;
+
+  overflow-x: scroll;
+  max-width: 100vw;
 }
 
 .fixed-fullsize-container {

--- a/frontend/css/media-mobile.css
+++ b/frontend/css/media-mobile.css
@@ -6,6 +6,7 @@
   body {
     padding: 0;
     transition: var(--transitions);
+    font-size: 16px;
   }
 
   header {

--- a/frontend/src/modals/ModalBase.svelte
+++ b/frontend/src/modals/ModalBase.svelte
@@ -112,4 +112,15 @@
   .content :global(.fieldset) {
     margin-bottom: 6px;
   }
+
+  @media (max-width: 767px) {
+    .overlay {
+      height: 100%;
+    }
+
+    .content {
+      height: 100%;
+      margin: 0;
+    }
+  }
 </style>

--- a/frontend/src/modals/ModalBase.svelte
+++ b/frontend/src/modals/ModalBase.svelte
@@ -12,6 +12,20 @@
   export let closeHandler = closeOverlay;
 
   /**
+   * Prevent scrolling of the main body while the dialog is open.
+   */
+  function setBodyScrollLock(state: boolean) {
+    const body = document.getElementsByTagName("body")[0];
+    if (body) {
+      body.style.overflow = state ? "hidden" : "auto";
+    }
+    const dialog = document.getElementById("modal-dialog");
+    if (dialog) {
+      dialog.style.overflow = "auto";
+    }
+  }
+
+  /**
    * A Svelte action to handle focus within a modal.
    */
   function handleFocus(el: HTMLElement) {
@@ -40,8 +54,13 @@
       attemptFocus(focusEl);
     }
 
+    setBodyScrollLock(true);
+
     return {
-      destroy: () => document.removeEventListener("keydown", keydown),
+      destroy: () => {
+        document.removeEventListener("keydown", keydown);
+        setBodyScrollLock(false);
+      },
     };
   }
 </script>
@@ -49,7 +68,13 @@
 {#if shown}
   <div class="overlay">
     <div class="background" on:click={closeHandler} aria-hidden="true" />
-    <div class="content" use:handleFocus role="dialog" aria-modal="true">
+    <div
+      class="content"
+      id="modal-dialog"
+      use:handleFocus
+      role="dialog"
+      aria-modal="true"
+    >
       <slot />
       <button type="button" class="muted close" on:click={closeHandler}
         >x</button


### PR DESCRIPTION
I have a need to input entries to Fava using mobile phone. When testing it I found few bugs which made the mobile usage a bit nuisance. Here are fixes to problems I encountered. Each commit message has more specific rationale and other thoughts but here is overview of each issue with screenschots of before and after:

## Set dialogs fullscreen on mobile
Previously dialogs were quite small at least on my iPhone 14 Pro. I think it might be best to just use the whole screen on phones for dialogs.

Before: 
![dialog_on_mobile_1](https://user-images.githubusercontent.com/3398165/230480955-119449b6-e62f-48b5-b83a-3d00dc3913d1.png)
After:
![dialog_fix](https://user-images.githubusercontent.com/3398165/230480983-697f305b-48be-4278-81b8-8f35cf4de2db.png)

Additionally IMHO when dialog is open, the underlying body scroll should be disabled for UX.

## Prevent large tables etc. from breaking the app layout
On mobile many tables etc. are too wide to fit to the mobile screen. This broke the whole layout as you can see in this before screenshot:
![body_on_mobile_1](https://user-images.githubusercontent.com/3398165/230481405-0dd10cbc-0cd0-482e-bb39-c62a5222f1a1.png)

Notice how the top bar does not go from left to right. This also broke dialogs by making them horizontally scrollable for no reason. Suggested solution here simply adds `overflow: scroll` to the `<article>` tag. It fixes most of the problem. 

However I think it might be better to use more fine grained approach and make only the specific wide elements such as tables horizontally scrollable if they are wider than the view port. If you agree, do you have any specific suggestions how you'd like that to be implemented?

Here is after screenshot where the lower part of the view overflows horizontally and is scrollable:
![body_fix](https://user-images.githubusercontent.com/3398165/230482041-91c30175-f01e-4caa-9082-243ca504347f.png)

## Prevent zooming in on inputs on mobile
At least on iOS Safari the browser automatically zooms on inputs which use <16px font size. This makes the UX bad since some elements get left out of the screen and then requires the user to pinch zoom out. Here I simply changed all fonts from 14px -> 16px on mobile. This removes the zoom feature on iOS. However, I think increasing _all_ fonts might have been too heavy handed, so please tell me if you think that only input fonts should be increased. Personally I don't mind either way. Though I guess larger font on mobile improves readability a bit (with trade off having less content on screen).

Below is a screenshot before on my iPhone zoomed in to entry field notably hiding the close button:
![zoom_on_mobile_1](https://user-images.githubusercontent.com/3398165/230482917-921c65b8-9575-460c-b535-b1d8b5b2d126.png)

## For reviewer
I tested the changes manually on my phone and desktop PC and to me it seemed like these changes should not affect negatively to desktop users. However, since I literally got familiar with the code base today I might have easily missed something. In case you find some problems or just mistakes in conventions etc. just leave a comment and a pointer to example etc. for me to look into and I'm happy to fix the PR.

I did not had access to real Android phone so I tested this only on iPhone 14 Pro and Chrome on regular Linux desktop by using Chrome mobile dev tools so I'd appreciate if you could check the changes on Android.

Finally, I checked the titles of open issues and did not see any specific issues related to these issues I had.