### PR TITLE
remove ctrl-c as shortcut of show charts

### DIFF
--- a/frontend/src/charts/Chart.svelte
+++ b/frontend/src/charts/Chart.svelte
@@ -4,7 +4,6 @@
   import type { Writable } from "svelte/store";
 
   import { _ } from "../i18n";
-  import { keyboardShortcut } from "../keyboard-shortcuts";
   import {
     barChartMode,
     chartCurrency,
@@ -87,7 +86,6 @@
   <button
     type="button"
     on:click={() => showCharts.update((v) => !v)}
-    use:keyboardShortcut={"Control+c"}
     class:closed={!$showCharts}
     class="toggle-chart"
   />


### PR DESCRIPTION
<!--
Hi, thank you for opening a PR!

Please ensure that your change passes tests and the various linters by running
`make test` and `make lint`. If testable, your changes should be covered by
unit tests.

Explain your changes below and link to related issues.
-->

Ctrl+C is the shortcut to copy content on Windows and Linux, but on Fava it also toggles the charts. I have to say this is very annoying. I believe it is pretty common that someone wants to copy some data from the page, while it is rare that someone wants to hide the chart. I'm not even sure it's even useful to allow hiding it on UI at all.

So I don't think we need a shortcut for this functionality. It might be fine to pick another shortcut, but I'm not sure it's even worth it.