### PR TITLE
Add custom endpoints to extensions

### DIFF
--- a/frontend/src/extensions.ts
+++ b/frontend/src/extensions.ts
@@ -6,26 +6,134 @@
 import { get as store_get } from "svelte/store";
 
 import { getUrlPath, urlFor } from "./helpers";
+import { fetch } from "./lib/fetch";
 import { log_error } from "./log";
 import { extensions } from "./stores";
+
+class ExtensionApi {
+  extension_name: string;
+
+  constructor(extension_name: string) {
+    this.extension_name = extension_name;
+  }
+
+  request(
+    endpoint: string,
+    method: string,
+    params: Record<string, string | number> | undefined,
+    body: object | undefined,
+    output: "json" | "string" | "raw" = "json",
+  ) {
+    const url = urlFor(
+      `extension/${this.extension_name}/${endpoint}`,
+      params,
+      false,
+    );
+    let opts = {};
+    if (body) {
+      opts =
+        body instanceof FormData
+          ? { body }
+          : {
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify(body),
+            };
+    }
+    const request = fetch(url, { method, ...opts });
+    if (output === "json") {
+      return request.then((res) => res.json());
+    }
+    if (output === "string") {
+      return request.then((res) => res.text());
+    }
+    return request;
+  }
+
+  get(
+    endpoint: string,
+    params: Record<string, string | number>,
+    output: "json" | "string" | "raw" = "json",
+  ) {
+    return this.request(endpoint, "GET", params, undefined, output);
+  }
+
+  put(
+    endpoint: string,
+    body: object | undefined,
+    output: "json" | "string" | "raw" = "json",
+  ) {
+    return this.request(endpoint, "PUT", undefined, body, output);
+  }
+
+  post(
+    endpoint: string,
+    body: object | undefined,
+    output: "json" | "string" | "raw" = "json",
+  ) {
+    return this.request(endpoint, "POST", undefined, body, output);
+  }
+
+  delete(
+    endpoint: string,
+    body: object | undefined,
+    output: "json" | "string" | "raw" = "json",
+  ) {
+    return this.request(endpoint, "DELETE", undefined, body, output);
+  }
+}
+
+export interface ExtensionContext {
+  api: ExtensionApi;
+  getExt: (name: string) => Promise<ExtensionData>;
+}
 
 /**
  * The Javascript code of a Fava extension should export an object of this type.
  */
 export interface ExtensionModule {
   /** Initialise this Javascript module / run some code on the initial load. */
-  init?: () => void;
+  init?: (c: ExtensionContext) => void;
   /** Run some code after any Fava page has loaded. */
-  onPageLoad?: () => void;
+  onPageLoad?: (c: ExtensionContext) => void;
   /** Run some code after the page for this extension has loaded. */
-  onExtensionPageLoad?: () => void;
+  onExtensionPageLoad?: (c: ExtensionContext) => void;
 }
 
-async function loadExtensionModule(name: string): Promise<ExtensionModule> {
+export class ExtensionData implements Required<ExtensionModule> {
+  context: ExtensionContext;
+
+  extension: ExtensionModule;
+
+  constructor(context: ExtensionContext, extension: ExtensionModule) {
+    this.context = context;
+    this.extension = extension;
+  }
+
+  init(): void {
+    this.extension.init?.(this.context);
+  }
+
+  onPageLoad(): void {
+    this.extension.onPageLoad?.(this.context);
+  }
+
+  onExtensionPageLoad(): void {
+    this.extension.onExtensionPageLoad?.(this.context);
+  }
+}
+
+async function loadExtensionModule(
+  name: string,
+  getExtension: (name: string) => Promise<ExtensionData>,
+): Promise<ExtensionData> {
   const url = urlFor(`extension_js_module/${name}.js`, undefined, false);
   const mod = await (import(url) as Promise<{ default?: ExtensionModule }>);
   if (typeof mod.default === "object") {
-    return mod.default;
+    const context: ExtensionContext = {
+      api: new ExtensionApi(name),
+      getExt: getExtension,
+    };
+    return new ExtensionData(context, mod.default);
   }
   throw new Error(
     `Error importing module for extension ${name}: module must export "default" object`,
@@ -33,17 +141,17 @@ async function loadExtensionModule(name: string): Promise<ExtensionModule> {
 }
 
 /** A map of all extensions modules that have been (requested to be) loaded already. */
-const loaded_extensions = new Map<string, Promise<ExtensionModule>>();
+const loaded_extensions = new Map<string, Promise<ExtensionData>>();
 
 /** Get the extensions module - if it has not been imported yet, initialise it. */
-async function getExt(name: string): Promise<ExtensionModule> {
+async function getExt(name: string): Promise<ExtensionData> {
   const loaded_ext = loaded_extensions.get(name);
   if (loaded_ext) {
     return loaded_ext;
   }
-  const ext = loadExtensionModule(name);
+  const ext = loadExtensionModule(name, getExt);
   loaded_extensions.set(name, ext);
-  (await ext).init?.();
+  (await ext).init();
   return ext;
 }
 
@@ -55,7 +163,9 @@ export function handleExtensionPageLoad(): void {
   for (const { name } of exts) {
     // Run the onPageLoad handler for all pages.
     getExt(name)
-      .then((m) => m.onPageLoad?.())
+      .then((m) => {
+        m.onPageLoad();
+      })
       .catch(log_error);
   }
   const path = getUrlPath(window.location);
@@ -63,7 +173,9 @@ export function handleExtensionPageLoad(): void {
     for (const { name } of exts) {
       if (path.startsWith(`extension/${name}`)) {
         getExt(name)
-          .then((m) => m.onExtensionPageLoad?.())
+          .then((m) => {
+            m.onExtensionPageLoad();
+          })
           .catch(log_error);
       }
     }

--- a/src/fava/application.py
+++ b/src/fava/application.py
@@ -310,6 +310,23 @@ def _setup_routes(fava_app: Flask) -> None:  # noqa: PLR0915
             return render_template(f"{report_name}.html")
         return abort(404)
 
+    @fava_app.route(
+        "/<bfile>/extension/<extension_name>/<endpoint>",
+        methods=["GET", "POST", "PUT", "DELETE"],
+    )
+    def extension_endpoint(extension_name: str, endpoint: str) -> Response:
+        ext = g.ledger.extensions.get_extension(extension_name)
+        key = (endpoint, request.method)
+        if ext is None or key not in ext.endpoints:
+            return abort(404)
+        response = ext.endpoints[key](ext)
+
+        return (
+            fava_app.make_response(response)
+            if response is not None
+            else abort(404)
+        )
+
     @fava_app.route("/<bfile>/extension_js_module/<extension_name>.js")
     def extension_js_module(extension_name: str) -> Response:
         """Endpoint for extension module source."""

--- a/src/fava/ext/__init__.py
+++ b/src/fava/ext/__init__.py
@@ -16,6 +16,10 @@ from flask import current_app
 from fava.helpers import BeancountError
 
 if TYPE_CHECKING:  # pragma: no cover
+    from typing import Callable
+
+    from flask.wrappers import Response
+
     from fava.beans.abc import Directive
     from fava.core import FavaLedger
 
@@ -39,6 +43,8 @@ class FavaExtensionBase:
 
     config: Any
 
+    endpoints: dict[tuple[str, str], Callable[[FavaExtensionBase], Any]]
+
     def __init__(self, ledger: FavaLedger, config: str | None = None) -> None:
         """Initialise extension.
 
@@ -47,6 +53,16 @@ class FavaExtensionBase:
             config: Configuration options string passed from the
                     beancount file's 'fava-extension' line.
         """
+        self.endpoints = {}
+
+        # Go through each of the subclass's functions to find the ones
+        # marked as endpoints by @extension_endpoint
+        for _, func in inspect.getmembers(self.__class__, inspect.isfunction):
+            if hasattr(func, "endpoint_key"):
+                name, methods = func.endpoint_key
+                for method in methods:
+                    self.endpoints[(name, method)] = func
+
         self.ledger = ledger
         try:
             self.config = ast.literal_eval(config) if config else None
@@ -71,6 +87,15 @@ class FavaExtensionBase:
         ext_loader = jinja2.FileSystemLoader(self.extension_dir / "templates")
         loader = jinja2.ChoiceLoader([ext_loader, current_app.jinja_loader])
         return current_app.jinja_env.overlay(loader=loader)
+
+    def set_endpoint(
+        self,
+        endpoint_name: str,
+        func: Callable[[FavaExtensionBase], Any],
+        methods: list[str] | None = None,
+    ) -> None:
+        for method in methods or ["GET"]:
+            self.endpoints[(endpoint_name, method)] = func
 
     def after_entry_modified(self, entry: Directive, new_lines: str) -> None:
         """Run after an `entry` has been modified."""
@@ -139,3 +164,49 @@ def find_extensions(
         )
 
     return classes, []
+
+
+def extension_endpoint(
+    func_or_endpoint_name: Callable[[FavaExtensionBase], Any]
+    | str
+    | None = None,
+    methods: list[str] | None = None,
+) -> (
+    Callable[[FavaExtensionBase], Response]
+    | Callable[
+        [Callable[[FavaExtensionBase], Response]],
+        Callable[[FavaExtensionBase], Response],
+    ]
+):
+    """Decorator to mark a function as an endpoint.
+
+    Can be used as @extension_endpoint or @extension_endpoint(endpoint_name, methods)
+
+    When used as @extension_endpoint, the endpoint name is the name of the function,
+    and methods is "GET"
+
+    When used as @extension_endpoint(endpoint_name, methods), the given endpoint name
+    and methods are used, but both are optional. If endpoint_name is None, default to
+    the function name, and if methods is None, default to "GET"
+    """
+    endpoint_name = (
+        func_or_endpoint_name
+        if isinstance(func_or_endpoint_name, str)
+        else None
+    )
+
+    def decorator(
+        func: Callable[[FavaExtensionBase], Response],
+    ) -> Callable[[FavaExtensionBase], Response]:
+        f: Any = func
+        f.endpoint_key = (
+            endpoint_name if endpoint_name else func.__name__,
+            methods or ["GET"],
+        )
+        return func
+
+    return (
+        decorator(func_or_endpoint_name)
+        if callable(func_or_endpoint_name)
+        else decorator
+    )

--- a/src/fava/ext/__init__.py
+++ b/src/fava/ext/__init__.py
@@ -88,15 +88,6 @@ class FavaExtensionBase:
         loader = jinja2.ChoiceLoader([ext_loader, current_app.jinja_loader])
         return current_app.jinja_env.overlay(loader=loader)
 
-    def set_endpoint(
-        self,
-        endpoint_name: str,
-        func: Callable[[FavaExtensionBase], Any],
-        methods: list[str] | None = None,
-    ) -> None:
-        for method in methods or ["GET"]:
-            self.endpoints[(endpoint_name, method)] = func
-
     def after_entry_modified(self, entry: Directive, new_lines: str) -> None:
         """Run after an `entry` has been modified."""
 
@@ -180,14 +171,15 @@ def extension_endpoint(
 ):
     """Decorator to mark a function as an endpoint.
 
-    Can be used as @extension_endpoint or @extension_endpoint(endpoint_name, methods)
+    Can be used as `@extension_endpoint` or
+    `@extension_endpoint(endpoint_name, methods)`.
 
-    When used as @extension_endpoint, the endpoint name is the name of the function,
-    and methods is "GET"
+    When used as @extension_endpoint, the endpoint name is the name of the
+    function and methods is "GET".
 
-    When used as @extension_endpoint(endpoint_name, methods), the given endpoint name
-    and methods are used, but both are optional. If endpoint_name is None, default to
-    the function name, and if methods is None, default to "GET"
+    When used as @extension_endpoint(endpoint_name, methods), the given endpoint
+    name and methods are used, but both are optional. If endpoint_name is None,
+    default to the function name, and if methods is None, default to "GET"
     """
     endpoint_name = (
         func_or_endpoint_name


### PR DESCRIPTION
Thanks for merging #1600. This is a small WIP addon to that, that adds the ability for extensions to register their own endpoints that can be called at '/beancount/extension/<ext_name>/<endpoint>', so that the template html or the new js module can communicate with the extension backend, which I think opens up the possibility for much more advanced extensions. This is a pretty bare-bones version of the change that doesn't handle arguments particularly well, and might have issues with locking (I'm not sure how locking around requests works), but it has been working well for me in a few personal extensions that I've written in the past few weeks.

I'm not sure if this type of thing is something you'd want to support, so I wanted to see if this was interesting at all before spending too much time cleaning it up.