### PR TITLE
extensions: refactor

### DIFF
--- a/frontend/src/api/validators.ts
+++ b/frontend/src/api/validators.ts
@@ -71,8 +71,13 @@ export const ledgerDataValidator = object({
   years: array(string),
   user_queries: array(object({ name: string, query_string: string })),
   upcoming_events_count: number,
-  extension_reports: array(tuple([string, string])),
-  extension_js_modules: array(string),
+  extensions: array(
+    object({
+      name: string,
+      report_title: optional(string),
+      has_js_module: boolean,
+    })
+  ),
   sidebar_links: array(tuple([string, string])),
   other_ledgers: array(tuple([string, string])),
 });

--- a/frontend/src/extensions.ts
+++ b/frontend/src/extensions.ts
@@ -7,7 +7,7 @@ import { get as store_get } from "svelte/store";
 
 import { getUrlPath, urlFor } from "./helpers";
 import { log_error } from "./log";
-import { extension_js_modules } from "./stores";
+import { extensions } from "./stores";
 
 /**
  * The Javascript code of a Fava extension should export an object of this type.
@@ -51,8 +51,8 @@ async function getExt(name: string): Promise<ExtensionModule> {
  * On page load, run check if the new page is an extension report page and run hooks.
  */
 export function handleExtensionPageLoad() {
-  const exts = store_get(extension_js_modules);
-  for (const name of exts) {
+  const exts = store_get(extensions).filter((e) => e.has_js_module);
+  for (const { name } of exts) {
     // Run the onPageLoad handler for all pages.
     getExt(name)
       .then((m) => m.onPageLoad?.())
@@ -60,7 +60,7 @@ export function handleExtensionPageLoad() {
   }
   const path = getUrlPath(window.location);
   if (path?.startsWith("extension/")) {
-    for (const name of exts) {
+    for (const { name } of exts) {
       if (path.startsWith(`extension/${name}`)) {
         getExt(name)
           .then((m) => m.onExtensionPageLoad?.())

--- a/frontend/src/lib/equals.ts
+++ b/frontend/src/lib/equals.ts
@@ -1,7 +1,13 @@
+/** Types for which we can do a strict comparison. */
+export type StrictEquality = string | number | null;
+
 /**
- * Shallow equality of two arrays.
+ * Shallow equality of two arrays - the elements are compared strictly.
  */
-export function shallow_equal<T>(a: T[], b: T[]): boolean {
+export function shallow_equal<T extends StrictEquality>(
+  a: T[],
+  b: T[]
+): boolean {
   const l = a.length;
   if (l !== b.length) {
     return false;

--- a/frontend/src/lib/store.ts
+++ b/frontend/src/lib/store.ts
@@ -1,6 +1,7 @@
 import type { Readable, Writable } from "svelte/store";
 import { derived, writable } from "svelte/store";
 
+import type { StrictEquality } from "./equals";
 import { shallow_equal } from "./equals";
 import { parseJSON } from "./json";
 import type { Validator } from "./validation";
@@ -10,7 +11,7 @@ import type { Validator } from "./validation";
  * @param store - The store to derive the value from.
  * @param getter - A getter that obtains the array that should be contained in the store.
  */
-export function derived_array<S, T>(
+export function derived_array<S, T extends StrictEquality>(
   store: Readable<S>,
   getter: (values: S) => T[]
 ): Readable<T[]> {

--- a/frontend/src/sidebar/Aside.svelte
+++ b/frontend/src/sidebar/Aside.svelte
@@ -2,7 +2,7 @@
   import { urlFor } from "../helpers";
   import { _ } from "../i18n";
   import { keyboardShortcut } from "../keyboard-shortcuts";
-  import { errors, ledgerData } from "../stores";
+  import { errors, extensions, ledgerData } from "../stores";
 
   import AccountSelector from "./AccountSelector.svelte";
   import Link from "./SidebarLink.svelte";
@@ -11,8 +11,8 @@
 
   $: user_queries = $ledgerData.user_queries;
   $: upcoming_events_count = $ledgerData.upcoming_events_count;
-  $: extension_reports = $ledgerData.extension_reports;
   $: sidebar_links = $ledgerData.sidebar_links;
+  $: extension_reports = $extensions.filter((e) => e.report_title);
 </script>
 
 {#if sidebar_links.length}
@@ -75,8 +75,8 @@
 </ul>
 {#if extension_reports.length}
   <ul class="navigation">
-    {#each extension_reports as [name, label]}
-      <Link report={`extension/${name}`} name={label} />
+    {#each extension_reports as ext}
+      <Link report={`extension/${ext.name}`} name={ext.report_title ?? ""} />
     {/each}
   </ul>
 {/if}

--- a/frontend/src/stores/index.ts
+++ b/frontend/src/stores/index.ts
@@ -27,11 +27,8 @@ export const HAVE_EXCEL = derived(ledgerData, (val) => val.have_excel);
 export const incognito = derived(ledgerData, (val) => val.incognito);
 /** Base URL. */
 export const base_url = derived(ledgerData, (val) => val.base_url);
-/** The names of Fava extensions that have JS modules. */
-export const extension_js_modules = derived_array(
-  ledgerData,
-  (val) => val.extension_js_modules
-);
+/** The Fava extensions. */
+export const extensions = derived(ledgerData, (val) => val.extensions);
 
 /** The ranked array of all accounts. */
 export const accounts = derived_array(ledgerData, (val) => val.accounts);

--- a/frontend/test/equals.test.ts
+++ b/frontend/test/equals.test.ts
@@ -8,8 +8,6 @@ test("shallow array equality", () => {
   assert.ok(shallow_equal(["asdf", 1], ["asdf", 1]));
   assert.ok(!shallow_equal([1, "asdf"], ["asdf", 1]));
   assert.ok(shallow_equal(["asdf"], ["asdf"]));
-  const obj = {};
-  assert.ok(shallow_equal([obj], [obj]));
 });
 
 test.run();

--- a/src/fava/ext/__init__.py
+++ b/src/fava/ext/__init__.py
@@ -5,14 +5,13 @@ import ast
 import importlib
 import inspect
 import sys
+from pathlib import Path
 from typing import Any
 from typing import TYPE_CHECKING
 
 from fava.helpers import BeancountError
 
 if TYPE_CHECKING:  # pragma: no cover
-    from pathlib import Path
-
     from fava.beans.abc import Directive
     from fava.core import FavaLedger
 
@@ -28,9 +27,11 @@ class FavaExtensionBase:
     discover all subclasses of this class in the specified modules.
     """
 
+    #: Name for a HTML report for this extension.
     report_title: str | None = None
 
-    has_js_module: bool | None = None
+    #: Whether this extension includes a Javascript module.
+    has_js_module: bool = False
 
     config: Any
 
@@ -47,7 +48,16 @@ class FavaExtensionBase:
             self.config = ast.literal_eval(config) if config else None
         except ValueError:
             self.config = None
-        self.name = self.__class__.__qualname__
+
+    @property
+    def name(self) -> str:
+        """Unique name of this extension."""
+        return self.__class__.__qualname__
+
+    @property
+    def extension_dir(self) -> Path:
+        """Directory to look for templates directory and Javascript code."""
+        return Path(inspect.getfile(self.__class__)).parent
 
     def after_entry_modified(self, entry: Directive, new_lines: str) -> None:
         """Run after an `entry` has been modified."""

--- a/src/fava/internal_api.py
+++ b/src/fava/internal_api.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:  # pragma: no cover
 
     from fava.beans.abc import Meta
     from fava.core.accounts import AccountDict
+    from fava.core.extensions import ExtensionDetails
     from fava.core.fava_options import FavaOptions
     from fava.helpers import BeancountError
     from fava.util.date import Interval
@@ -66,8 +67,7 @@ class LedgerData:
     years: list[str]
     user_queries: list[Any]
     upcoming_events_count: int
-    extension_reports: list[tuple[str, str]]
-    extension_js_modules: list[str]
+    extensions: list[ExtensionDetails]
     sidebar_links: list[tuple[str, str]]
     other_ledgers: list[tuple[str, str]]
 
@@ -104,8 +104,7 @@ def get_ledger_data() -> LedgerData:
         ledger.attributes.years,
         ledger.query_shell.queries[: ledger.fava_options.sidebar_show_queries],
         len(ledger.misc.upcoming_events),
-        ledger.extensions.reports,
-        ledger.extensions.js_modules,
+        ledger.extensions.extension_details,
         ledger.misc.sidebar_links,
         [
             (ledger.options["title"], url_for("index", bfile=file_slug))

--- a/tests/__snapshots__/test_application.py-test_client_side_reports
+++ b/tests/__snapshots__/test_application.py-test_client_side_reports
@@ -899,8 +899,7 @@
 "XYZ"
 ],
 "errors": [],
-"extension_js_modules": [],
-"extension_reports": [],
+"extensions": [],
 "fava_options": {
 "account_journal_include_children": true,
 "auto_reload": false,

--- a/tests/__snapshots__/test_internal_api.py-test_get_ledger_data
+++ b/tests/__snapshots__/test_internal_api.py-test_get_ledger_data
@@ -884,8 +884,7 @@
   "XYZ"
  ],
  "errors": [],
- "extension_js_modules": [],
- "extension_reports": [],
+ "extensions": [],
  "fava_options": {
   "account_journal_include_children": true,
   "auto_reload": false,

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -249,20 +249,18 @@ def test_static_url(app: Flask) -> None:
         assert url == "/static/nonexistent.js?mtime=0"
 
 
-def test_load_extension_reports(app: Flask, test_client: FlaskClient) -> None:
+def test_load_extension_reports(test_client: FlaskClient) -> None:
     """Extension can register reports."""
-    with app.test_request_context("/extension-report/"):
-        app.preprocess_request()
-        assert g.ledger.extensions.reports == [
-            ("PortfolioList", "Portfolio List")
-        ]
 
-        url = "/extension-report/extension/PortfolioList/"
-        result = test_client.get(url)
-        assert result.status_code == 200
-        url = "/extension-report/extension_js_module/PortfolioList.js"
-        result = test_client.get(url)
-        assert result.status_code == 200
-        url = "/extension-report/extension/MissingExtension/"
-        result = test_client.get(url)
-        assert result.status_code == 404
+    url = "/extension-report/extension/PortfolioList/"
+    result = test_client.get(url)
+    assert result.status_code == 200
+    url = "/extension-report/extension_js_module/PortfolioList.js"
+    result = test_client.get(url)
+    assert result.status_code == 200
+    url = "/extension-report/extension_js_module/Missing.js"
+    result = test_client.get(url)
+    assert result.status_code == 404
+    url = "/extension-report/extension/MissingExtension/"
+    result = test_client.get(url)
+    assert result.status_code == 404

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -3,28 +3,25 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from fava.core.extensions import ExtensionDetails
+
 if TYPE_CHECKING:  # pragma: no cover
     from .conftest import GetFavaLedger
 
 
 def test_report_page_globals(get_ledger: GetFavaLedger) -> None:
-    """Extensions can register reports."""
+    """Extensions can register reports and have JS modules."""
     extension_report_ledger = get_ledger("extension-report")
-    result = extension_report_ledger.extensions.reports
-    assert result == [("PortfolioList", "Portfolio List")]
+    result = extension_report_ledger.extensions.extension_details
+    assert result == [
+        ExtensionDetails("PortfolioList", "Portfolio List", True)
+    ]
 
     extension_report_ledger.extensions.after_write_source("test", "test")
 
+    ext = extension_report_ledger.extensions.get_extension("PortfolioList")
+    assert ext
+    assert ext.name == "PortfolioList"
 
-def test_extension_module_globals(get_ledger: GetFavaLedger) -> None:
-    """Extensions can have Javascript modules."""
-    extension_report_ledger = get_ledger("extension-report")
-    modules = extension_report_ledger.extensions.js_modules
-    assert modules == ["PortfolioList"]
-
-    module_path = extension_report_ledger.extensions.get_extension_js_module(
-        "PortfolioList"
-    )
-
-    assert module_path.exists()
-    assert module_path.name == "PortfolioList.js"
+    assert ext.extension_dir.exists()
+    assert (ext.extension_dir / "PortfolioList.js").exists()


### PR DESCRIPTION
Unify the information about the extensions that is sent to the frontend
to a single array.

Also, simplify/remove some of the code in fava.core.extensions by
accessing attributes of the extension directly in fava.application.

<!--
Hi, thank you for opening a PR!

Please ensure that your change passes tests and the various linters by running
`make test` and `make lint`. If testable, your changes should be covered by
unit tests.

Explain your changes below and link to related issues.
-->
