### PR TITLE
Fix offset of AppMenuItem

### DIFF
--- a/frontend/src/reports/editor/AppMenuItem.svelte
+++ b/frontend/src/reports/editor/AppMenuItem.svelte
@@ -48,7 +48,7 @@
     display: none;
     width: 500px;
     max-height: 400px;
-    margin: 0.75rem 0 0 -0.5rem;
+    margin: 0.7rem 0 0 -0.5rem;
     overflow-y: auto;
     background-color: var(--background);
     border: 1px solid var(--border);


### PR DESCRIPTION
Commit c9a19191 changed the vertical padding of ".dropdown > span" from 0.75rem to 0.7rem, and added a top margin of 0.75rem to the "ul" that is in ".dropdown > span". At least on Firefox on Linux this causes the dropdown to be 1 pixel too far down, causing a gap between the hit detection for the hover target and the actual dropdown, which causes the dropdown to disappear when trying to move the mouse over it.
