### PR TITLE
Delete entries

### DIFF
--- a/frontend/src/editor/DeleteButton.svelte
+++ b/frontend/src/editor/DeleteButton.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  import { _ } from "../i18n";
+
+  export let deleting: boolean;
+  export let onDelete: () => void;
+
+  $: buttonContent = deleting ? _("Deleting...") : _("Delete");
+</script>
+
+<button
+  type="button"
+  class="muted"
+  on:click={onDelete}
+  title={`${_("Delete")}`}
+>
+  {buttonContent}
+</button>

--- a/src/fava/core/extensions.py
+++ b/src/fava/core/extensions.py
@@ -80,6 +80,10 @@ class ExtensionModule(FavaModule):
         for ext in self._exts:
             ext.after_insert_entry(entry)
 
+    def after_delete_entry(self, entry: Directive) -> None:
+        for ext in self._exts:
+            ext.after_delete_entry(entry)
+
     def after_insert_metadata(
         self, entry: Directive, key: str, value: str
     ) -> None:

--- a/src/fava/ext/__init__.py
+++ b/src/fava/ext/__init__.py
@@ -65,6 +65,9 @@ class FavaExtensionBase:
     def after_insert_entry(self, entry: Directive) -> None:
         """Run after an `entry` has been inserted."""
 
+    def after_delete_entry(self, entry: Directive) -> None:
+        """Run after an `entry` has been deleted."""
+
     def after_insert_metadata(
         self, entry: Directive, key: str, value: str
     ) -> None:

--- a/src/fava/ext/auto_commit.py
+++ b/src/fava/ext/auto_commit.py
@@ -37,6 +37,10 @@ class AutoCommit(FavaExtensionBase):
         message = f"autocommit: entry on {entry.date}"
         self._run(["git", "commit", "-am", message])
 
+    def after_delete_entry(self, entry: Directive) -> None:
+        message = f"autocommit: deleted entry on {entry.date}"
+        self._run(["git", "commit", "-am", message])
+
     def after_entry_modified(self, entry: Directive, _: Any) -> None:
         message = f"autocommit: modified entry on {entry.date}"
         self._run(["git", "commit", "-am", message])

--- a/src/fava/help/extensions.md
+++ b/src/fava/help/extensions.md
@@ -82,6 +82,12 @@ Called after an `entry` has been modified, e.g., via the context popup.
 
 ---
 
+### `after_delete_entry(entry: Directive)`
+
+Called after an `entry` has been deleted, e.g., via the context popup.
+
+---
+
 ## Extension attributes
 
 ### `report_title`

--- a/src/fava/json_api.py
+++ b/src/fava/json_api.py
@@ -289,6 +289,13 @@ def put_source_slice(entry_hash: str, source: str, sha256sum: str) -> str:
 
 
 @api_endpoint
+def delete_source_slice(entry_hash: str, sha256sum: str) -> str:
+    """Delete an entry source slice."""
+    g.ledger.file.delete_entry_slice(entry_hash, sha256sum)
+    return f"Deleted entry {entry_hash}."
+
+
+@api_endpoint
 def put_format_source(source: str) -> str:
     """Format beancount file."""
     return align(source, g.ledger.fava_options.currency_column)


### PR DESCRIPTION
This adds a doDelete function to the TypeScript API for calling DELETE endpoints, and adds a DELETE handler for the entry_slice endpoint to delete a given source slice. It also adds a button next to the save button in the SliceEditor to delete the given slice.

This allows an entry to actually be deleted without going into the editor. Currently, I believe the best you can do is save an empty slice, but that leaves an extra newline in the source file.
