### PR TITLE
Make tables wrap better

### DIFF
--- a/frontend/css/journal-table.css
+++ b/frontend/css/journal-table.css
@@ -60,7 +60,7 @@
 }
 
 .journal .postings .num {
-  overflow: hidden;
+  overflow: scroll;
   line-height: 16px;
 }
 
@@ -126,7 +126,6 @@
 
 .journal p > .num {
   width: 9rem;
-  white-space: pre;
   border-left: 1px solid var(--table-border);
 }
 

--- a/src/fava/templates/_tree_table.html
+++ b/src/fava/templates/_tree_table.html
@@ -3,6 +3,7 @@
 
 {% macro render_diff_and_number(balance, cost, currency, invert=False) %}
   {% set num = balance.pop(currency, 0) %}
+  <span class="number">{{ num|format_currency(currency, invert=invert) }}</span>
   {% if currency in cost %}
     {% set cost_num = cost.pop(currency, 0) %}
     {% set diff = num - cost_num %}
@@ -10,10 +11,10 @@
       {% set diff = -diff %}
     {% endif %}
     {%- if diff -%}
+    <br>
     <span class="diff{{ ' positive' if diff > 0 else ' negative' }}" title="{{ cost_num|format_currency(currency, invert=invert) }} {{ currency }}">({{ diff|format_currency(currency) }})</span>
     {%- endif -%}
   {%- endif -%}
-  <span class="number">{{ num|format_currency(currency, invert=invert) }}</span>
 {%- endmacro %}
 
 {% macro tree(account_node, invert=False, ledger=None) %}

--- a/tests/__snapshots__/test_templates.py-test_render_diff_and_number
+++ b/tests/__snapshots__/test_templates.py-test_render_diff_and_number
@@ -1,1 +1,3 @@
-<span class="diff positive" title="10.00 EUR">(2.00)</span><span class="number">12.00</span>
+  <span class="number">12.00</span>
+<br>
+    <span class="diff positive" title="10.00 EUR">(2.00)</span>

--- a/tests/__snapshots__/test_templates.py-test_render_diff_and_number-2
+++ b/tests/__snapshots__/test_templates.py-test_render_diff_and_number-2
@@ -1,1 +1,3 @@
-<span class="diff negative" title="-10.00 EUR">(-2.00)</span><span class="number">-12.00</span>
+  <span class="number">-12.00</span>
+<br>
+    <span class="diff negative" title="-10.00 EUR">(-2.00)</span>

--- a/tests/__snapshots__/test_templates.py-test_render_diff_and_number-3
+++ b/tests/__snapshots__/test_templates.py-test_render_diff_and_number-3
@@ -1,1 +1,3 @@
-<span class="diff negative" title="12.00 EUR">(-2.00)</span><span class="number">10.00</span>
+  <span class="number">10.00</span>
+<br>
+    <span class="diff negative" title="12.00 EUR">(-2.00)</span>

--- a/tests/__snapshots__/test_templates.py-test_render_diff_and_number-4
+++ b/tests/__snapshots__/test_templates.py-test_render_diff_and_number-4
@@ -1,1 +1,3 @@
-<span class="diff positive" title="-12.00 EUR">(2.00)</span><span class="number">-10.00</span>
+  <span class="number">-10.00</span>
+<br>
+    <span class="diff positive" title="-12.00 EUR">(2.00)</span>

--- a/tests/__snapshots__/test_templates.py-test_tree_off_by_one
+++ b/tests/__snapshots__/test_templates.py-test_tree_off_by_one
@@ -14,8 +14,11 @@ Hold Ctrl or Cmd while clicking to expand one level.">
         <a href="/off-by-one/account/Assets/?conversion=at_value" class="account">Assets</a>
       </span>
       <span class="num">
-        <span class="balance"><span class="number"></span></span>
-        <span class="balance-children"><span class="diff positive" title="100 USD">(4)</span><span class="number">104</span></span>
+        <span class="balance">  <span class="number"></span>
+</span>
+        <span class="balance-children">  <span class="number">104</span>
+<br>
+    <span class="diff positive" title="100 USD">(4)</span></span>
       </span>
       <span class="num other">
         <span class="balance">
@@ -30,8 +33,10 @@ Hold Ctrl or Cmd while clicking to expand one level.">
         <a href="/off-by-one/account/Assets:Cash/?conversion=at_value" class="account">Cash</a>
       </span>
       <span class="num">
-        <span class="balance"><span class="number"></span></span>
-        <span class="balance-children"><span class="number"></span></span>
+        <span class="balance">  <span class="number"></span>
+</span>
+        <span class="balance-children">  <span class="number"></span>
+</span>
       </span>
       <span class="num other">
         <span class="balance">
@@ -47,8 +52,12 @@ Hold Ctrl or Cmd while clicking to expand one level.">
         <a href="/off-by-one/account/Assets:Commodity/?conversion=at_value" class="account">Commodity</a>
       </span>
       <span class="num">
-        <span class="balance"><span class="diff positive" title="100 USD">(4)</span><span class="number">104</span></span>
-        <span class="balance-children"><span class="diff positive" title="100 USD">(4)</span><span class="number">104</span></span>
+        <span class="balance">  <span class="number">104</span>
+<br>
+    <span class="diff positive" title="100 USD">(4)</span></span>
+        <span class="balance-children">  <span class="number">104</span>
+<br>
+    <span class="diff positive" title="100 USD">(4)</span></span>
       </span>
       <span class="num other">
         <span class="balance">


### PR DESCRIPTION
Fixes #1575

Commit ca6d1d928 made it so that currencies don't wrap at all, which means in many cases currencies or amounts get cut off, whenever one or more of the following happen:
 - the currency name is too long
 - the amount is large
 - there are a lot of decimal places in an amount

This removes the white-space rule that was added by that commit, which allows amounts and commodities to wrap if necessary, so that they can be read.
It also changes the overflow of .num from hidden to scroll. This means that if an individual number or currency is too long to fit, but won't wrap because it's one word, at least you can scroll the box to see the rest

Finally it adds a line break between the value and the diff in _tree_table.html and moves the diff after the value. This is a similar issue where the combination of the value and the diff is often long enough to overflow the cell that it's in, so the line break means everything fits in a single cell
