### PR TITLE
Create github workflow for pushing to ghcr.io

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,38 @@
+name: Docker Image
+
+on:
+  push:
+    branches: [ "main" ]
+    tags: ["*"]
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - uses: docker/login-action@v1
+      with:
+        registry: ghcr.io
+        username: ${{github.actor}}
+        password: ${{secrets.GITHUB_TOKEN}}
+
+    - name: Publish Docker image (latest)
+      if: github.ref_type != 'tag'
+      run: |
+          docker build contrib/docker --tag ghcr.io/beancount/fava:latest
+          docker push ghcr.io/beancount/fava:latest
+
+    - name: Set release version
+      if: github.ref_type == 'tag'
+      id: release
+      run: echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
+
+    - name: Publish Docker image (tag)
+      if: github.ref_type == 'tag'
+      run: |
+          docker build contrib/docker --tag ghcr.io/beancount/fava:${{ steps.release.outputs.tag }}
+          docker push ghcr.io/beancount/fava:${{ steps.release.outputs.tag }}


### PR DESCRIPTION
This PR should cause any push to `main` to automatically cause the Dockerfile to be built, tagged and pushed to `ghcr.io/beancount/fava:latest` 

whenever there is a commit _tagged_ , the Dockerfile should again be built, tagged, but this time pushed to `ghcr.io/beancount/fava:<tag>`

The idea being that instead of relying on other images that are floating around like yegle or alexiri which get stale an "official" image can be used instead.
