### PR TITLE
charts: toggle currencies in bar and line charts

### DIFF
--- a/frontend/src/charts/Axis.svelte
+++ b/frontend/src/charts/Axis.svelte
@@ -1,40 +1,39 @@
 <script lang="ts">
   import type { Axis } from "d3-axis";
+  import type { NumberValue } from "d3-scale";
   import { select } from "d3-selection";
 
+  type Ax = Axis<string> | Axis<NumberValue>;
+
   /** The d3 axis to use. */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  export let axis: Axis<any>;
+  export let axis: Ax;
   /** True if this is an x axis. */
   export let x = false;
   /** True if this is a y axis. */
   export let y = false;
-  /** Whether to show a more pronounced line at zero (for y axis). */
-  export let lineAtZero = false;
+  /** Show a pronounced line at zero (for y axis). */
+  export let lineAtZero: number | null = null;
   /** Height of the chart (needed for the correct offset of an x axis) */
   export let innerHeight = 0;
 
   $: transform = x ? `translate(0,${innerHeight})` : undefined;
 
   /** Svelte action to render the axis. */
-  function use(
-    node: SVGGElement,
-    ax: Axis<unknown>
-  ): { update: (a: Axis<unknown>) => void } {
+  function use(node: SVGGElement, ax: Ax): { update: (a: Ax) => void } {
     const selection = select(node);
     ax(selection);
 
     return {
-      update(a) {
-        a(selection);
+      update(new_ax) {
+        new_ax(selection);
       },
     };
   }
 </script>
 
 <g class:y use:use={axis} {transform}>
-  {#if y && lineAtZero}
-    <g class="zero" transform={`translate(0,${axis.scale()(0) ?? 0})`}>
+  {#if y && lineAtZero !== null}
+    <g class="zero" transform={`translate(0,${lineAtZero})`}>
       <line x2={-axis.tickSizeInner()} />
     </g>
   {/if}

--- a/frontend/src/charts/Chart.svelte
+++ b/frontend/src/charts/Chart.svelte
@@ -19,12 +19,12 @@
   import ModeSwitch from "./ModeSwitch.svelte";
   import ScatterPlot from "./ScatterPlot.svelte";
 
-  import type { NamedFavaChart } from ".";
+  import type { FavaChart } from ".";
 
   /**
    * The chart to render.
    */
-  export let chart: NamedFavaChart;
+  export let chart: FavaChart;
 
   /**
    * Width of the chart.
@@ -72,7 +72,7 @@
           ["area", _("Area chart")],
         ]}
       />
-    {:else if chart.type === "barchart" && chart.data.hasStackedData}
+    {:else if chart.type === "barchart" && chart.hasStackedData}
       <ModeSwitch
         bind:value={$barChartMode}
         options={[
@@ -95,13 +95,13 @@
 <div hidden={!$showCharts} bind:clientWidth={width}>
   {#if width}
     {#if chart.type === "barchart"}
-      <BarChart data={chart.data} tooltipText={chart.tooltipText} {width} />
+      <BarChart {chart} {width} />
     {:else if chart.type === "hierarchy"}
-      <HierarchyContainer data={chart.data} {width} />
+      <HierarchyContainer {chart} {width} />
     {:else if chart.type === "linechart"}
-      <LineChart data={chart.data} tooltipText={chart.tooltipText} {width} />
+      <LineChart {chart} {width} />
     {:else if chart.type === "scatterplot"}
-      <ScatterPlot data={chart.data} {width} />
+      <ScatterPlot {chart} {width} />
     {/if}
   {/if}
 </div>

--- a/frontend/src/charts/ChartLegend.svelte
+++ b/frontend/src/charts/ChartLegend.svelte
@@ -1,21 +1,48 @@
 <script lang="ts">
+  import { chartToggledCurrencies } from "../stores/chart";
+
   export let legend: [string, string][];
 </script>
 
 {#each legend as [item, color]}
-  <span> <i style="background-color: {color}" /> {item} </span>
+  {@const isActive = !$chartToggledCurrencies.includes(item)}
+  <button
+    type="button"
+    on:click={() => {
+      if (isActive) {
+        $chartToggledCurrencies = [...$chartToggledCurrencies, item];
+      } else {
+        $chartToggledCurrencies = $chartToggledCurrencies.filter(
+          (i) => i !== item
+        );
+      }
+    }}
+    class:inactive={!isActive}
+  >
+    <i style="background-color: {color}" />
+    <span>{item}</span>
+  </button>
 {/each}
 
 <style>
-  span,
-  i {
-    display: inline-block;
+  button {
+    display: contents;
+    color: inherit;
+  }
+
+  .inactive span {
+    text-decoration: line-through;
   }
 
   i {
+    display: inline-block;
     width: 10px;
     height: 10px;
     margin-left: 5px;
     border-radius: 10px;
+  }
+
+  .inactive i {
+    filter: grayscale();
   }
 </style>

--- a/frontend/src/charts/ChartSwitcher.svelte
+++ b/frontend/src/charts/ChartSwitcher.svelte
@@ -7,11 +7,11 @@
   import Chart from "./Chart.svelte";
   import ConversionAndInterval from "./ConversionAndInterval.svelte";
 
-  import type { NamedFavaChart } from ".";
+  import type { FavaChart } from ".";
 
-  export let charts: NamedFavaChart[];
+  export let charts: FavaChart[];
 
-  const setChart = (c: NamedFavaChart) => {
+  const setChart = (c: FavaChart) => {
     $lastActiveChartName = c.name;
   };
 

--- a/frontend/src/charts/HierarchyContainer.svelte
+++ b/frontend/src/charts/HierarchyContainer.svelte
@@ -11,8 +11,10 @@
 
   const context: Writable<string[]> = getContext("chart-currencies");
 
-  export let data: HierarchyChart["data"];
+  export let chart: HierarchyChart
   export let width: number;
+
+  $: data = chart.data;
 
   $: currencies = [...data.keys()];
   $: currency = $chartCurrency || currencies[0];

--- a/frontend/src/charts/ScatterPlot.svelte
+++ b/frontend/src/charts/ScatterPlot.svelte
@@ -8,32 +8,27 @@
 
   import Axis from "./Axis.svelte";
   import { scatterplotScale } from "./helpers";
-  import type { ScatterPlotDatum } from "./scatterplot";
+  import type { ScatterPlot, ScatterPlotDatum } from "./scatterplot";
   import type { TooltipFindNode } from "./tooltip";
   import { domHelpers, positionedTooltip } from "./tooltip";
 
-  export let data: ScatterPlotDatum[];
+  export let chart: ScatterPlot;
   export let width: number;
 
   const today = new Date();
-  const margin = {
-    top: 10,
-    right: 10,
-    bottom: 30,
-    left: 70,
-  };
+  const margin = { top: 10, right: 10, bottom: 30, left: 70 };
   const height = 250;
   $: innerWidth = width - margin.left - margin.right;
   $: innerHeight = height - margin.top - margin.bottom;
 
   // Scales
-  $: dateExtent = extent(data, (d) => d.date);
+  $: dateExtent = extent(chart.data, (d) => d.date);
   $: x = scaleUtc()
     .domain(dateExtent[0] ? dateExtent : [0, 1])
     .range([0, innerWidth]);
   $: y = scalePoint()
     .padding(1)
-    .domain(data.map((d) => d.type))
+    .domain(chart.data.map((d) => d.type))
     .range([innerHeight, 0]);
 
   // Axes
@@ -45,7 +40,7 @@
 
   /** Quadtree for hover. */
   $: quad = quadtree(
-    data,
+    chart.data,
     (d) => x(d.date),
     (d) => y(d.type) ?? 0
   );
@@ -68,7 +63,7 @@
     <Axis x axis={xAxis} {innerHeight} />
     <Axis y axis={yAxis} />
     <g>
-      {#each data as dot}
+      {#each chart.data as dot}
         <circle
           r="5"
           fill={scatterplotScale(dot.type)}

--- a/frontend/src/charts/bar.ts
+++ b/frontend/src/charts/bar.ts
@@ -4,6 +4,7 @@ import { stack, stackOffsetDiverging } from "d3-shape";
 
 import type { FormatterContext } from "../format";
 import type { Result } from "../lib/result";
+import type { ValidationT } from "../lib/validation";
 import { array, date, number, object, record } from "../lib/validation";
 
 import type { ChartContext } from "./context";
@@ -28,25 +29,6 @@ export interface BarChartDatum {
   account_balances: Record<string, Record<string, number>>;
 }
 
-export interface BarChart {
-  type: "barchart";
-  data: {
-    /** All accounts that occur as some child account. */
-    accounts: string[];
-    /** The data for the (single) bars for all the intervals in this chart. */
-    bar_groups: BarChartDatum[];
-    /** For each currency, the stacks (one series per account) */
-    stacks: [currency: string, stacks: Series<BarChartDatum, string>[]][];
-    /** Whether this chart contains any stacks (or is just a single account). */
-    hasStackedData: boolean;
-  };
-  tooltipText: (
-    c: FormatterContext,
-    d: BarChartDatum,
-    e: string,
-  ) => TooltipContent;
-}
-
 const bar_validator = array(
   object({
     date,
@@ -56,52 +38,140 @@ const bar_validator = array(
   }),
 );
 
-/** Calculate the currencies to use for the chart. */
-function calculateCurrenciesToShow(
-  data: {
-    budgets: Record<string, number>;
-    balance: Record<string, number>;
-  }[],
-  operatingCurrencies: string[],
+type ParsedBarChartData = ValidationT<typeof bar_validator>;
+
+export class BarChart {
+  readonly type = "barchart";
+
+  /** The accounts that occur in some bar.  */
+  readonly accounts: string[];
+
+  /** For each currency, the stacks (one series per account) */
+  private readonly stacks: [
+    currency: string,
+    stacks: Series<BarChartDatum, string>[],
+  ][];
+
+  constructor(
+    readonly name: string | null,
+    /** The currencies that are shown in this bar chart. */
+    readonly currencies: string[],
+    /** The data for the (single) bars for all the intervals in this chart. */
+    private readonly bar_groups: BarChartDatum[],
+  ) {
+    this.accounts = Array.from(
+      new Set(bar_groups.map((d) => Object.keys(d.account_balances)).flat(2)),
+    ).sort();
+
+    this.stacks = currencies.map((currency) => [
+      currency,
+      stack<BarChartDatum, string>()
+        .keys(this.accounts)
+        .value((d, account) => d.account_balances[account]?.[currency] ?? 0)
+        .offset(stackOffsetDiverging)(bar_groups)
+        .filter((b) => b[0] !== b[1] && !Number.isNaN(b[1])),
+    ]);
+  }
+
+  filter(hidden_names: string[]): {
+    currencies: string[];
+    bar_groups: BarChartDatum[];
+    stacks: [currency: string, stacks: Series<BarChartDatum, string>[]][];
+  } {
+    const hidden_names_set = new Set(hidden_names);
+    const currencies = new Set(
+      this.currencies.filter((c) => !hidden_names_set.has(c)),
+    );
+    const bar_groups = this.bar_groups.map((b) => ({
+      ...b,
+      values: b.values.filter((v) => currencies.has(v.currency)),
+    }));
+    const stacks = this.stacks.filter((s) => currencies.has(s[0]));
+    return { currencies: [...currencies], bar_groups, stacks };
+  }
+
+  /** Whether this chart contains any stacks (or is just a single account). */
+  get hasStackedData(): boolean {
+    return this.accounts.length > 1;
+  }
+
+  /** The tooltip for a hovered account in the stacked bar chart. */
+  tooltipTextAccount(
+    c: FormatterContext,
+    d: BarChartDatum,
+    account: string,
+  ): TooltipContent {
+    const content = [];
+    content.push(domHelpers.em(account));
+    d.values.forEach((a) => {
+      const value = d.account_balances[account]?.[a.currency] ?? 0;
+      content.push(domHelpers.t(`${c.amount(value, a.currency)}`));
+      content.push(domHelpers.br());
+    });
+    content.push(domHelpers.em(d.label));
+    return content;
+  }
+
+  /** The tooltip for a hovered bar group in the bar chart. */
+  tooltipText(c: FormatterContext, d: BarChartDatum): TooltipContent {
+    const content = [];
+    d.values.forEach((a) => {
+      content.push(
+        domHelpers.t(
+          a.budget
+            ? `${c.amount(a.value, a.currency)} / ${c.amount(
+                a.budget,
+                a.currency,
+              )}`
+            : c.amount(a.value, a.currency),
+        ),
+      );
+      content.push(domHelpers.br());
+    });
+    content.push(domHelpers.em(d.label));
+    return content;
+  }
+}
+
+/** Get the currencies to use for the bar chart. */
+function currencies_to_show(
+  data: ParsedBarChartData,
+  ctx: ChartContext,
 ): string[] {
   // Count the usage of each currency in the data.
-  const inData = rollup(
+  const counts = rollup(
     data.flatMap((interval) => [
-      ...Object.entries(interval.budgets),
-      ...Object.entries(interval.balance),
+      ...Object.keys(interval.budgets),
+      ...Object.keys(interval.balance),
     ]),
     (v) => v.length,
-    (r) => r[0],
+    (r) => r,
   );
 
-  const toShow = [];
-  // Always take operating currencies if they are used in the data.
-  for (const currency of operatingCurrencies) {
-    if (inData.has(currency)) {
-      toShow.push(currency);
-      inData.delete(currency);
-    }
-  }
-  // Decide the number of currencies we want to pick
-  const maxPick = Math.max(operatingCurrencies.length, 5);
-  // Find the most used ones.
-  const sorted = [...inData].sort((a, b) => b[1] - a[1]);
-  for (const item of sorted.slice(0, maxPick - toShow.length)) {
-    toShow.push(item[0]);
-  }
+  // Show all operating currencies that are used in the data.
+  const to_show = ctx.currencies.filter((c) => counts.delete(c));
 
-  return toShow;
+  // Also add some of the most common other currencies (up to 5 in total)
+  to_show.push(
+    ...[...counts]
+      .sort((a, b) => b[1] - a[1])
+      .map((i) => i[0])
+      .slice(0, Math.max(to_show.length, 5) - to_show.length),
+  );
+
+  return to_show;
 }
 
 /**
  * Try to parse a bar chart.
  */
 export function bar(
+  label: string | null,
   json: unknown,
   ctx: ChartContext,
 ): Result<BarChart, string> {
   return bar_validator(json).map((parsedData) => {
-    const currencies = calculateCurrenciesToShow(parsedData, ctx.currencies);
+    const currencies = currencies_to_show(parsedData, ctx);
 
     const bar_groups = parsedData.map((interval) => ({
       values: currencies.map((currency) => ({
@@ -113,54 +183,7 @@ export function bar(
       label: ctx.dateFormat(interval.date),
       account_balances: interval.account_balances,
     }));
-    const accounts = Array.from(
-      new Set(
-        parsedData.map((d) => [...Object.keys(d.account_balances)]).flat(2),
-      ),
-    ).sort();
-    const hasStackedData = accounts.length > 1;
 
-    const stacks = currencies.map(
-      (currency): [string, Series<BarChartDatum, string>[]] => [
-        currency,
-        stack<BarChartDatum>()
-          .keys(accounts)
-          .value((obj, key) => obj.account_balances[key]?.[currency] ?? 0)
-          .offset(stackOffsetDiverging)(bar_groups)
-          .filter((b) => b[0] !== b[1] && !Number.isNaN(b[1])),
-      ],
-    );
-
-    return {
-      type: "barchart",
-      data: { accounts, bar_groups, stacks, hasStackedData },
-      tooltipText: (c, d, e) => {
-        const content: TooltipContent = [];
-        if (e === "") {
-          d.values.forEach((a) => {
-            content.push(
-              domHelpers.t(
-                a.budget
-                  ? `${c.amount(a.value, a.currency)} / ${c.amount(
-                      a.budget,
-                      a.currency,
-                    )}`
-                  : c.amount(a.value, a.currency),
-              ),
-            );
-            content.push(domHelpers.br());
-          });
-        } else {
-          content.push(domHelpers.em(e));
-          d.values.forEach((a) => {
-            const value = d.account_balances[e]?.[a.currency] ?? 0;
-            content.push(domHelpers.t(`${c.amount(value, a.currency)}`));
-            content.push(domHelpers.br());
-          });
-        }
-        content.push(domHelpers.em(d.label));
-        return content;
-      },
-    };
+    return new BarChart(label, currencies, bar_groups);
   });
 }

--- a/frontend/src/charts/hierarchy.ts
+++ b/frontend/src/charts/hierarchy.ts
@@ -32,9 +32,13 @@ function addInternalNodesAsLeaves(node: AccountHierarchyDatum): void {
   }
 }
 
-export interface HierarchyChart {
-  type: "hierarchy";
-  data: Map<string, AccountHierarchyNode>;
+export class HierarchyChart {
+  readonly type = "hierarchy";
+
+  constructor(
+    readonly name: string | null,
+    readonly data: Map<string, AccountHierarchyNode>,
+  ) {}
 }
 
 const account_hierarchy_validator: Validator<AccountHierarchyDatum> = object({
@@ -49,6 +53,7 @@ const hierarchy_validator = object({
 });
 
 export function hierarchy(
+  label: string | null,
   json: unknown,
   { currencies }: ChartContext,
 ): Result<HierarchyChart, string> {
@@ -66,6 +71,6 @@ export function hierarchy(
       }
     });
 
-    return { type: "hierarchy", data };
+    return new HierarchyChart(label, data);
   });
 }

--- a/frontend/src/charts/index.ts
+++ b/frontend/src/charts/index.ts
@@ -21,9 +21,9 @@ const parsers: Partial<
   Record<
     string,
     (
+      label: string,
       json: unknown,
       ctx: ChartContext,
-      label: string,
     ) => Result<FavaChart, string>
   >
 > = {
@@ -34,7 +34,6 @@ const parsers: Partial<
 };
 
 export type FavaChart = HierarchyChart | BarChart | ScatterPlot | LineChart;
-export type NamedFavaChart = FavaChart & { name?: string };
 
 const chart_data_validator = array(
   object({ label: string, type: string, data: unknown }),
@@ -43,15 +42,15 @@ const chart_data_validator = array(
 export function parseChartData(
   data: unknown,
   ctx: ChartContext,
-): Result<NamedFavaChart[], string> {
+): Result<FavaChart[], string> {
   return chart_data_validator(data).map((chartData) => {
-    const result: NamedFavaChart[] = [];
+    const result: FavaChart[] = [];
     chartData.forEach((chart) => {
       const parser = parsers[chart.type];
       if (parser) {
-        const r = parser(chart.data, ctx, chart.label);
+        const r = parser(chart.label, chart.data, ctx);
         if (r.is_ok) {
-          result.push({ name: chart.label, ...r.value });
+          result.push(r.value);
         }
       }
     });

--- a/frontend/src/charts/line.ts
+++ b/frontend/src/charts/line.ts
@@ -1,3 +1,5 @@
+import { sort } from "d3-array";
+
 import type { FormatterContext } from "../format";
 import { day } from "../format";
 import type { Result } from "../lib/result";
@@ -6,26 +8,59 @@ import { array, date, number, object, record } from "../lib/validation";
 import type { TooltipContent } from "./tooltip";
 import { domHelpers } from "./tooltip";
 
+/**
+ * A single data point on a line or area chart.
+ */
 export interface LineChartDatum {
   name: string;
   date: Date;
   value: number;
 }
 
-export interface LineChartData {
+/**
+ * A series of values for a line chart, e.g., for a single currency.
+ */
+interface LineChartSeries {
   name: string;
   values: LineChartDatum[];
 }
 
-export interface LineChart {
-  type: "linechart";
-  data: LineChartData[];
-  tooltipText: (c: FormatterContext, d: LineChartDatum) => TooltipContent;
+/**
+ * A line or area chart.
+ *
+ * This consists of several series of points, e.g., a line for each currency
+ * in the balances of an account.
+ */
+export class LineChart {
+  readonly type = "linechart";
+
+  readonly series_names: string[];
+
+  constructor(
+    readonly name: string | null,
+    private readonly data: LineChartSeries[],
+    readonly tooltipText: (
+      c: FormatterContext,
+      d: LineChartDatum,
+    ) => TooltipContent,
+  ) {
+    this.data = sort(data, (d) => -d.values.length);
+    this.series_names = this.data.map((series) => series.name);
+  }
+
+  /** Filter the data of this chart, excluding some series. */
+  filter(hidden_names: string[]): LineChartSeries[] {
+    const hidden_names_set = new Set(hidden_names);
+    return this.data.filter((series) => !hidden_names_set.has(series.name));
+  }
 }
 
 const balances_validator = array(object({ date, balance: record(number) }));
 
-export function balances(json: unknown): Result<LineChart, string> {
+export function balances(
+  label: string | null,
+  json: unknown,
+): Result<LineChart, string> {
   return balances_validator(json).map((parsedData) => {
     const groups = new Map<string, LineChartDatum[]>();
     for (const { date: date_val, balance } of parsedData) {
@@ -44,13 +79,9 @@ export function balances(json: unknown): Result<LineChart, string> {
       values,
     }));
 
-    return {
-      type: "linechart",
-      data,
-      tooltipText: (c, d) => [
-        domHelpers.t(c.amount(d.value, d.name)),
-        domHelpers.em(day(d.date)),
-      ],
-    };
+    return new LineChart(label, data, (c, d) => [
+      domHelpers.t(c.amount(d.value, d.name)),
+      domHelpers.em(day(d.date)),
+    ]);
   });
 }

--- a/frontend/src/charts/query-charts.ts
+++ b/frontend/src/charts/query-charts.ts
@@ -5,14 +5,10 @@ import { stratify } from "../lib/tree";
 import { array, number, object, record, string } from "../lib/validation";
 
 import type { ChartContext } from "./context";
-import type {
-  AccountHierarchyDatum,
-  AccountHierarchyNode,
-  HierarchyChart,
-} from "./hierarchy";
+import type { AccountHierarchyDatum, AccountHierarchyNode } from "./hierarchy";
+import { HierarchyChart } from "./hierarchy";
+import type { LineChart } from "./line";
 import { balances } from "./line";
-
-import type { FavaChart } from "./index";
 
 const grouped_chart_validator = array(
   object({ group: string, balance: record(number) }),
@@ -42,7 +38,7 @@ export function parseGroupedQueryChart(
         }
       });
 
-      return { type: "hierarchy", data };
+      return new HierarchyChart(null, data);
     });
 }
 
@@ -53,11 +49,11 @@ export function parseGroupedQueryChart(
 export function parseQueryChart(
   json: unknown,
   ctx: ChartContext,
-): Result<FavaChart, string> {
+): Result<HierarchyChart | LineChart, string> {
   return (
     parseGroupedQueryChart(json, ctx)
       // Try balances chart if the grouped chart parse
-      .or_else(() => balances(json))
+      .or_else(() => balances(null, json))
       .map_err(() => "No query chart found.")
   );
 }

--- a/frontend/src/charts/scatterplot.ts
+++ b/frontend/src/charts/scatterplot.ts
@@ -7,18 +7,24 @@ export interface ScatterPlotDatum {
   description: string;
 }
 
-export interface ScatterPlot {
-  type: "scatterplot";
-  data: ScatterPlotDatum[];
+export class ScatterPlot {
+  readonly type = "scatterplot";
+
+  constructor(
+    readonly name: string | null,
+    readonly data: ScatterPlotDatum[],
+  ) {}
 }
 
 const scatterplot_validator = array(
   object({ type: string, date, description: string }),
 );
 
-export function scatterplot(json: unknown): Result<ScatterPlot, string> {
-  return scatterplot_validator(json).map((value) => ({
-    type: "scatterplot",
-    data: value,
-  }));
+export function scatterplot(
+  label: string | null,
+  json: unknown,
+): Result<ScatterPlot, string> {
+  return scatterplot_validator(json).map(
+    (value) => new ScatterPlot(label, value),
+  );
 }

--- a/frontend/src/reports/commodities/load.ts
+++ b/frontend/src/reports/commodities/load.ts
@@ -1,5 +1,6 @@
 import { get } from "../../api";
-import type { NamedFavaChart } from "../../charts";
+import type { FavaChart } from "../../charts";
+import { LineChart } from "../../charts/line";
 import { domHelpers } from "../../charts/tooltip";
 import { day } from "../../format";
 import { getURLFilters } from "../../stores/filters";
@@ -12,25 +13,18 @@ export const load = (
     quote: string;
     prices: [Date, number][];
   }[];
-  charts: NamedFavaChart[];
+  charts: FavaChart[];
 }> =>
   get("commodities", getURLFilters(url)).then((commodities) => {
-    const charts: NamedFavaChart[] = commodities.map(
-      ({ base, quote, prices }) => {
-        const name = `${base} / ${quote}`;
-        const values = prices.map((d) => ({ name, date: d[0], value: d[1] }));
+    const charts = commodities.map(({ base, quote, prices }) => {
+      const name = `${base} / ${quote}`;
+      const values = prices.map((d) => ({ name, date: d[0], value: d[1] }));
 
-        return {
-          name,
-          type: "linechart",
-          data: [{ name, values }],
-          tooltipText: (c, d) => [
-            domHelpers.t(`1 ${base} = ${c.amount(d.value, quote)}`),
-            domHelpers.em(day(d.date)),
-          ],
-        };
-      },
-    );
+      return new LineChart(name, [{ name, values }], (c, d) => [
+        domHelpers.t(`1 ${base} = ${c.amount(d.value, quote)}`),
+        domHelpers.em(day(d.date)),
+      ]);
+    });
     return { commodities, charts };
   });
 

--- a/frontend/src/reports/events/load.ts
+++ b/frontend/src/reports/events/load.ts
@@ -1,14 +1,15 @@
 import { group } from "d3-array";
 
 import { get } from "../../api";
-import type { NamedFavaChart } from "../../charts";
+import type { FavaChart } from "../../charts";
+import { ScatterPlot } from "../../charts/scatterplot";
 import { _, format } from "../../i18n";
 import { getURLFilters } from "../../stores/filters";
 
 export const load = (
   url: URL,
 ): Promise<{
-  charts: NamedFavaChart[];
+  charts: FavaChart[];
   groups: [
     string,
     {
@@ -21,14 +22,11 @@ export const load = (
   get("events", getURLFilters(url)).then((events) => {
     const groups = [...group(events, (e) => e.type)];
 
-    const charts: NamedFavaChart[] = [
-      { name: _("Events"), type: "scatterplot", data: events },
+    const charts = [
+      new ScatterPlot(_("Events"), events),
       ...groups.map(
-        ([type, data]): NamedFavaChart => ({
-          name: format(_("Event: %(type)s"), { type }),
-          type: "scatterplot",
-          data,
-        }),
+        ([type, data]) =>
+          new ScatterPlot(format(_("Event: %(type)s"), { type }), data),
       ),
     ];
 

--- a/frontend/src/stores/chart.ts
+++ b/frontend/src/stores/chart.ts
@@ -3,7 +3,7 @@ import { derived, writable } from "svelte/store";
 import { _, format } from "../i18n";
 import iso4217currencies from "../lib/iso4217";
 import { localStorageSyncedStore } from "../lib/store";
-import { constant, union } from "../lib/validation";
+import { array, constant, string, union } from "../lib/validation";
 
 import {
   conversion_currencies,
@@ -13,8 +13,11 @@ import {
 
 /** Whether the charts should be shown - this applies globally to all charts. */
 export const showCharts = writable(true);
+
 /** This store is used to switch to the same chart (as identified by name) on navigation. */
-export const lastActiveChartName = writable<string | undefined>(undefined);
+export const lastActiveChartName = writable<string | null>(null);
+
+/** The currently selected hierarchy chart mode. */
 export const hierarchyChartMode = localStorageSyncedStore<
   "treemap" | "sunburst"
 >(
@@ -22,16 +25,28 @@ export const hierarchyChartMode = localStorageSyncedStore<
   union(constant("treemap"), constant("sunburst")),
   () => "treemap",
 );
+
+/** The currently selected line chart mode. */
 export const lineChartMode = localStorageSyncedStore<"line" | "area">(
   "line-chart-mode",
   union(constant("line"), constant("area")),
   () => "line",
 );
+
+/** The currently selected bar chart mode. */
 export const barChartMode = localStorageSyncedStore<"stacked" | "single">(
   "bar-chart-mode",
   union(constant("stacked"), constant("single")),
   () => "stacked",
 );
+
+/** The currencies that are currently not shown in the bar and line charts. */
+export const chartToggledCurrencies = localStorageSyncedStore<string[]>(
+  "chart-toggled-currencies",
+  array(string),
+  () => [],
+);
+
 export const chartCurrency = writable("");
 
 const currencySuggestions = derived(

--- a/frontend/test/end-to-end-validation.test.ts
+++ b/frontend/test/end-to-end-validation.test.ts
@@ -7,7 +7,7 @@ import assert from "uvu/assert";
 import { getAPIValidators, ledgerDataValidator } from "../src/api/validators";
 import { parseJSON } from "../src/lib/json";
 
-function loadSnapshot(name: string): Promise<string> {
+export function loadSnapshot(name: string): Promise<string> {
   const path = join(__dirname, "..", "..", "tests", "__snapshots__", name);
   return readFile(path, "utf8");
 }

--- a/tests/__snapshots__/test_internal_api.py-test_chart_api
+++ b/tests/__snapshots__/test_internal_api.py-test_chart_api
@@ -1,0 +1,205 @@
+[
+  {
+    "data": {
+      "modifier": 1,
+      "root": {
+        "account": "Assets",
+        "balance": {},
+        "balance_children": {
+          "IRAUSD": 7200.00,
+          "USD": 94320.27840,
+          "VACHR": -82
+        },
+        "children": [
+          {
+            "account": "Assets:US",
+            "balance": {},
+            "balance_children": {
+              "IRAUSD": 7200.00,
+              "USD": 94220.27840,
+              "VACHR": -82
+            },
+            "children": [
+              {
+                "account": "Assets:US:Federal",
+                "balance": {},
+                "balance_children": {
+                  "IRAUSD": 7200.00
+                },
+                "children": [
+                  {
+                    "account": "Assets:US:Federal:PreTax401k",
+                    "balance": {
+                      "IRAUSD": 7200.00
+                    },
+                    "balance_children": {
+                      "IRAUSD": 7200.00
+                    },
+                    "children": []
+                  }
+                ]
+              },
+              {
+                "account": "Assets:US:BofA",
+                "balance": {},
+                "balance_children": {
+                  "USD": 1632.79
+                },
+                "children": [
+                  {
+                    "account": "Assets:US:BofA:Checking",
+                    "balance": {
+                      "USD": 1632.79
+                    },
+                    "balance_children": {
+                      "USD": 1632.79
+                    },
+                    "children": []
+                  }
+                ]
+              },
+              {
+                "account": "Assets:US:ETrade",
+                "balance": {},
+                "balance_children": {
+                  "USD": 23137.54
+                },
+                "children": [
+                  {
+                    "account": "Assets:US:ETrade:Cash",
+                    "balance": {
+                      "USD": 641.76
+                    },
+                    "balance_children": {
+                      "USD": 641.76
+                    },
+                    "children": []
+                  },
+                  {
+                    "account": "Assets:US:ETrade:ITOT",
+                    "balance": {
+                      "USD": 4972.52
+                    },
+                    "balance_children": {
+                      "USD": 4972.52
+                    },
+                    "children": []
+                  },
+                  {
+                    "account": "Assets:US:ETrade:VEA",
+                    "balance": {
+                      "USD": 7297.47
+                    },
+                    "balance_children": {
+                      "USD": 7297.47
+                    },
+                    "children": []
+                  },
+                  {
+                    "account": "Assets:US:ETrade:VHT",
+                    "balance": {
+                      "USD": 5325.81
+                    },
+                    "balance_children": {
+                      "USD": 5325.81
+                    },
+                    "children": []
+                  },
+                  {
+                    "account": "Assets:US:ETrade:GLD",
+                    "balance": {
+                      "USD": 4899.98
+                    },
+                    "balance_children": {
+                      "USD": 4899.98
+                    },
+                    "children": []
+                  }
+                ]
+              },
+              {
+                "account": "Assets:US:Vanguard",
+                "balance": {},
+                "balance_children": {
+                  "USD": 69449.94840
+                },
+                "children": [
+                  {
+                    "account": "Assets:US:Vanguard:VBMPX",
+                    "balance": {
+                      "USD": 27779.92083
+                    },
+                    "balance_children": {
+                      "USD": 27779.92083
+                    },
+                    "children": []
+                  },
+                  {
+                    "account": "Assets:US:Vanguard:RGAGX",
+                    "balance": {
+                      "USD": 41670.00757
+                    },
+                    "balance_children": {
+                      "USD": 41670.00757
+                    },
+                    "children": []
+                  },
+                  {
+                    "account": "Assets:US:Vanguard:Cash",
+                    "balance": {
+                      "USD": 0.02
+                    },
+                    "balance_children": {
+                      "USD": 0.02
+                    },
+                    "children": []
+                  }
+                ]
+              },
+              {
+                "account": "Assets:US:BayBook",
+                "balance": {},
+                "balance_children": {
+                  "VACHR": -82
+                },
+                "children": [
+                  {
+                    "account": "Assets:US:BayBook:Vacation",
+                    "balance": {
+                      "VACHR": -82
+                    },
+                    "balance_children": {
+                      "VACHR": -82
+                    },
+                    "children": []
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "account": "Assets:Testing",
+            "balance": {},
+            "balance_children": {
+              "USD": 100
+            },
+            "children": [
+              {
+                "account": "Assets:Testing:MultipleCommodities",
+                "balance": {
+                  "USD": 100
+                },
+                "balance_children": {
+                  "USD": 100
+                },
+                "children": []
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "label": "Assets",
+    "type": "hierarchy"
+  }
+]

--- a/tests/test_internal_api.py
+++ b/tests/test_internal_api.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from fava.core.charts import dumps
+from fava.internal_api import ChartApi
 from fava.internal_api import get_ledger_data
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -17,3 +18,10 @@ def test_get_ledger_data(app: Flask, snapshot: SnapshotFunc) -> None:
     with app.test_request_context("/long-example/"):
         app.preprocess_request()
         snapshot(dumps(get_ledger_data()))
+
+
+def test_chart_api(app: Flask, snapshot: SnapshotFunc) -> None:
+    """The serialisation and generation of charts works."""
+    with app.test_request_context("/long-example/"):
+        app.preprocess_request()
+        snapshot(dumps([ChartApi.hierarchy("Assets")]))


### PR DESCRIPTION
This allows hiding of currencies that are of no interest in the charts and makes it possible to toggle currencies that might operate on different scales.

Fix #1497