### PR TITLE
Fix editor error line number handling

### DIFF
--- a/frontend/src/codemirror/editor-transactions.ts
+++ b/frontend/src/codemirror/editor-transactions.ts
@@ -43,7 +43,7 @@ export function setErrors(
 ): TransactionSpec {
   const diagnostics = errors.map(({ source, message }): Diagnostic => {
     // Show errors without a line number on first line and ensure it is within the document.
-    const lineno = Math.max(Math.min(source?.lineno ?? 1, 1), state.doc.lines);
+    const lineno = Math.min(Math.max(source?.lineno ?? 1, 1), state.doc.lines);
     const line = state.doc.line(lineno);
     return {
       from: line.from,


### PR DESCRIPTION
This fixes a small bug in the logic to clamp an error's line number in the editor. Currently the line number gets forced to state.doc.lines because the min and max calls are flipped, so all errors show up at the end of the file.
