### PR TITLE
Add option to skip duplicates when exploring entries on import extract

### DIFF
--- a/frontend/src/reports/import/Extract.svelte
+++ b/frontend/src/reports/import/Extract.svelte
@@ -20,18 +20,11 @@
     currentIndex = 0;
   }
 
-  function submitOrNext() {
-    if (currentIndex < entries.length - 1) {
-      nextEntry();
-    } else {
-      save();
-    }
-  }
-
   function nextEntry() {
     if(skipDuplicates) {
-      for (let index = currentIndex+1; index < entries.length; index++) {
-        if (!isDuplicate(entries[index]!)) {
+      for (let index = currentIndex+1; index < entries.length; index+=1) {
+        const newEntry = entries[index];
+        if (newEntry !== undefined && !isDuplicate(newEntry)) {
           currentIndex = index;
           return;
         }
@@ -41,11 +34,20 @@
       currentIndex += 1;
     }
   }
+  
+  function submitOrNext() {
+    if (currentIndex < entries.length - 1) {
+      nextEntry();
+    } else {
+      save();
+    }
+  }
 
   function previousEntry() {
     if(skipDuplicates) {
-      for (let index = currentIndex-1; index >= 0; index--) {
-        if (!isDuplicate(entries[index]!)) {
+      for (let index = currentIndex-1; index >= 0; index-=1) {
+        const newEntry = entries[index];
+        if (newEntry !== undefined && !isDuplicate(newEntry)) {
           currentIndex = index;
           return;
         }

--- a/frontend/src/reports/import/Extract.svelte
+++ b/frontend/src/reports/import/Extract.svelte
@@ -29,12 +29,12 @@
           return;
         }
       }
-      currentIndex = entries.length;
+      currentIndex = entries.length-1;
     }else{
       currentIndex += 1;
     }
   }
-  
+
   function submitOrNext() {
     if (currentIndex < entries.length - 1) {
       nextEntry();

--- a/frontend/src/reports/import/Extract.svelte
+++ b/frontend/src/reports/import/Extract.svelte
@@ -14,6 +14,7 @@
   $: shown = entries.length > 0;
   $: entry = entries[currentIndex];
   $: duplicate = entry && isDuplicate(entry);
+  $: skipDuplicates = true;
   $: duplicates = entries.filter(isDuplicate).length;
   $: if (entries.length > 0 && currentIndex >= entries.length) {
     currentIndex = 0;
@@ -21,20 +22,47 @@
 
   function submitOrNext() {
     if (currentIndex < entries.length - 1) {
-      currentIndex += 1;
+      nextEntry();
     } else {
       save();
     }
   }
 
+  function nextEntry() {
+    if(skipDuplicates) {
+      for (let index = currentIndex+1; index < entries.length; index++) {
+        if (!isDuplicate(entries[index]!)) {
+          currentIndex = index;
+          return;
+        }
+      }
+      currentIndex = entries.length;
+    }else{
+      currentIndex += 1;
+    }
+  }
+
   function previousEntry() {
-    currentIndex = Math.max(currentIndex - 1, 0);
+    if(skipDuplicates) {
+      for (let index = currentIndex-1; index >= 0; index--) {
+        if (!isDuplicate(entries[index]!)) {
+          currentIndex = index;
+          return;
+        }
+      }
+      currentIndex = 0;
+    }else{
+      currentIndex = Math.max(currentIndex - 1, 0);
+    }
   }
 
   function toggleDuplicate() {
     if (entry) {
       entry.meta.__duplicate__ = !entry.meta.__duplicate__;
     }
+  }
+  function toggleSkipDuplicates() {
+    skipDuplicates = !skipDuplicates;
   }
 </script>
 
@@ -80,6 +108,14 @@
           </button>
         {/if}
         <span class="spacer" />
+          <label class="button muted">
+          <input
+            type="checkbox"
+            checked={skipDuplicates}
+            on:click={toggleSkipDuplicates}
+          />
+          skip duplicates
+        </label>
         {#if currentIndex < entries.length - 1}
           <button type="submit">{_("Next")}</button>
           <button

--- a/frontend/src/reports/import/Extract.svelte
+++ b/frontend/src/reports/import/Extract.svelte
@@ -14,25 +14,24 @@
   $: shown = entries.length > 0;
   $: entry = entries[currentIndex];
   $: duplicate = entry && isDuplicate(entry);
-  $: skipDuplicates = true;
   $: duplicates = entries.filter(isDuplicate).length;
   $: if (entries.length > 0 && currentIndex >= entries.length) {
     currentIndex = 0;
   }
 
-  function nextEntry() {
-    if(skipDuplicates) {
-      for (let index = currentIndex+1; index < entries.length; index+=1) {
-        const newEntry = entries[index];
-        if (newEntry !== undefined && !isDuplicate(newEntry)) {
-          currentIndex = index;
-          return;
-        }
+  function nextNonDuplicateEntry() {
+    for (let index = currentIndex+1; index < entries.length; index+=1) {
+      const newEntry = entries[index];
+      if (newEntry !== undefined && !isDuplicate(newEntry)) {
+        currentIndex = index;
+        return;
       }
-      currentIndex = entries.length-1;
-    }else{
-      currentIndex += 1;
     }
+    currentIndex = entries.length-1;
+  }
+
+  function nextEntry() {
+    currentIndex += 1;
   }
 
   function submitOrNext() {
@@ -43,28 +42,25 @@
     }
   }
 
-  function previousEntry() {
-    if(skipDuplicates) {
-      for (let index = currentIndex-1; index >= 0; index-=1) {
-        const newEntry = entries[index];
-        if (newEntry !== undefined && !isDuplicate(newEntry)) {
-          currentIndex = index;
-          return;
-        }
+  function previousNonDuplicateEntry() {
+    for (let index = currentIndex-1; index >= 0; index-=1) {
+      const newEntry = entries[index];
+      if (newEntry !== undefined && !isDuplicate(newEntry)) {
+        currentIndex = index;
+        return;
       }
-      currentIndex = 0;
-    }else{
-      currentIndex = Math.max(currentIndex - 1, 0);
     }
+    currentIndex = 0;
+  }
+
+  function previousEntry() {
+      currentIndex = Math.max(currentIndex - 1, 0);
   }
 
   function toggleDuplicate() {
     if (entry) {
       entry.meta.__duplicate__ = !entry.meta.__duplicate__;
     }
-  }
-  function toggleSkipDuplicates() {
-    skipDuplicates = !skipDuplicates;
   }
 </script>
 
@@ -105,21 +101,19 @@
           >
             ⏮
           </button>
-          <button type="button" class="muted" on:click={previousEntry}>
-            {_("Previous")}
+          <button type="button" class="muted" on:click={previousNonDuplicateEntry} title="{_('Previous non-duplicate entry')}">
+            &lt;&lt;
+          </button>
+          <button type="button" class="muted" on:click={previousEntry} title="_('Previous entry')">
+            &lt;
           </button>
         {/if}
         <span class="spacer" />
-          <label class="button muted">
-          <input
-            type="checkbox"
-            checked={skipDuplicates}
-            on:click={toggleSkipDuplicates}
-          />
-          skip duplicates
-        </label>
         {#if currentIndex < entries.length - 1}
-          <button type="submit">{_("Next")}</button>
+          <button type="submit" class="muted" title="{_('Next entry')}">&gt;</button>
+          <button type="button" class="muted" on:click={nextNonDuplicateEntry} title="{_('Next non-duplicate entry')}">
+            &gt;&gt;
+          </button>
           <button
             type="button"
             class="muted"


### PR DESCRIPTION
Hi! I use the Importer UI with some API-driven importers, for which the downloaded files are really only config files yet they read the full history from the origin bank APIs (like https://tariochbctools.readthedocs.io/en/latest/importers.html#nordigen).

Those output a big chunk of past entries, sometimes from multiple banks and not necessarily in chronological order. And, most of the time, a big percentage of those entries will be duplicated - in some importers the de-duplication is done by the importer against the bank's entry ID so I'm almost completely sure they are not false positives.

So I'm only interested (most of the time) on checking the non-duplicate entries, however in some cases (like combining multiple banks into a same importer, or reconciling a long tail of history) they will be 4-5 new/non-duplicate entries out of a list of >400 entries, in the middle of the list.

Browsing them and finding them with the next/back buttons is a bit awkward, so to make this easier, I've added a checkbox that will only make the prev/next buttons in the Extract window move only across the non-duplicate entries, which is enabled by default - which I think may be a more desired standard behavior?

It looks like this on the UI:

![image](https://github.com/beancount/fava/assets/863975/16605aec-067a-418f-9e41-992d6f6b4b8d)
The checkbox make the buttons go to the next and previous non-duplicate items - and if there's none left, they will just go to the first/last entry (to finalize the import, in the latter case).

I found this quite useful for my workflow but it may not fit everyone's usage or the project's alikes - happy to address any feedback or tweaks. :blush: 