### PR TITLE
tree table: restore v1.25 layout

### DIFF
--- a/frontend/src/reports/tree_reports/IncomeStatement.svelte
+++ b/frontend/src/reports/tree_reports/IncomeStatement.svelte
@@ -17,9 +17,14 @@
 {/if}
 
 <div class="row">
-  {#each trees as tree}
-    <div class="column">
+  <div class="column">
+    {#each trees.slice(0, 2) as tree}
       <TreeTable {tree} end={date_range?.end ?? null} />
-    </div>
-  {/each}
+    {/each}
+  </div>
+  <div class="column">
+    {#each trees.slice(2) as tree}
+      <TreeTable {tree} end={date_range?.end ?? null} />
+    {/each}
+  </div>
 </div>

--- a/frontend/src/stores/accounts.ts
+++ b/frontend/src/stores/accounts.ts
@@ -1,5 +1,7 @@
 import { derived } from "svelte/store";
 
+import { _ } from "../i18n";
+
 import { account_details, fava_options, options } from ".";
 
 /** Whether an account should be collapsed in the account trees. */
@@ -16,7 +18,8 @@ export const invert_account = derived(
       ? (name) =>
           name.startsWith($options.name_income) ||
           name.startsWith($options.name_liabilities) ||
-          name.startsWith($options.name_equity)
+          name.startsWith($options.name_equity) ||
+          name === _("Net Profit")
       : () => false,
 );
 

--- a/src/fava/json_api.py
+++ b/src/fava/json_api.py
@@ -492,8 +492,8 @@ def get_income_statement() -> TreeReport:
     root_tree = g.filtered.root_tree
     trees = [
         root_tree.get(options["name_income"]),
-        root_tree.get(options["name_expenses"]),
         root_tree.net_profit(options, gettext("Net Profit")),
+        root_tree.get(options["name_expenses"]),
     ]
 
     return TreeReport(

--- a/tests/__snapshots__/test_json_api.py-test_api-income_statement
+++ b/tests/__snapshots__/test_json_api.py-test_api-income_statement
@@ -2671,6 +2671,19 @@
       "has_txns": false
     },
     {
+      "account": "Net Profit",
+      "balance": {
+        "USD": -35857.24,
+        "VACHR": -130
+      },
+      "balance_children": {
+        "USD": -35857.24,
+        "VACHR": -130
+      },
+      "children": [],
+      "has_txns": true
+    },
+    {
       "account": "Expenses",
       "balance": {},
       "balance_children": {
@@ -3046,19 +3059,6 @@
         }
       ],
       "has_txns": false
-    },
-    {
-      "account": "Net Profit",
-      "balance": {
-        "USD": -35857.24,
-        "VACHR": -130
-      },
-      "balance_children": {
-        "USD": -35857.24,
-        "VACHR": -130
-      },
-      "children": [],
-      "has_txns": true
     }
   ]
 }


### PR DESCRIPTION
After upgrading to Fava 1.26 the layout of the Income Sheet changed, and all three columns are now in the same row, making them small:

### Fava v1.26
![fava1 26](https://github.com/beancount/fava/assets/538011/c4bdaa28-8699-4bf5-a62d-ebc0d553fa3e)

### Fava v1.25
![fava1 25](https://github.com/beancount/fava/assets/538011/d8b8d35d-a88d-4a0c-80ac-47afb4644b6e)

### With changes from this PR
Almost pixel-for-pixel identical to v1.25:
![pr](https://github.com/beancount/fava/assets/538011/f569adfe-773a-4b6d-8ba4-02ef139a97ea)

The sign of the Net Profit chart changed behavior, in v1.25 it was positive if income is greater than expenses and the `invert-income-liabilities-equity` option is set, but in v1.26 the sign is negative. This PR changes that, but it currently only works when the language is set to English. Should I create a `$options.name_net_profit` variable with the localized net profit? Alternatively, it could be flipped in the backend (`Tree.net_profit()` or `get_income_statement()`).