### PR TITLE
Add instruction to install Babel for development

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -12,11 +12,13 @@ system package manager):
 - `Node.js`_ - with `npm`, to install the Javascript dependencies,
 - `tox`_ - to run the Python tests,
 - `pre-commit`_ - to lint changes with a git pre-commit hook.
+- `Babel`_ - to compile translation files.
 
 .. _Python 3: https://www.python.org/
 .. _Node.js: https://nodejs.org/
 .. _tox: https://tox.wiki/en/latest/
 .. _pre-commit: https://pre-commit.com/
+.. _Babel: https://babel.pocoo.org/en/latest/index.html/
 
 Then this will get you up and running:
 


### PR DESCRIPTION
I was following the development guide and encounter the following error in the step running `make`. 

```
...
pybabel compile -d src/fava/translations
make: pybabel: No such file or directory
make: *** [src/fava/translations/bg/LC_MESSAGES/messages.mo] Error 1
```

Figured out I could avoid the error with Babel installed by `pip install Babel` first.

Thought it would make sense to add this extra information in the development guide, or please let me know if I should have this fixed elsewhere.
