### PR TITLE
for pages with exactly two graphs: fix graph cycling shortcuts

### DIFF
--- a/frontend/src/charts/ChartSwitcher.svelte
+++ b/frontend/src/charts/ChartSwitcher.svelte
@@ -15,20 +15,18 @@
     charts.find((c) => c.name === $lastActiveChartName) ?? charts?.[0];
 
   // Get the shortcut key for jumping to the previous chart.
-  $: shortcutBackward = (index: number): KeySpec | undefined => {
-    const current = charts.findIndex((e) => e === active_chart);
-    if (index === (current - 1 + charts.length) % charts.length) {
-      return { key: "C", note: _("Previous") };
-    }
-    return undefined;
+  $: shortcutPrevious = (index: number): KeySpec | undefined => {
+    const current = active_chart ? charts.indexOf(active_chart) : -1;
+    return index === (current - 1 + charts.length) % charts.length
+      ? { key: "C", note: _("Previous") }
+      : undefined;
   };
-  // Get the shortcut key for jumping to the previous chart.
-  $: shortcutForward = (index: number): KeySpec | undefined => {
-    const current = charts.findIndex((e) => e === active_chart);
-    if (index === (current + 1 + charts.length) % charts.length) {
-      return { key: "c", note: _("Next") };
-    }
-    return undefined;
+  // Get the shortcut key for jumping to the next chart.
+  $: shortcutNext = (index: number): KeySpec | undefined => {
+    const current = active_chart ? charts.indexOf(active_chart) : -1;
+    return index === (current + 1 + charts.length) % charts.length
+      ? { key: "c", note: _("Next") }
+      : undefined;
   };
 </script>
 
@@ -45,8 +43,8 @@
         on:click={() => {
           $lastActiveChartName = chart.name;
         }}
-        use:keyboardShortcut={shortcutBackward(index)}
-        use:keyboardShortcut={shortcutForward(index)}
+        use:keyboardShortcut={shortcutPrevious(index)}
+        use:keyboardShortcut={shortcutNext(index)}
       >
         {chart.name}
       </button>

--- a/frontend/src/charts/ChartSwitcher.svelte
+++ b/frontend/src/charts/ChartSwitcher.svelte
@@ -14,12 +14,17 @@
   $: active_chart =
     charts.find((c) => c.name === $lastActiveChartName) ?? charts?.[0];
 
-  // Get the shortcut key for jumping to the previous or next chart.
-  $: shortcut = (index: number): KeySpec | undefined => {
+  // Get the shortcut key for jumping to the previous chart.
+  $: shortcutBackward = (index: number): KeySpec | undefined => {
     const current = charts.findIndex((e) => e === active_chart);
     if (index === (current - 1 + charts.length) % charts.length) {
       return { key: "C", note: _("Previous") };
     }
+    return undefined;
+  };
+  // Get the shortcut key for jumping to the previous chart.
+  $: shortcutForward = (index: number): KeySpec | undefined => {
+    const current = charts.findIndex((e) => e === active_chart);
     if (index === (current + 1 + charts.length) % charts.length) {
       return { key: "c", note: _("Next") };
     }
@@ -40,7 +45,8 @@
         on:click={() => {
           $lastActiveChartName = chart.name;
         }}
-        use:keyboardShortcut={shortcut(index)}
+        use:keyboardShortcut={shortcutBackward(index)}
+        use:keyboardShortcut={shortcutForward(index)}
       >
         {chart.name}
       </button>


### PR DESCRIPTION
fixes #1677

When a page has exactly two graphs, the two shortcuts for cycling to the previous and next graph need to be bound to the same graph. This is one way to allow this.

However, only the last instance of use:keyboardShortcut will show up in the HTML attribute data-key. That’s why I have chosen this shortcutForward() to be the last of the two.

*There are several ways to do this, I have chosen one with minimal code changes. A larger approach might be to allow an array of KeySpecs in keyboardShortcut. I am not sure whether you use the HTML attribute `data-key` in any way. It is not incomplete with my approach.*


<!--
Hi, thank you for opening a PR!

Please ensure that your change passes tests and the various linters by running
`make test` and `make lint`. If testable, your changes should be covered by
unit tests.

Explain your changes below and link to related issues.
-->
