### PR TITLE
Fix the style issue of cost in journal table.

### DIFF
--- a/frontend/css/journal-table.css
+++ b/frontend/css/journal-table.css
@@ -117,7 +117,7 @@
 }
 
 .journal p > .num {
-  width: 9rem;
+  width: 14rem;
   border-left: 1px solid var(--table-border);
 }
 


### PR DESCRIPTION
Adjust the spacing between price and cost so that the date in the cost is not compressed to the point where it cannot be seen.

e.g., in the figure below
<img width="1881" alt="image" src="https://github.com/beancount/fava/assets/2995667/a465a440-bf5d-48f6-8817-1f15432ea85e">

This is followed by the effect of the adjustment
<img width="1846" alt="image" src="https://github.com/beancount/fava/assets/2995667/5805685a-1be6-421c-a6fe-1fcf3d0d47ed">



<!--
Hi, thank you for opening a PR!

Please ensure that your change passes tests and the various linters by running
`make test` and `make lint`. If testable, your changes should be covered by
unit tests.

Explain your changes below and link to related issues.
-->
