### PR TITLE
feat: update overriding mimetype (Python 3.12)

### DIFF
--- a/src/fava/application.py
+++ b/src/fava/application.py
@@ -93,11 +93,11 @@ CLIENT_SIDE_REPORTS = [
 ]
 
 
-if mimetypes.types_map.get(".js") != "application/javascript":
+if not mimetypes.types_map.get(".js", "").endswith("/javascript"):
     # This is sometimes broken on windows, see
     # https://github.com/beancount/fava/issues/1446
     logging.error("Invalid mimetype set for '.js', overriding")
-    mimetypes.add_type("application/javascript", ".js")
+    mimetypes.add_type("text/javascript", ".js")
 
 
 def _ledger_slugs_dict(ledgers: Iterable[FavaLedger]) -> dict[str, FavaLedger]:


### PR DESCRIPTION
- [x] (Python 3.12) hide error message: `Invalid mimetype set for '.js', overriding`
  - `mimetype` sometimes broken on windows: <https://github.com/beancount/fava/issues/1446>
  - use `text/javascript`: <https://github.com/python/cpython/issues/97646>
  ```console
  $ fava bcs/main.bc -p 5001
  Invalid mimetype set for '.js', overriding  # <- !
  Starting Fava on http://127.0.0.1:5001
  ```
