### PR TITLE
fix(cli): support relative `BEANCOUNT_FILE`

### DIFF
--- a/src/fava/cli.py
+++ b/src/fava/cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import errno
 import os
+from pathlib import Path
 
 import click
 from cheroot.wsgi import Server
@@ -83,10 +84,10 @@ def main(
     For example, `--host=0.0.0.0` is equivalent to setting the environment
     variable `FAVA_HOST=0.0.0.0`.
     """
-    env_filename = os.environ.get("BEANCOUNT_FILE")
-    all_filenames = (
-        filenames + tuple(env_filename.split()) if env_filename else filenames
+    env_filenames = tuple(
+        Path(x).resolve() for x in os.environ.get("BEANCOUNT_FILE", "").split()
     )
+    all_filenames = filenames + env_filenames if env_filenames else filenames
 
     if not all_filenames:
         raise click.UsageError("No file specified")


### PR DESCRIPTION
Support relative path string like `bcs/main.bc` and pass it thru `BEANCOUNT_FILE`.
```console
$ BEANCOUNT_FILE=bcs/main.bc fava -p 5001
Invalid mimetype set for '.js', overriding
Starting Fava on http://127.0.0.1:5001
Exception on / [GET]
Traceback (most recent call last):
  File "./.venv/lib/python3.12/site-packages/flask/app.py", line 1455, in wsgi_app
    response = self.full_dispatch_request()
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "./.venv/lib/python3.12/site-packages/flask/app.py", line 869, in full_dispatch_request
    rv = self.handle_user_exception(e)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "./.venv/lib/python3.12/site-packages/flask/app.py", line 865, in full_dispatch_request
    rv = self.preprocess_request()
         ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "./.venv/lib/python3.12/site-packages/flask/app.py", line 1234, in preprocess_request
    url_func(request.endpoint, request.view_args)
  File "./.venv/lib/python3.12/site-packages/fava/application.py", line 233, in _pull_beancount_file
    fava_app.config["LEDGERS"] = _ledger_slugs_dict(
                                 ^^^^^^^^^^^^^^^^^^^
  File "./.venv/lib/python3.12/site-packages/fava/application.py", line 106, in _ledger_slugs_dict
    for ledger in ledgers:
  File "./.venv/lib/python3.12/site-packages/fava/application.py", line 234, in <genexpr>
    FavaLedger(filepath)
  File "./.venv/lib/python3.12/site-packages/fava/core/__init__.py", line 272, in __init__
    self.load_file()
  File "./.venv/lib/python3.12/site-packages/fava/core/__init__.py", line 279, in load_file
    self.all_entries, self.errors, self.options = _load(
                                                  ^^^^^^
  File "./.venv/lib/python3.12/site-packages/beancount/loader.py", line 501, in _load
    entries, parse_errors, options_map = _parse_recursive(
                                         ^^^^^^^^^^^^^^^^^
  File "./.venv/lib/python3.12/site-packages/beancount/loader.py", line 371, in _parse_recursive
    assert path.isabs(source)
AssertionError
```
