### PR TITLE
editor: improve parser and mapping between tree-sitter and Lezer

### DIFF
--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -67,13 +67,13 @@
 
   /* Editor */
   --editor-comment: #998;
-  --editor-trailing-whitespace: rgb(255 199 199 / 50%);
   --editor-directive: #333;
   --editor-class: #b84;
   --editor-date: #099;
   --editor-constant: #008080;
   --editor-account: var(--link-color);
   --editor-invalid: #333;
+  --editor-invalid-background: rgb(255 199 199 / 50%);
   --editor-activeline: #ffc;
 
   /* Misc */

--- a/frontend/src/codemirror/beancount-highlight.ts
+++ b/frontend/src/codemirror/beancount-highlight.ts
@@ -46,10 +46,6 @@ export const beancountHighlight = HighlightStyle.define([
     // Invalid token
     tag: tags.invalid,
     color: "var(--editor-invalid)",
-  },
-  {
-    // Trailing whitespace
-    tag: tags.special(tags.invalid),
-    backgroundColor: "var(--editor-trailing-whitespace)",
+    backgroundColor: "var(--editor-invalid-background)",
   },
 ]);

--- a/frontend/src/codemirror/beancount.ts
+++ b/frontend/src/codemirror/beancount.ts
@@ -5,7 +5,7 @@ import {
   LanguageSupport,
   syntaxHighlighting,
 } from "@codemirror/language";
-import { keymap } from "@codemirror/view";
+import { highlightTrailingWhitespace, keymap } from "@codemirror/view";
 import { styleTags, tags } from "@lezer/highlight";
 import TSParser from "web-tree-sitter";
 import ts_wasm from "web-tree-sitter/tree-sitter.wasm";
@@ -41,6 +41,7 @@ const beancountLanguageSupportExtensions = [
     commentTokens: { line: ";" },
     indentOnInput: /^\s+\d\d\d\d/,
   }),
+  highlightTrailingWhitespace(),
 ];
 
 /** The node props that allow for highlighting/coloring of the code. */

--- a/frontend/src/codemirror/editor-transactions.ts
+++ b/frontend/src/codemirror/editor-transactions.ts
@@ -27,6 +27,9 @@ export function scrollToLine(
   state: EditorState,
   line: number,
 ): TransactionSpec {
+  if (line < 1 || line > state.doc.lines) {
+    return {};
+  }
   const linePos = state.doc.line(line);
   return {
     selection: { ...linePos, anchor: linePos.from },
@@ -41,10 +44,11 @@ export function setErrors(
   state: EditorState,
   errors: BeancountError[],
 ): TransactionSpec {
+  const { doc } = state;
   const diagnostics = errors.map(({ source, message }): Diagnostic => {
     // Show errors without a line number on first line and ensure it is within the document.
-    const lineno = Math.min(Math.max(source?.lineno ?? 1, 1), state.doc.lines);
-    const line = state.doc.line(lineno);
+    const lineno = Math.min(Math.max(source?.lineno ?? 1, 1), doc.lines);
+    const line = doc.line(lineno);
     return {
       from: line.from,
       to: line.to,

--- a/frontend/src/lib/array.ts
+++ b/frontend/src/lib/array.ts
@@ -1,7 +1,14 @@
 /** A type for an array with at least one element. */
-export type NonEmptyArray<T> = [T, ...T[]];
+export type NonEmptyArray<T> = readonly [T, ...T[]];
 
 /** Type guard for non-empty array. */
-export function is_non_empty<T>(array: T[]): array is NonEmptyArray<T> {
+export function is_non_empty<T>(
+  array: readonly T[],
+): array is NonEmptyArray<T> {
   return array.length > 0;
+}
+
+/** Get the last element of an non-empty array. */
+export function last_element<T>(array: NonEmptyArray<T>): T {
+  return array[array.length - 1] as T;
 }

--- a/frontend/src/log.ts
+++ b/frontend/src/log.ts
@@ -2,9 +2,22 @@
  * Log various errors
  *
  * In the future, this might turn into a noop for production builds.
- * @param error
  */
 export function log_error(...args: unknown[]): void {
   // eslint-disable-next-line no-console
   console.error(...args);
+}
+
+/**
+ * Assert some condition.
+ *
+ * In the future, this might turn into a noop for production builds.
+ */
+export function assert(
+  condition: boolean,
+  message: string,
+  ...extraArgs: unknown[]
+): void {
+  // eslint-disable-next-line no-console
+  console.assert(condition, message, ...extraArgs);
 }

--- a/frontend/test/editor.test.ts
+++ b/frontend/test/editor.test.ts
@@ -1,0 +1,85 @@
+import { setDiagnosticsEffect } from "@codemirror/lint";
+import { EditorState } from "@codemirror/state";
+import { test } from "uvu";
+import assert from "uvu/assert";
+
+import {
+  replaceContents,
+  scrollToLine,
+  setErrors,
+} from "../src/codemirror/editor-transactions";
+
+test("replace editor contents", () => {
+  const state = EditorState.create({ doc: "test\n" });
+  assert.equal(state.sliceDoc(), "test\n");
+  const transaction = state.update(replaceContents(state, "asdfasdf\n"));
+  assert.equal(transaction.docChanged, true);
+  assert.equal(transaction.state.sliceDoc(), "asdfasdf\n");
+});
+
+test("scroll to line", () => {
+  const state = EditorState.create({ doc: "test\ntest\ntest\n" });
+
+  const second_line = state.update(scrollToLine(state, 2));
+  assert.equal(second_line.docChanged, false);
+  assert.ok(second_line.selection);
+  assert.equal(second_line.state.selection.main.from, 5);
+
+  const last_line = state.update(scrollToLine(state, state.doc.lines));
+  assert.equal(last_line.docChanged, false);
+  assert.ok(last_line.selection);
+  assert.equal(last_line.state.selection.main.from, 15);
+
+  const after_end = state.update(scrollToLine(state, state.doc.lines + 1));
+  assert.equal(after_end.docChanged, false);
+  assert.equal(after_end.selection, undefined);
+
+  const line_zero = state.update(scrollToLine(state, 0));
+  assert.equal(line_zero.docChanged, false);
+  assert.equal(line_zero.selection, undefined);
+});
+
+test("set errors", () => {
+  const state = EditorState.create({ doc: "test\ntest\ntest\n" });
+
+  const transaction = state.update(
+    setErrors(state, [
+      { type: "type", message: "first error", source: null },
+      {
+        type: "type",
+        message: "second error",
+        source: { lineno: 100, filename: "asdf" },
+      },
+      {
+        type: "type",
+        message: "third error",
+        source: { lineno: 2, filename: "asdf" },
+      },
+    ]),
+  );
+  const effect = transaction.effects[0];
+  assert.ok(effect);
+  assert.ok(effect.is(setDiagnosticsEffect));
+  assert.equal(effect.value, [
+    {
+      from: 0,
+      to: 4,
+      severity: "error",
+      message: "first error",
+    },
+    {
+      from: 15,
+      to: 15,
+      severity: "error",
+      message: "second error",
+    },
+    {
+      from: 5,
+      to: 9,
+      severity: "error",
+      message: "third error",
+    },
+  ]);
+});
+
+test.run();

--- a/frontend/test/parser.test.ts
+++ b/frontend/test/parser.test.ts
@@ -1,10 +1,16 @@
 import { join } from "path";
 
+import type { Tree } from "@lezer/common";
+import { TreeFragment } from "@lezer/common";
 import { test } from "uvu";
 import assert from "uvu/assert";
 import TSParser from "web-tree-sitter";
 
-import { LezerTSParser } from "../src/codemirror/tree-sitter-parser";
+import {
+  input_edit_for_fragments,
+  LezerTSParser,
+} from "../src/codemirror/tree-sitter-parser";
+import { is_non_empty } from "../src/lib/array";
 
 async function load(): Promise<TSParser> {
   await TSParser.init();
@@ -20,16 +26,101 @@ async function load(): Promise<TSParser> {
   parser.setLanguage(lang);
   return parser;
 }
+// eslint-disable-next-line @typescript-eslint/no-base-to-string
+const tree_string = (t: Tree) => t.toString();
+
+test("deduce an deletion at the end", () => {
+  const edit = input_edit_for_fragments(
+    [new TreeFragment(0, 315, { length: 733 } as Tree, 0, false, true)],
+    315,
+  );
+  assert.ok(edit);
+  assert.equal(edit.startIndex, 314);
+  assert.equal(edit.oldEndIndex, 733);
+  assert.equal(edit.newEndIndex, 315);
+});
+
+test("deduce an deletion at the start", () => {
+  const edit = input_edit_for_fragments(
+    [new TreeFragment(0, 418, { length: 733 } as Tree, 315, true, false)],
+    315,
+  );
+  assert.ok(edit);
+  assert.equal(edit.startIndex, 0);
+  assert.equal(edit.oldEndIndex, 316);
+  assert.equal(edit.newEndIndex, 1);
+});
+
+test("deduce a deletion in the middle", () => {
+  const tree = { length: 733 } as Tree;
+  const edit = input_edit_for_fragments(
+    [
+      new TreeFragment(0, 164, tree, 0, false, true),
+      new TreeFragment(164, 422, tree, 311, true, false),
+    ],
+    422,
+  );
+  assert.ok(edit);
+  assert.equal(edit.startIndex, 163);
+  assert.equal(edit.oldEndIndex, 476);
+  assert.equal(edit.newEndIndex, 165);
+});
+
+test("deduce an insertion in the middle", () => {
+  const tree = { length: 422 } as Tree;
+  const edit = input_edit_for_fragments(
+    [
+      new TreeFragment(0, 164, tree, 0, false, true),
+      new TreeFragment(475, 733, tree, -311, true, false),
+    ],
+    733,
+  );
+  assert.ok(edit);
+  assert.equal(edit.startIndex, 163);
+  assert.equal(edit.oldEndIndex, 165);
+  assert.equal(edit.newEndIndex, 476);
+});
+
+test("parse that reuses a single fragment", async () => {
+  const ts_parser = await load();
+  const parser = new LezerTSParser(ts_parser, [], "beancount_file");
+  const line = "2012-12-12 price USD 1 EUR\n";
+  const tree = parser.parse(line + line);
+  assert.equal(tree.length, line.length * 2);
+  assert.snapshot(
+    tree_string(tree),
+    "beancount_file(price(date,PRICE,currency,amount(number,currency)),price(date,PRICE,currency,amount(number,currency)))",
+  );
+  let fragments = TreeFragment.addTree(tree);
+  fragments = TreeFragment.applyChanges(fragments, [
+    { fromA: 0, toA: line.length, fromB: 0, toB: 0 },
+  ]);
+  assert.equal(fragments.length, 1);
+  assert.ok(is_non_empty(fragments));
+  const edit = input_edit_for_fragments(fragments, line.length);
+  assert.equal(edit?.startIndex, 0);
+  assert.equal(edit?.oldEndIndex, line.length + 1);
+  assert.equal(edit?.newEndIndex, 1);
+  const new_tree = parser.parse(line, fragments);
+  assert.snapshot(
+    tree_string(new_tree),
+    "beancount_file(price(date,PRICE,currency,amount(number,currency)))",
+  );
+});
 
 test("parse a single price directive", async () => {
   const ts_parser = await load();
   const parser = new LezerTSParser(ts_parser, [], "beancount_file");
-  const tree = parser.parse("2012-12-12 price USD 1 EUR\n");
+  const line = "2012-12-12 price USD 1 EUR\n";
+  const tree = parser.parse(line);
   assert.snapshot(
-    // eslint-disable-next-line @typescript-eslint/no-base-to-string
-    tree.toString(),
+    tree_string(tree),
     "beancount_file(price(date,PRICE,currency,amount(number,currency)))",
   );
+
+  const partial_parse = parser.startParse(line);
+  // Advance directly returns the tree.
+  assert.ok(partial_parse.advance());
 });
 
 test.run();


### PR DESCRIPTION
With this change we reuse the previous parse trees in more cases to
improve performance and also tighten up the handling of some incorrect
states.

Also, re-add highlighting of trailing whitespace and add red background
to parse errors.

<!--
Hi, thank you for opening a PR!

Please ensure that your change passes tests and the various linters by running
`make test` and `make lint`. If testable, your changes should be covered by
unit tests.

Explain your changes below and link to related issues.
-->
