### PR TITLE
prettier: ensure svelte files are formatted

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,16 +6,16 @@ root = true
 [*]
 charset = utf-8
 end_of_line = lf
-indent_size = 4
-indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
+
+[*.py]
+indent_style = space
+indent_size = 4
 
 [Makefile]
 indent_style = tab
 
-[*.md]
-trim_trailing_whitespace = false
-
-[*.{js,json,ts,css,html,svelte}]
+[*.{ts,json,css,html,svelte}]
+indent_style = space
 indent_size = 2

--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -1,44 +1,44 @@
 name: Deploy website to GitHub Pages
 
 on:
-    workflow_dispatch:
-    push:
-        branches:
-            - main
-    pull_request:
-        branches:
-            - main
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
-    build:
-        runs-on: "ubuntu-latest"
-        steps:
-            - uses: actions/checkout@v4
-            - uses: actions/setup-python@v5
-              with:
-                  python-version: "3.12"
-                  cache: "pip"
-                  cache-dependency-path: "constraints*.txt"
-            - run: python -m pip install -c constraints.txt tox
-            - run: tox -e docs
-            - if: github.repository == 'beancount/fava'
-              uses: actions/configure-pages@v4
-            - uses: actions/upload-pages-artifact@v3
-              with:
-                  path: "build/docs"
-    deploy:
-        if: github.repository == 'beancount/fava' && github.event_name == 'push'
-        needs: "build"
-        permissions:
-            pages: write
-            id-token: write
-        concurrency:
-            group: "pages"
-            cancel-in-progress: false
-        environment:
-            name: github-pages
-            url: ${{ steps.deployment.outputs.page_url }}
-        runs-on: "ubuntu-latest"
-        steps:
-            - id: deployment
-              uses: actions/deploy-pages@v4
+  build:
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+          cache-dependency-path: "constraints*.txt"
+      - run: python -m pip install -c constraints.txt tox
+      - run: tox -e docs
+      - if: github.repository == 'beancount/fava'
+        uses: actions/configure-pages@v4
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: "build/docs"
+  deploy:
+    if: github.repository == 'beancount/fava' && github.event_name == 'push'
+    needs: "build"
+    permissions:
+      pages: write
+      id-token: write
+    concurrency:
+      group: "pages"
+      cancel-in-progress: false
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: "ubuntu-latest"
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,39 +1,39 @@
 name: Build Python package (and upload to PyPI on tags)
 
 on:
-    workflow_dispatch:
-    push:
-        branches:
-            - main
-        tags:
-            - "v*"
-    pull_request:
-        branches:
-            - main
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    tags:
+      - "v*"
+  pull_request:
+    branches:
+      - main
 
 jobs:
-    build-and-publish:
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v4
-              with:
-                  fetch-depth: 0
-            - uses: actions/setup-python@v5
-              with:
-                  python-version: "3.12"
-                  cache: "pip"
-                  cache-dependency-path: "constraints*.txt"
-            - uses: actions/setup-node@v4
-              with:
-                  node-version: "lts/*"
-                  cache: "npm"
-                  cache-dependency-path: frontend/package-lock.json
-            - run: python -m pip install -c constraints.txt build twine
-            - run: python -m build
-            - run: twine check dist/*
-            - name: Publish release
-              if: github.event_name == 'push' && github.ref_type == 'tag'
-              env:
-                  TWINE_USERNAME: __token__
-                  TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
-              run: python -m twine upload dist/*
+  build-and-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+          cache-dependency-path: "constraints*.txt"
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "lts/*"
+          cache: "npm"
+          cache-dependency-path: frontend/package-lock.json
+      - run: python -m pip install -c constraints.txt build twine
+      - run: python -m build
+      - run: twine check dist/*
+      - name: Publish release
+        if: github.event_name == 'push' && github.ref_type == 'tag'
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+        run: python -m twine upload dist/*

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,90 +1,90 @@
 name: Test
 
 on:
-    workflow_dispatch:
-    push:
-        branches:
-            - main
-    pull_request:
-        branches:
-            - main
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
-    test-py:
-        runs-on: ${{ matrix.os }}
-        strategy:
-            matrix:
-                os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-                py: ["3.12", "3.8"]
-                toxenv: ["py", "old_deps"]
-                exclude:
-                    - os: "macos-latest"
-                      toxenv: "old_deps"
-                    - os: "windows-latest"
-                      toxenv: "old_deps"
-        steps:
-            - uses: actions/checkout@v4
-            - uses: actions/setup-python@v5
-              with:
-                  python-version: ${{ matrix.py }}
-                  cache: "pip"
-                  cache-dependency-path: "constraints*.txt"
-            - run: python -m pip install -c constraints.txt tox
-            - run: touch src/fava/static/app.js
-            - run: tox -e ${{ matrix.toxenv }}
-    test-js:
-        runs-on: ${{ matrix.os }}
-        strategy:
-            matrix:
-                os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        steps:
-            - uses: actions/checkout@v4
-            - uses: actions/setup-node@v4
-              with:
-                  node-version: "lts/*"
-                  cache: "npm"
-                  cache-dependency-path: frontend/package-lock.json
-            - run: cd frontend && npm ci
-            - run: cd frontend && npm run build
-            - run: cd frontend && npm test
-    lint-js:
-        runs-on: "ubuntu-latest"
-        steps:
-            - uses: actions/checkout@v4
-            - uses: actions/setup-python@v5
-              with:
-                  python-version: "3.12"
-                  cache: "pip"
-                  cache-dependency-path: "constraints*.txt"
-            - uses: actions/setup-node@v4
-              with:
-                  node-version: "lts/*"
-                  cache: "npm"
-                  cache-dependency-path: frontend/package-lock.json
-            - run: python -m pip install -c constraints.txt pre-commit
-            - run: cd frontend && npm ci
-            - run: pre-commit run -a eslint
-            - run: cd frontend; npx tsc
-            - run: cd frontend; npx svelte-check
-    lint-python:
-        runs-on: "ubuntu-latest"
-        steps:
-            - uses: actions/checkout@v4
-            - uses: actions/setup-python@v5
-              with:
-                  python-version: "3.12"
-                  cache: "pip"
-                  cache-dependency-path: "constraints*.txt"
-            - run: python -m pip install -c constraints.txt tox
-            - run: tox -e lint
-    build-pyinstaller:
-        runs-on: "ubuntu-latest"
-        steps:
-            - uses: actions/checkout@v4
-            - uses: actions/setup-python@v5
-              with:
-                  python-version: "3.12"
-                  cache: "pip"
-                  cache-dependency-path: "constraints*.txt"
-            - run: python -m pip install -c constraints.txt tox
-            - run: tox -e pyinstaller
+  test-py:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        py: ["3.12", "3.8"]
+        toxenv: ["py", "old_deps"]
+        exclude:
+          - os: "macos-latest"
+            toxenv: "old_deps"
+          - os: "windows-latest"
+            toxenv: "old_deps"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.py }}
+          cache: "pip"
+          cache-dependency-path: "constraints*.txt"
+      - run: python -m pip install -c constraints.txt tox
+      - run: touch src/fava/static/app.js
+      - run: tox -e ${{ matrix.toxenv }}
+  test-js:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "lts/*"
+          cache: "npm"
+          cache-dependency-path: frontend/package-lock.json
+      - run: cd frontend && npm ci
+      - run: cd frontend && npm run build
+      - run: cd frontend && npm test
+  lint-js:
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+          cache-dependency-path: "constraints*.txt"
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "lts/*"
+          cache: "npm"
+          cache-dependency-path: frontend/package-lock.json
+      - run: python -m pip install -c constraints.txt pre-commit
+      - run: cd frontend && npm ci
+      - run: pre-commit run -a eslint
+      - run: cd frontend; npx tsc
+      - run: cd frontend; npx svelte-check
+  lint-python:
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+          cache-dependency-path: "constraints*.txt"
+      - run: python -m pip install -c constraints.txt tox
+      - run: tox -e lint
+  build-pyinstaller:
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+          cache-dependency-path: "constraints*.txt"
+      - run: python -m pip install -c constraints.txt tox
+      - run: tox -e pyinstaller

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,39 +1,39 @@
 ci:
-    skip: ["eslint"]
+  skip: ["eslint"]
 repos:
-    - repo: https://github.com/psf/black
-      rev: 23.12.1
-      hooks:
-          - id: black
-    - repo: https://github.com/astral-sh/ruff-pre-commit
-      rev: v0.1.9
-      hooks:
-          - id: ruff
-    - repo: local
-      hooks:
-          - id: prettier
-            name: prettier
-            language: node
-            entry: prettier --write --list-different --ignore-unknown
-            require_serial: true
-            additional_dependencies:
-                - "prettier@3.1.1"
-                - "prettier-plugin-svelte@3.1.2"
-                - "svelte@4.2.8"
-          - id: stylelint
-            name: stylelint
-            language: node
-            entry: stylelint --fix
-            files: \.(css|svelte)$
-            require_serial: true
-            additional_dependencies:
-                - "stylelint@16.1.0"
-                - "stylelint-config-recess-order@4.4.0"
-                - "stylelint-config-standard@36.0.0"
-                - "postcss-html@1.5.0"
-          - id: eslint
-            name: eslint
-            language: node
-            entry: ./frontend/node_modules/eslint/bin/eslint.js --max-warnings 0
-            require_serial: true
-            files: frontend/.*\.(js|ts|svelte)$
+  - repo: https://github.com/psf/black
+    rev: 23.12.1
+    hooks:
+      - id: black
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.1.9
+    hooks:
+      - id: ruff
+  - repo: local
+    hooks:
+      - id: prettier
+        name: prettier
+        language: node
+        entry: prettier --write --list-different --ignore-unknown
+        require_serial: true
+        additional_dependencies:
+          - "prettier@3.1.1"
+          - "prettier-plugin-svelte@3.1.2"
+          - "svelte@4.2.8"
+      - id: stylelint
+        name: stylelint
+        language: node
+        entry: stylelint --fix
+        files: \.(css|svelte)$
+        require_serial: true
+        additional_dependencies:
+          - "stylelint@16.1.0"
+          - "stylelint-config-recess-order@4.4.0"
+          - "stylelint-config-standard@36.0.0"
+          - "postcss-html@1.5.0"
+      - id: eslint
+        name: eslint
+        language: node
+        entry: ./frontend/node_modules/eslint/bin/eslint.js --max-warnings 0
+        require_serial: true
+        files: frontend/.*\.(js|ts|svelte)$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.9
+    rev: v0.1.11
     hooks:
       - id: ruff
   - repo: local

--- a/constraints.txt
+++ b/constraints.txt
@@ -82,9 +82,9 @@ furo==2023.9.10
     # via fava (pyproject.toml)
 google-api-core==2.15.0
     # via google-api-python-client
-google-api-python-client==2.111.0
+google-api-python-client==2.112.0
     # via beancount
-google-auth==2.25.2
+google-auth==2.26.1
     # via
     #   google-api-core
     #   google-api-python-client
@@ -133,7 +133,7 @@ lml==0.1.0
     # via
     #   pyexcel
     #   pyexcel-io
-lxml==5.0.0
+lxml==5.0.1
     # via
     #   beancount
     #   pyexcel-ezodf
@@ -169,6 +169,7 @@ packaging==23.2
     # via
     #   build
     #   pyinstaller
+    #   pyinstaller-hooks-contrib
     #   pyproject-api
     #   pytest
     #   sphinx
@@ -225,7 +226,7 @@ pygments==2.17.2
     #   sphinx
 pyinstaller==6.3.0
     # via fava (pyproject.toml)
-pyinstaller-hooks-contrib==2023.11
+pyinstaller-hooks-contrib==2023.12
     # via pyinstaller
 pylint==3.0.3
     # via fava (pyproject.toml)
@@ -235,7 +236,7 @@ pyproject-api==1.6.1
     # via tox
 pyproject-hooks==1.0.0
     # via build
-pytest==7.4.3
+pytest==7.4.4
     # via
     #   beancount
     #   fava (pyproject.toml)
@@ -314,7 +315,7 @@ tox==4.11.4
     # via fava (pyproject.toml)
 twine==4.0.2
     # via fava (pyproject.toml)
-types-setuptools==69.0.0.0
+types-setuptools==69.0.0.20240106
     # via fava (pyproject.toml)
 types-simplejson==3.19.0.2
     # via fava (pyproject.toml)

--- a/contrib/pythonanywhere/README.md
+++ b/contrib/pythonanywhere/README.md
@@ -1,11 +1,11 @@
 Fava has two example pages hosted on
 [pythonanywhere.com](https://pythonanywhere.com):
 
--   [fava.pythonanywhere.com](https://fava.pythonanywhere.com), which runs the
-    latest released version.
--   [favadev.pythonanywhere.com](https://favadev.pythonanywhere.com), which
-    tracks the HEAD of the GitHub repo
-    ([github.com/beancount/fava](https://github.com/beancount/fava))
+- [fava.pythonanywhere.com](https://fava.pythonanywhere.com), which runs the
+  latest released version.
+- [favadev.pythonanywhere.com](https://favadev.pythonanywhere.com), which tracks
+  the HEAD of the GitHub repo
+  ([github.com/beancount/fava](https://github.com/beancount/fava))
 
 There are four parts to both instances:
 

--- a/frontend/.prettierrc.cjs
+++ b/frontend/.prettierrc.cjs
@@ -1,0 +1,8 @@
+// @ts-check
+/** @type {import("prettier").Options} */
+const config = {
+  plugins: [require.resolve("prettier-plugin-svelte")],
+  proseWrap: "always",
+};
+
+module.exports = config;

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -51,7 +51,7 @@
         "@types/node": "^20.2.5",
         "@typescript-eslint/eslint-plugin": "^6.0.0",
         "@typescript-eslint/parser": "^6.0.0",
-        "c8": "^8.0.1",
+        "c8": "^9.0.0",
         "chokidar": "^3.5.1",
         "esbuild": "^0.19.0",
         "esbuild-register": "^3.0.0",
@@ -365,9 +365,9 @@
       }
     },
     "node_modules/@csstools/css-parser-algorithms": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-2.4.0.tgz",
-      "integrity": "sha512-/PPLr2g5PAUCKAPEbfyk6/baZA+WJHQtUhPkoCQMpyRE8I0lXrG1QFRN8e5s3ZYxM8d/g5BZc6lH3s8Op7/VEg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-2.5.0.tgz",
+      "integrity": "sha512-abypo6m9re3clXA00eu5syw+oaPHbJTPapu9C4pzNsJ4hdZDzushT50Zhu+iIYXgEe1CxnRMn7ngsbV+MLrlpQ==",
       "dev": true,
       "funding": [
         {
@@ -383,13 +383,13 @@
         "node": "^14 || ^16 || >=18"
       },
       "peerDependencies": {
-        "@csstools/css-tokenizer": "^2.2.2"
+        "@csstools/css-tokenizer": "^2.2.3"
       }
     },
     "node_modules/@csstools/css-tokenizer": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-2.2.2.tgz",
-      "integrity": "sha512-wCDUe/MAw7npAHFLyW3QjSyLA66S5QFaV1jIXlNQvdJ8RzXDSgALa49eWcUO6P55ARQaz0TsDdAgdRgkXFYY8g==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-2.2.3.tgz",
+      "integrity": "sha512-pp//EvZ9dUmGuGtG1p+n17gTHEOqu9jO+FiCUjNN3BDmyhdA2Jq9QsVeR7K8/2QCK17HSsioPlTW9ZkzoWb3Lg==",
       "dev": true,
       "funding": [
         {
@@ -406,9 +406,9 @@
       }
     },
     "node_modules/@csstools/media-query-list-parser": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-2.1.6.tgz",
-      "integrity": "sha512-R6AKl9vaU0It7D7TR2lQn0pre5aQfdeqHRePlaRCY8rHL3l9eVlNRpsEVDKFi/zAjzv68CxH2M5kqbhPFPKjvw==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-2.1.7.tgz",
+      "integrity": "sha512-lHPKJDkPUECsyAvD60joYfDmp8UERYxHGkFfyLJFTVK/ERJe0sVlIFLXU5XFxdjNDTerp5L4KeaKG+Z5S94qxQ==",
       "dev": true,
       "funding": [
         {
@@ -424,8 +424,8 @@
         "node": "^14 || ^16 || >=18"
       },
       "peerDependencies": {
-        "@csstools/css-parser-algorithms": "^2.4.0",
-        "@csstools/css-tokenizer": "^2.2.2"
+        "@csstools/css-parser-algorithms": "^2.5.0",
+        "@csstools/css-tokenizer": "^2.2.3"
       }
     },
     "node_modules/@csstools/selector-specificity": {
@@ -1312,16 +1312,16 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "6.16.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.16.0.tgz",
-      "integrity": "sha512-O5f7Kv5o4dLWQtPX4ywPPa+v9G+1q1x8mz0Kr0pXUtKsevo+gIJHLkGc8RxaZWtP8RrhwhSNIWThnW42K9/0rQ==",
+      "version": "6.17.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.17.0.tgz",
+      "integrity": "sha512-Vih/4xLXmY7V490dGwBQJTpIZxH4ZFH6eCVmQ4RFkB+wmaCTDAx4dtgoWwMNGKLkqRY1L6rPqzEbjorRnDo4rQ==",
       "dev": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.5.1",
-        "@typescript-eslint/scope-manager": "6.16.0",
-        "@typescript-eslint/type-utils": "6.16.0",
-        "@typescript-eslint/utils": "6.16.0",
-        "@typescript-eslint/visitor-keys": "6.16.0",
+        "@typescript-eslint/scope-manager": "6.17.0",
+        "@typescript-eslint/type-utils": "6.17.0",
+        "@typescript-eslint/utils": "6.17.0",
+        "@typescript-eslint/visitor-keys": "6.17.0",
         "debug": "^4.3.4",
         "graphemer": "^1.4.0",
         "ignore": "^5.2.4",
@@ -1347,15 +1347,15 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "6.16.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.16.0.tgz",
-      "integrity": "sha512-H2GM3eUo12HpKZU9njig3DF5zJ58ja6ahj1GoHEHOgQvYxzoFJJEvC1MQ7T2l9Ha+69ZSOn7RTxOdpC/y3ikMw==",
+      "version": "6.17.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.17.0.tgz",
+      "integrity": "sha512-C4bBaX2orvhK+LlwrY8oWGmSl4WolCfYm513gEccdWZj0CwGadbIADb0FtVEcI+WzUyjyoBj2JRP8g25E6IB8A==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "6.16.0",
-        "@typescript-eslint/types": "6.16.0",
-        "@typescript-eslint/typescript-estree": "6.16.0",
-        "@typescript-eslint/visitor-keys": "6.16.0",
+        "@typescript-eslint/scope-manager": "6.17.0",
+        "@typescript-eslint/types": "6.17.0",
+        "@typescript-eslint/typescript-estree": "6.17.0",
+        "@typescript-eslint/visitor-keys": "6.17.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -1375,13 +1375,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "6.16.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.16.0.tgz",
-      "integrity": "sha512-0N7Y9DSPdaBQ3sqSCwlrm9zJwkpOuc6HYm7LpzLAPqBL7dmzAUimr4M29dMkOP/tEwvOCC/Cxo//yOfJD3HUiw==",
+      "version": "6.17.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.17.0.tgz",
+      "integrity": "sha512-RX7a8lwgOi7am0k17NUO0+ZmMOX4PpjLtLRgLmT1d3lBYdWH4ssBUbwdmc5pdRX8rXon8v9x8vaoOSpkHfcXGA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.16.0",
-        "@typescript-eslint/visitor-keys": "6.16.0"
+        "@typescript-eslint/types": "6.17.0",
+        "@typescript-eslint/visitor-keys": "6.17.0"
       },
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -1392,13 +1392,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "6.16.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.16.0.tgz",
-      "integrity": "sha512-ThmrEOcARmOnoyQfYkHw/DX2SEYBalVECmoldVuH6qagKROp/jMnfXpAU/pAIWub9c4YTxga+XwgAkoA0pxfmg==",
+      "version": "6.17.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.17.0.tgz",
+      "integrity": "sha512-hDXcWmnbtn4P2B37ka3nil3yi3VCQO2QEB9gBiHJmQp5wmyQWqnjA85+ZcE8c4FqnaB6lBwMrPkgd4aBYz3iNg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "6.16.0",
-        "@typescript-eslint/utils": "6.16.0",
+        "@typescript-eslint/typescript-estree": "6.17.0",
+        "@typescript-eslint/utils": "6.17.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.0.1"
       },
@@ -1419,9 +1419,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "6.16.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.16.0.tgz",
-      "integrity": "sha512-hvDFpLEvTJoHutVl87+MG/c5C8I6LOgEx05zExTSJDEVU7hhR3jhV8M5zuggbdFCw98+HhZWPHZeKS97kS3JoQ==",
+      "version": "6.17.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.17.0.tgz",
+      "integrity": "sha512-qRKs9tvc3a4RBcL/9PXtKSehI/q8wuU9xYJxe97WFxnzH8NWWtcW3ffNS+EWg8uPvIerhjsEZ+rHtDqOCiH57A==",
       "dev": true,
       "engines": {
         "node": "^16.0.0 || >=18.0.0"
@@ -1432,13 +1432,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "6.16.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.16.0.tgz",
-      "integrity": "sha512-VTWZuixh/vr7nih6CfrdpmFNLEnoVBF1skfjdyGnNwXOH1SLeHItGdZDHhhAIzd3ACazyY2Fg76zuzOVTaknGA==",
+      "version": "6.17.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.17.0.tgz",
+      "integrity": "sha512-gVQe+SLdNPfjlJn5VNGhlOhrXz4cajwFd5kAgWtZ9dCZf4XJf8xmgCTLIqec7aha3JwgLI2CK6GY1043FRxZwg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.16.0",
-        "@typescript-eslint/visitor-keys": "6.16.0",
+        "@typescript-eslint/types": "6.17.0",
+        "@typescript-eslint/visitor-keys": "6.17.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -1460,17 +1460,17 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "6.16.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.16.0.tgz",
-      "integrity": "sha512-T83QPKrBm6n//q9mv7oiSvy/Xq/7Hyw9SzSEhMHJwznEmQayfBM87+oAlkNAMEO7/MjIwKyOHgBJbxB0s7gx2A==",
+      "version": "6.17.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.17.0.tgz",
+      "integrity": "sha512-LofsSPjN/ITNkzV47hxas2JCsNCEnGhVvocfyOcLzT9c/tSZE7SfhS/iWtzP1lKNOEfLhRTZz6xqI8N2RzweSQ==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
         "@types/json-schema": "^7.0.12",
         "@types/semver": "^7.5.0",
-        "@typescript-eslint/scope-manager": "6.16.0",
-        "@typescript-eslint/types": "6.16.0",
-        "@typescript-eslint/typescript-estree": "6.16.0",
+        "@typescript-eslint/scope-manager": "6.17.0",
+        "@typescript-eslint/types": "6.17.0",
+        "@typescript-eslint/typescript-estree": "6.17.0",
         "semver": "^7.5.4"
       },
       "engines": {
@@ -1485,12 +1485,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "6.16.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.16.0.tgz",
-      "integrity": "sha512-QSFQLruk7fhs91a/Ep/LqRdbJCZ1Rq03rqBdKT5Ky17Sz8zRLUksqIe9DW0pKtg/Z35/ztbLQ6qpOCN6rOC11A==",
+      "version": "6.17.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.17.0.tgz",
+      "integrity": "sha512-H6VwB/k3IuIeQOyYczyyKN8wH6ed8EwliaYHLxOIhyF0dYEIsN8+Bk3GE19qafeMKyZJJHP8+O1HiFhFLUNKSg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "6.16.0",
+        "@typescript-eslint/types": "6.17.0",
         "eslint-visitor-keys": "^3.4.1"
       },
       "engines": {
@@ -1791,19 +1791,18 @@
       }
     },
     "node_modules/c8": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/c8/-/c8-8.0.1.tgz",
-      "integrity": "sha512-EINpopxZNH1mETuI0DzRA4MZpAUH+IFiRhnmFD3vFr3vdrgxqi3VfE3KL0AIL+zDq8rC9bZqwM/VDmmoe04y7w==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/c8/-/c8-9.0.0.tgz",
+      "integrity": "sha512-nFJhU2Cz6Frh2awk3IW7wwk3wx27/U2v8ojQCHGc1GWTCHS6aMu4lal327/ZnnYj7oSThGF1X3qUP1yzAJBcOQ==",
       "dev": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^0.2.3",
         "@istanbuljs/schema": "^0.1.3",
         "find-up": "^5.0.0",
-        "foreground-child": "^2.0.0",
+        "foreground-child": "^3.1.1",
         "istanbul-lib-coverage": "^3.2.0",
         "istanbul-lib-report": "^3.0.1",
         "istanbul-reports": "^3.1.6",
-        "rimraf": "^3.0.2",
         "test-exclude": "^6.0.0",
         "v8-to-istanbul": "^9.0.0",
         "yargs": "^17.7.2",
@@ -1813,7 +1812,7 @@
         "c8": "bin/c8.js"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14.14.0"
       }
     },
     "node_modules/call-bind": {
@@ -3093,16 +3092,19 @@
       }
     },
     "node_modules/foreground-child": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-2.0.0.tgz",
-      "integrity": "sha512-dCIq9FpEcyQyXKCkyzmlPTFNgrCzPudOe+mhvJU5zAtlBnGVy2yKxtfsxK2tQBThwq225jcvBjpw1Gr40uzZCA==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
+      "integrity": "sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==",
       "dev": true,
       "dependencies": {
         "cross-spawn": "^7.0.0",
-        "signal-exit": "^3.0.2"
+        "signal-exit": "^4.0.1"
       },
       "engines": {
-        "node": ">=8.0.0"
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/fs.realpath": {
@@ -4112,9 +4114,9 @@
       "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA=="
     },
     "node_modules/meow": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-13.0.0.tgz",
-      "integrity": "sha512-4Hu+75Vo7EOR+8C9RmkabfLijuwd9SrzQ8f0SyC4qZZwU6BlxeOt5ulF3PGCpcMJX4hI+ktpJhea0P6PN1RiWw==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-13.1.0.tgz",
+      "integrity": "sha512-o5R/R3Tzxq0PJ3v3qcQJtSvSE9nKOLSAaDuuoMzDVuGTwHdccMWcYomh9Xolng2tjT6O/Y83d+0coVGof6tqmA==",
       "dev": true,
       "engines": {
         "node": ">=18"
@@ -4525,9 +4527,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.32",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.32.tgz",
-      "integrity": "sha512-D/kj5JNu6oo2EIy+XL/26JEDTlIbB8hw85G8StOE6L74RQAVVP5rej6wxCNqyMbR4RkPfqvezVbPw81Ngd6Kcw==",
+      "version": "8.4.33",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.33.tgz",
+      "integrity": "sha512-Kkpbhhdjw2qQs2O2DGX+8m5OVqEcbB9HRBvuYM9pgrjEFUg30A9LmXNlTAUj4S9kgtGyrMbTzVjH7E+s5Re2yg==",
       "dev": true,
       "funding": [
         {
@@ -5004,10 +5006,16 @@
       }
     },
     "node_modules/signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/slash": {
       "version": "3.0.0",
@@ -5347,22 +5355,6 @@
         "node": ">=16"
       }
     },
-    "node_modules/stylelint/node_modules/foreground-child": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
-      "integrity": "sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==",
-      "dev": true,
-      "dependencies": {
-        "cross-spawn": "^7.0.0",
-        "signal-exit": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/stylelint/node_modules/glob": {
       "version": "10.3.10",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.10.tgz",
@@ -5431,18 +5423,6 @@
       "bin": {
         "rimraf": "dist/esm/bin.mjs"
       },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/stylelint/node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
       "engines": {
         "node": ">=14"
       },
@@ -6096,18 +6076,6 @@
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/write-file-atomic/node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/y18n": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,7 +25,7 @@
     "@types/node": "^20.2.5",
     "@typescript-eslint/eslint-plugin": "^6.0.0",
     "@typescript-eslint/parser": "^6.0.0",
-    "c8": "^8.0.1",
+    "c8": "^9.0.0",
     "chokidar": "^3.5.1",
     "esbuild": "^0.19.0",
     "esbuild-register": "^3.0.0",

--- a/frontend/src/charts/BarChart.svelte
+++ b/frontend/src/charts/BarChart.svelte
@@ -63,7 +63,7 @@
     chart.currencies.map((c) => [
       c,
       showStackedBars ? null : $currenciesScale(c),
-    ])
+    ]),
   );
 
   // Axes

--- a/frontend/src/charts/ChartLegend.svelte
+++ b/frontend/src/charts/ChartLegend.svelte
@@ -18,7 +18,7 @@
           active.set(item);
         } else if (toggled) {
           toggled.update((v) =>
-            v.includes(item) ? v.filter((i) => i !== item) : [...v, item]
+            v.includes(item) ? v.filter((i) => i !== item) : [...v, item],
           );
         }
       }}

--- a/frontend/src/charts/LineChart.svelte
+++ b/frontend/src/charts/LineChart.svelte
@@ -46,7 +46,7 @@
   $: quad = quadtree(
     allValues,
     (d) => x(d.date),
-    (d) => y(d.value)
+    (d) => y(d.value),
   );
 
   $: lineShape = line<LineChartDatum>()

--- a/frontend/src/charts/ScatterPlot.svelte
+++ b/frontend/src/charts/ScatterPlot.svelte
@@ -39,7 +39,7 @@
   $: quad = quadtree(
     [...chart.data],
     (d) => x(d.date),
-    (d) => y(d.type) ?? 0
+    (d) => y(d.type) ?? 0,
   );
 
   function tooltipText(d: ScatterPlotDatum) {

--- a/frontend/src/charts/Treemap.svelte
+++ b/frontend/src/charts/Treemap.svelte
@@ -4,7 +4,7 @@
   import type { Action } from "svelte/action";
 
   import { formatPercentage } from "../format";
-  import {  urlForAccount } from "../helpers";
+  import { urlForAccount } from "../helpers";
   import { ctx } from "../stores/format";
 
   import { treemapScale } from "./helpers";
@@ -38,7 +38,7 @@
 
     return [
       domHelpers.t(
-        `${$ctx.amount(val, currency)} (${formatPercentage(val / rootValue)})`
+        `${$ctx.amount(val, currency)} (${formatPercentage(val / rootValue)})`,
       ),
       domHelpers.em(d.data.account),
     ];

--- a/frontend/src/editor/SliceEditor.svelte
+++ b/frontend/src/editor/SliceEditor.svelte
@@ -78,7 +78,7 @@
         },
       },
     ],
-    beancount_language_support
+    beancount_language_support,
   );
 </script>
 

--- a/frontend/src/entry-forms/AccountInput.svelte
+++ b/frontend/src/entry-forms/AccountInput.svelte
@@ -23,7 +23,7 @@
   $: account_suggestions = suggestions ?? $accounts;
   $: filtered_suggestions = parsed_date
     ? account_suggestions.filter(
-        (account) => !$is_closed_account(account, parsed_date)
+        (account) => !$is_closed_account(account, parsed_date),
       )
     : account_suggestions;
 </script>

--- a/frontend/src/entry-forms/EntryMetadata.svelte
+++ b/frontend/src/entry-forms/EntryMetadata.svelte
@@ -7,7 +7,7 @@
   export let meta: EntryMetadata;
 
   $: metakeys = Object.keys(meta).filter(
-    (key) => !key.startsWith("_") && key !== "filename" && key !== "lineno"
+    (key) => !key.startsWith("_") && key !== "filename" && key !== "lineno",
   );
 
   function removeMetadata(metakey: string) {

--- a/frontend/src/entry-forms/Transaction.svelte
+++ b/frontend/src/entry-forms/Transaction.svelte
@@ -39,7 +39,7 @@
           notify_err(
             error,
             (err) =>
-              `Fetching account suggestions for payee ${payee} failed: ${err.message}`
+              `Fetching account suggestions for payee ${payee} failed: ${err.message}`,
           );
         });
     }

--- a/frontend/src/journal/JournalFilters.svelte
+++ b/frontend/src/journal/JournalFilters.svelte
@@ -16,7 +16,7 @@
     button_text: string,
     title: string | null,
     shortcut: KeySpec,
-    supertype?: string
+    supertype?: string,
   ][] = [
     ["open", "Open", null, "s o"],
     ["close", "Close", null, "s c"],

--- a/frontend/src/modals/DocumentUpload.svelte
+++ b/frontend/src/modals/DocumentUpload.svelte
@@ -37,7 +37,7 @@
         return put("add_document", formData).then(notify, (error) => {
           notify_err(error, (err) => `Upload error: ${err.message}`);
         });
-      })
+      }),
     );
     closeHandler();
     router.reload();

--- a/frontend/src/modals/EntryContext.svelte
+++ b/frontend/src/modals/EntryContext.svelte
@@ -15,7 +15,7 @@
     <a
       href={urlForSource(
         entry.meta.filename?.toString() ?? "",
-        entry.meta.lineno?.toString() ?? ""
+        entry.meta.lineno?.toString() ?? "",
       )}
     >
       {entry.meta.filename}:{entry.meta.lineno}

--- a/frontend/src/reports/documents/Documents.svelte
+++ b/frontend/src/reports/documents/Documents.svelte
@@ -26,7 +26,7 @@
   $: node = stratify(
     grouped.entries(),
     ([s]) => s,
-    (name, d) => ({ name, count: d?.[1].length ?? 0 })
+    (name, d) => ({ name, count: d?.[1].length ?? 0 }),
   );
 
   let selected: Document;

--- a/frontend/src/reports/documents/Table.svelte
+++ b/frontend/src/reports/documents/Table.svelte
@@ -26,7 +26,7 @@
   let sorter = new Sorter(columns[0], "desc");
 
   $: filtered_documents = data.filter((doc) =>
-    isDescendant(doc.account, $selectedAccount)
+    isDescendant(doc.account, $selectedAccount),
   );
   $: sorted_documents = sorter.sort(filtered_documents);
 </script>

--- a/frontend/src/reports/editor/Editor.svelte
+++ b/frontend/src/reports/editor/Editor.svelte
@@ -71,7 +71,7 @@
         },
       },
     ],
-    beancount_language_support
+    beancount_language_support,
   );
 
   // update editor contents
@@ -85,7 +85,7 @@
   // go to line on file changes
   $: if (file_path) {
     const opts = $fava_options.insert_entry.filter(
-      (f) => f.filename === file_path
+      (f) => f.filename === file_path,
     );
     const line = parseInt($searchParams.get("line") ?? "0", 10);
     const last_insert_opt = opts[opts.length - 1];
@@ -105,7 +105,7 @@
   $: {
     // Only show errors for this file, or general errors (AKA no source)
     const errorsForFile = $errors.filter(
-      (err) => err.source === null || err.source.filename === file_path
+      (err) => err.source === null || err.source.filename === file_path,
     );
     editor.dispatch(setErrors(editor.state, errorsForFile));
   }

--- a/frontend/src/reports/events/Events.svelte
+++ b/frontend/src/reports/events/Events.svelte
@@ -19,7 +19,7 @@
         date: new Date(date),
         type,
         description,
-      }))
+      })),
     ),
   ];
 </script>

--- a/frontend/src/reports/import/Import.svelte
+++ b/frontend/src/reports/import/Import.svelte
@@ -36,7 +36,7 @@
   let extractCache = new Map<string, Entry[]>();
 
   $: importableFiles = files.filter(
-    (i) => i.importers[0]?.importer_name !== ""
+    (i) => i.importers[0]?.importer_name !== "",
   );
   $: otherFiles = files.filter((i) => i.importers[0]?.importer_name === "");
 
@@ -48,7 +48,7 @@
   onMount(() => router.addInteruptHandler(preventNavigation));
   $: {
     const existingFiles = Object.fromEntries(
-      files.map((file) => [file.name, file])
+      files.map((file) => [file.name, file]),
     );
     files = data.map((file) => {
       // Use existing importers if we found any, since the user might have changed these before a reload happens
@@ -129,7 +129,7 @@
         return put("upload_import_file", formData).then(notify, (error) => {
           notify_err(error, (err) => `Upload error: ${err.message}`);
         });
-      })
+      }),
     );
     fileUpload.value = "";
     router.reload();

--- a/frontend/src/reports/query/Query.svelte
+++ b/frontend/src/reports/query/Query.svelte
@@ -32,7 +32,7 @@
   const query_results: Record<string, ResultType> = {};
 
   $: query_result_array = $query_shell_history.map(
-    (item): [string, ResultType] => [item, query_results[item] ?? {}]
+    (item): [string, ResultType] => [item, query_results[item] ?? {}],
   );
 
   async function setResult(query: string, res: ResultType) {
@@ -71,7 +71,7 @@
       (res) => {
         const chart = parseQueryChart(res.chart, $chartContext).unwrap_or(null);
         setResult(query, { result: { chart, table: res.table } }).catch(
-          log_error
+          log_error,
         );
         window.scroll(0, 0);
       },
@@ -84,7 +84,7 @@
             error: "Received invalid data as query error.",
           }).catch(log_error);
         }
-      }
+      },
     );
   }
 
@@ -110,7 +110,7 @@
       if (query_string) {
         submit();
       }
-    })
+    }),
   );
 </script>
 

--- a/frontend/src/reports/query/QueryEditor.svelte
+++ b/frontend/src/reports/query/QueryEditor.svelte
@@ -13,7 +13,7 @@
       value = state.sliceDoc();
     },
     _("...enter a BQL query. 'help' to list available commands."),
-    submit
+    submit,
   );
 
   $: if (value !== editor.state.sliceDoc()) {

--- a/frontend/src/sidebar/FilterForm.svelte
+++ b/frontend/src/sidebar/FilterForm.svelte
@@ -23,7 +23,7 @@
     return matchLength !== undefined
       ? `${input.value.slice(
           0,
-          selectionStart - matchLength
+          selectionStart - matchLength,
         )}${value}${input.value.slice(selectionStart)}`
       : value;
   }

--- a/frontend/src/tree-table/AccountCellHeader.svelte
+++ b/frontend/src/tree-table/AccountCellHeader.svelte
@@ -11,7 +11,7 @@
 
   const help_title = _(
     "Hold Shift while clicking to expand all children.\n" +
-      "Hold Ctrl or Cmd while clicking to expand one level."
+      "Hold Ctrl or Cmd while clicking to expand one level.",
   );
 </script>
 

--- a/frontend/src/tree-table/IntervalTreeTable.svelte
+++ b/frontend/src/tree-table/IntervalTreeTable.svelte
@@ -28,7 +28,7 @@
   const not_shown = writable(new Set<string>());
   setTreeTableContext({ toggled, not_shown });
   $: $not_shown = intersection(
-    ...trees.map((n, index) => $get_not_shown(n, dates[index]?.end ?? null))
+    ...trees.map((n, index) => $get_not_shown(n, dates[index]?.end ?? null)),
   );
 
   $: account = trees[0].account;

--- a/src/fava/help/_index.md
+++ b/src/fava/help/_index.md
@@ -3,13 +3,13 @@ Welcome to the help pages for Fava! You are running Beancount version
 ([changelog](https://beancount.github.io/fava/changelog.html)). There are help
 pages for the following topics:
 
--   [Beancount Syntax](./beancount_syntax) - short overview of the syntax.
--   [Budgets](./budgets) - how to use Fava's budgeting feature.
--   [Fava's Features](./features) - the features in detail.
--   [Filtering entries](./filters) - how to filter the entries.
--   [Extensions](./extensions) - how Fava can be extended.
--   [Import](./import) - the import system.
--   [Options](./options) - the available options.
+- [Beancount Syntax](./beancount_syntax) - short overview of the syntax.
+- [Budgets](./budgets) - how to use Fava's budgeting feature.
+- [Fava's Features](./features) - the features in detail.
+- [Filtering entries](./filters) - how to filter the entries.
+- [Extensions](./extensions) - how Fava can be extended.
+- [Import](./import) - the import system.
+- [Options](./options) - the available options.
 
 Fava comes with keyboard shortcuts - press <kbd>?</kbd> on any page to see the
 available ones.
@@ -22,11 +22,11 @@ If you discover a bug in Fava, or have some ideas for improvement, please open a
 
 ### Related websites
 
--   Fava's [website](https://beancount.github.io/fava/),
-    [chat](https://gitter.im/beancount/fava) and Fava on
-    [GitHub](https://github.com/beancount/fava),
--   Beancount's [documentation](http://furius.ca/beancount/doc/index),
-    [mailing list](https://groups.google.com/forum/#!forum/beancount), and
-    [bug tracker](https://bitbucket.org/blais/beancount/issues),
--   An overview of other implementations of command-line accounting:
-    [Plain Text Accounting](http://plaintextaccounting.org).
+- Fava's [website](https://beancount.github.io/fava/),
+  [chat](https://gitter.im/beancount/fava) and Fava on
+  [GitHub](https://github.com/beancount/fava),
+- Beancount's [documentation](http://furius.ca/beancount/doc/index),
+  [mailing list](https://groups.google.com/forum/#!forum/beancount), and
+  [bug tracker](https://bitbucket.org/blais/beancount/issues),
+- An overview of other implementations of command-line accounting:
+  [Plain Text Accounting](http://plaintextaccounting.org).

--- a/src/fava/help/beancount_syntax.md
+++ b/src/fava/help/beancount_syntax.md
@@ -8,9 +8,9 @@ Beancount defines a language in which financial transactions are entered into a
 text-file, which then can be processed by Beancount. There are a few building
 blocks that are important to understand Beancount's syntax:
 
--   Commodities,
--   Accounts,
--   Directives.
+- Commodities,
+- Accounts,
+- Directives.
 
 ## Commodities
 

--- a/src/fava/help/extensions.md
+++ b/src/fava/help/extensions.md
@@ -24,10 +24,10 @@ module can define functions to be called when different events happen. Take a
 look at `fava/ext/portfolio_list/PortfolioList.js` for an example. Currently,
 the following events/functions can be specified:
 
--   `init`: is called when a Fava report is first opened
--   `onPageLoad`: Is called when any page in Fava is loaded (so on first open
-    and on any further navigation).
--   `onExtensionPageLoad`: Is called when the extension report is loaded.
+- `init`: is called when a Fava report is first opened
+- `onPageLoad`: Is called when any page in Fava is loaded (so on first open and
+  on any further navigation).
+- `onExtensionPageLoad`: Is called when the extension report is loaded.
 
 The whole extension system should be considered unstable and it might change
 drastically.

--- a/src/fava/help/features.md
+++ b/src/fava/help/features.md
@@ -56,9 +56,9 @@ They are shown next to accounts that have the metadata
 `fava-uptodate-indication: TRUE` set on their Open directive. The colors have
 the following meaning:
 
--   green: The last entry for this account is a balance check that passed.
--   red: The last entry is a balance check that failed.
--   yellow: The last entry is not a balance check.
+- green: The last entry for this account is a balance check that passed.
+- red: The last entry is a balance check that failed.
+- yellow: The last entry is not a balance check.
 
 In addition, a grey dot will be shown if the account has not been updated in a
 while, as configured by the `uptodate-indicator-grey-lookback-days` option.
@@ -68,10 +68,10 @@ while, as configured by the `uptodate-indicator-grey-lookback-days` option.
 To help display only the most relevant subset of accounts when managing a large
 number or a deep hierarchy of accounts, Fava offers the following options:
 
--   `show-closed-accounts`
--   `show-accounts-with-zero-balance`
--   `show-accounts-with-zero-transactions`
--   `collapse-pattern`
+- `show-closed-accounts`
+- `show-accounts-with-zero-balance`
+- `show-accounts-with-zero-transactions`
+- `collapse-pattern`
 
 ## Opening an external editor
 
@@ -102,8 +102,8 @@ example above, or absolute, even linking to an external site.
 Two frequently used custom links are for showing all Documents and all Notes
 found in the journal:
 
--   For all Documents: `/<slug>/journal/?show=document`
--   For all Notes: `/<slug>/journal/?show=note`
+- For all Documents: `/<slug>/journal/?show=document`
+- For all Notes: `/<slug>/journal/?show=note`
 
 There is a special URL handler `/jump` which can be used to jump to the current
 page with given URL parameters. For example, `/jump?time=month` will show the

--- a/src/fava/help/filters.md
+++ b/src/fava/help/filters.md
@@ -31,24 +31,24 @@ the account name, or a regular expression matching the account name, e.g.
 
 This final filter allows you to filter entries by various attributes.
 
--   Filter by `#tag` or `^link`.
--   Filter by any entry attribute, such as payee `payee:"restaurant"` or
-    narration `narration:'Dinner with Joe'`. The argument is a regular
-    expression which needs to be quoted (with `'` or `"`) if it contains spaces
-    or special characters. If the argument is not a valid regular expression,
-    Fava will look for an exact match instead.
--   Search in payee and narration if no specific entry attribute is given, e.g.
-    `"Cash withdrawal"`. For Note directives, the comment will be searched.
--   Filter for entries having certain metadata values: `document:"\.pdf$"`. Note
-    that if the entry has an attribute of the same name as the metadata key, the
-    filter will apply to the entry attribute, not the metadata value.
--   Exclude entries that match a filter by prepending a `-` to it, e.g. `-#tag`
-    or `-(^link #tag)`.
--   To match entries by posting attributes, you can use `any()` and `all()`,
-    e.g., `any(id:'12', account:"Cash$")` for all entries that have at least one
-    posting with metadata `id: 12` or account ending in `Cash`, or
-    `all(-account:"^Expenses:Food")` to exclude all transactions having a
-    posting to the Expenses:Food account.
+- Filter by `#tag` or `^link`.
+- Filter by any entry attribute, such as payee `payee:"restaurant"` or narration
+  `narration:'Dinner with Joe'`. The argument is a regular expression which
+  needs to be quoted (with `'` or `"`) if it contains spaces or special
+  characters. If the argument is not a valid regular expression, Fava will look
+  for an exact match instead.
+- Search in payee and narration if no specific entry attribute is given, e.g.
+  `"Cash withdrawal"`. For Note directives, the comment will be searched.
+- Filter for entries having certain metadata values: `document:"\.pdf$"`. Note
+  that if the entry has an attribute of the same name as the metadata key, the
+  filter will apply to the entry attribute, not the metadata value.
+- Exclude entries that match a filter by prepending a `-` to it, e.g. `-#tag` or
+  `-(^link #tag)`.
+- To match entries by posting attributes, you can use `any()` and `all()`, e.g.,
+  `any(id:'12', account:"Cash$")` for all entries that have at least one posting
+  with metadata `id: 12` or account ending in `Cash`, or
+  `all(-account:"^Expenses:Food")` to exclude all transactions having a posting
+  to the Expenses:Food account.
 
 These filters can be combined by separating them by spaces to match all entries
 satisfying all given filters or by commas to match all entries satisfying at

--- a/src/fava/help/options.md
+++ b/src/fava/help/options.md
@@ -20,20 +20,20 @@ If this setting is not specified, Fava will try to guess the language from your
 browser settings. Fava currently ships translations into the following
 languages:
 
--   Bulgarian (`bg`)
--   Catalan (`ca`)
--   Chinese (`zh_CN` and `zh_TW`)
--   Dutch (`nl`)
--   English (`en`)
--   French (`fr`)
--   German (`de`)
--   Persian (`fa`)
--   Portuguese (`pt`)
--   Russian (`ru`)
--   Slovak (`sk`)
--   Spanish (`es`)
--   Swedish (`sv`)
--   Ukrainian (`uk`)
+- Bulgarian (`bg`)
+- Catalan (`ca`)
+- Chinese (`zh_CN` and `zh_TW`)
+- Dutch (`nl`)
+- English (`en`)
+- French (`fr`)
+- German (`de`)
+- Persian (`fa`)
+- Portuguese (`pt`)
+- Russian (`ru`)
+- Slovak (`sk`)
+- Spanish (`es`)
+- Swedish (`sv`)
+- Ukrainian (`uk`)
 
 ---
 
@@ -82,9 +82,9 @@ or both dates in a date range in the time filter.
 
 Examples are:
 
--   `09-30` - US federal government
--   `06-30` - Australia / NZ
--   `04-05` - UK
+- `09-30` - US federal government
+- `06-30` - Australia / NZ
+- `04-05` - UK
 
 See [Fiscal Year on WikiPedia](https://en.wikipedia.org/wiki/Fiscal_year) for
 more examples.


### PR DESCRIPTION
Also, remove default indent size for all files from editorconfig so that
prettier's default of 2 spaces is used for most files (and only
explicitly set it in the editor config for the most common file types).

<!--
Hi, thank you for opening a PR!

Please ensure that your change passes tests and the various linters by running
`make test` and `make lint`. If testable, your changes should be covered by
unit tests.

Explain your changes below and link to related issues.
-->
