### PR TITLE
Fix the posting validation

### DIFF
--- a/frontend/src/entries.ts
+++ b/frontend/src/entries.ts
@@ -6,6 +6,7 @@ import {
   defaultValue,
   number,
   object,
+  optional,
   optional_string,
   record,
   string,
@@ -15,7 +16,7 @@ import {
 export interface Posting {
   account: string;
   amount: string;
-  meta: EntryMetadata;
+  meta: EntryMetadata | null;
 }
 
 const entry_meta_validator = record(
@@ -25,7 +26,7 @@ const entry_meta_validator = record(
 const postingValidator = object({
   account: string,
   amount: string,
-  meta: entry_meta_validator,
+  meta: optional(entry_meta_validator),
 });
 
 interface Amount {

--- a/frontend/test/entries.test.ts
+++ b/frontend/test/entries.test.ts
@@ -43,6 +43,22 @@ test("create entries from JSON data", () => {
     ],
   }).unwrap();
   assert.instance(transaction, Transaction);
+
+  const transactionWithoutPostingMeta = entryValidator({
+    t: "Transaction",
+    meta: { filename: "/home/test/test.beancount", lineno: 1 },
+    date: "2022-12-12",
+    flag: "*",
+    payee: "Some Store",
+    narration: "Bought food",
+    tags: [],
+    links: [],
+    postings: [
+      { account: "Expenses:Food", amount: "" },
+      { account: "Assets:Cash", amount: "-5.15 EUR" },
+    ],
+  }).unwrap();
+  assert.instance(transactionWithoutPostingMeta, Transaction);
 });
 
 test.run();


### PR DESCRIPTION
This pull request addresses the validation of the `meta` property within the `Posting` (#1738).

The API does not include a meta property in the JSON if it is empty. Therefore, the validation of this property should permit `meta` as optional in the frontend.
