### PR TITLE
[Fix] Add nullable meta to posting json

### DIFF
--- a/src/fava/serialisation.py
+++ b/src/fava/serialisation.py
@@ -71,9 +71,11 @@ def _(posting: Posting) -> Any:
     if posting.price is not None:
         position_str += f" @ {to_string(posting.price)}"
 
-    ret: dict[str, Any] = {"account": posting.account, "amount": position_str}
-    if posting.meta:
-        ret["meta"] = copy(posting.meta)
+    ret: dict[str, Any] = {
+        "account": posting.account,
+        "amount": position_str,
+        "meta": posting.meta if posting.meta else None,
+    }
     return ret
 
 

--- a/tests/__snapshots__/test_json_api-test_api_imports-2.json
+++ b/tests/__snapshots__/test_json_api-test_api_imports-2.json
@@ -24,11 +24,13 @@
     "postings": [
       {
         "account": "",
-        "amount": "50.00 EUR"
+        "amount": "50.00 EUR",
+        "meta": null
       },
       {
         "account": "Assets:Checking",
-        "amount": "-50.00 EUR"
+        "amount": "-50.00 EUR",
+        "meta": null
       }
     ],
     "t": "Transaction",
@@ -49,11 +51,13 @@
     "postings": [
       {
         "account": "",
-        "amount": "100.00 EUR"
+        "amount": "100.00 EUR",
+        "meta": null
       },
       {
         "account": "Assets:Checking",
-        "amount": "-100.00 EUR"
+        "amount": "-100.00 EUR",
+        "meta": null
       }
     ],
     "t": "Transaction",

--- a/tests/test_serialisation.py
+++ b/tests/test_serialisation.py
@@ -53,8 +53,12 @@ def test_serialise_txn() -> None:
         "payee": "Test3",
         "t": "Transaction",
         "postings": [
-            {"account": "Assets:ETrade:Cash", "amount": "100 USD"},
-            {"account": "Assets:ETrade:GLD", "amount": "0 USD"},
+            {
+                "account": "Assets:ETrade:Cash",
+                "amount": "100 USD",
+                "meta": None,
+            },
+            {"account": "Assets:ETrade:GLD", "amount": "0 USD", "meta": None},
         ],
     }
 
@@ -154,7 +158,11 @@ def test_serialise_posting(
         flag=None,
         meta=meta,
     )
-    json: dict[str, Any] = {"account": "Assets", "amount": amount_string}
+    json: dict[str, Any] = {
+        "account": "Assets",
+        "amount": amount_string,
+        "meta": None,
+    }
     if meta:
         json["meta"] = meta
     assert loads(dumps(serialise(pos))) == json


### PR DESCRIPTION
This pull request updates the outputted JSON to include a nullable `meta` field in the posting.

This resolves an issue in which the `meta` was not defined during the import and resolved into a `Invalid data returned in API request: Validating union failed` error . #1738