### PR TITLE
properly encode document filename in url

### DIFF
--- a/frontend/src/reports/documents/DocumentPreview.svelte
+++ b/frontend/src/reports/documents/DocumentPreview.svelte
@@ -26,7 +26,7 @@
   export let filename: string;
 
   $: extension = ext(filename).toLowerCase();
-  $: url = `${$base_url}document/?filename=${filename}`;
+  $: url = `${$base_url}document/?filename=${encodeURIComponent(filename)}`;
 </script>
 
 {#if extension === "pdf"}


### PR DESCRIPTION
When filename contains certain special characters like `#`, the URL would not be getting the right file. For example, if the document file is `/home/upsuper/beancount/receipt #1.pdf`, the URL would be `/document/?filename=/home/upsuper/beancount/receipt #1.pdf` whose meaning is requesting `/document/?filename=/home/upsuper/beancount/receipt ` and use the fragment `1.pdf`, which is wrong.

This PR makes it encode the filename as a URL component so that it would work regardless of characters used in the document filename.