### PR TITLE
charts: better error handling; backwards-compat

### DIFF
--- a/frontend/css/components.css
+++ b/frontend/css/components.css
@@ -1,3 +1,11 @@
+svelte-component.error {
+  display: block;
+  padding: 0.5em;
+  margin: 0.5em;
+  color: var(--error);
+  border: 1px solid var(--error);
+}
+
 details {
   display: block;
   min-width: 400px;

--- a/frontend/src/charts/tooltip.ts
+++ b/frontend/src/charts/tooltip.ts
@@ -22,13 +22,22 @@ const hide = (): void => {
 
 /** Some small utilities to create tooltip contents. */
 export const domHelpers = {
+  /** Create a <br> element. */
   br: (): HTMLBRElement => document.createElement("br"),
+  /** Create a <em> element with the given content. */
   em: (content: string): HTMLElement => {
     const em = document.createElement("em");
     em.textContent = content;
     return em;
   },
+  /** Create a text node for the given text. */
   t: (text: string): Text => document.createTextNode(text),
+  /** Create a <pre> element with the given content. */
+  pre: (content: string): HTMLPreElement => {
+    const pre = document.createElement("pre");
+    pre.textContent = content;
+    return pre;
+  },
 };
 
 export type TooltipContent = (HTMLElement | Text)[];

--- a/frontend/src/lib/result.ts
+++ b/frontend/src/lib/result.ts
@@ -115,3 +115,16 @@ export function ok<T>(value: T): Ok<T> {
 export function err<E>(error: E): Err<E> {
   return new Err(error);
 }
+
+/** Collect an array of results into a single result. */
+export function collect<T, E>(items: Result<T, E>[]): Result<T[], E> {
+  const ok_values: T[] = [];
+  for (const r of items) {
+    if (r.is_ok) {
+      ok_values.push(r.value);
+    } else {
+      return r;
+    }
+  }
+  return ok(ok_values);
+}

--- a/frontend/src/notifications.ts
+++ b/frontend/src/notifications.ts
@@ -48,6 +48,15 @@ export function notify(
 }
 
 /**
+ * Notify the user about an warning and log to console.
+ */
+export function notify_warn(msg: string): void {
+  notify(msg, "warning");
+  // eslint-disable-next-line no-console
+  console.warn(msg);
+}
+
+/**
  * Notify the user about an error and log to console.
  */
 export function notify_err(error: unknown, msg: (e: Error) => string): void {

--- a/frontend/src/svelte-custom-elements.ts
+++ b/frontend/src/svelte-custom-elements.ts
@@ -8,7 +8,9 @@ import { get as store_get } from "svelte/store";
 import { parseChartData } from "./charts";
 import ChartSwitcher from "./charts/ChartSwitcher.svelte";
 import { chartContext } from "./charts/context";
+import { domHelpers } from "./charts/tooltip";
 import { type Result } from "./lib/result";
+import { log_error } from "./log";
 
 /** This class pairs the components and their validation functions to use them in a type-safe way. */
 class SvelteCustomElementComponent<
@@ -23,7 +25,16 @@ class SvelteCustomElementComponent<
   render(target: HTMLElement, data: unknown): (() => void) | undefined {
     const res = this.validate(data);
     if (res.is_err) {
-      target.innerHTML = `Rendering component failed: ${res.error}`;
+      const type = target.getAttribute("type");
+      target.classList.add("error");
+      target.replaceChildren(
+        domHelpers.t(
+          `Rendering component '${type}' failed due to invalid JSON data:`,
+        ),
+        domHelpers.br(),
+        domHelpers.pre(res.error),
+      );
+      log_error("Invalid JSON for component:", data);
       return undefined;
     }
     const instance = new this.Component({ target, props: res.value });


### PR DESCRIPTION
Previously, charts with invalid data were quietly discarded, bubble up
the error instead.

On loading the data for a <svelte-component> custom element, render a
potential validation error message a bit more prominently and with more
context.

Also, add backwards-compatibility handler (with a warning) for hierarchy
charts that still have the "tree" nested one level deeper. The
`modifier` key has been removed in v1.26 and is now inferred
automatically.

<!--
Hi, thank you for opening a PR!

Please ensure that your change passes tests and the various linters by running
`make test` and `make lint`. If testable, your changes should be covered by
unit tests.

Explain your changes below and link to related issues.
-->
