### PR TITLE
Remove chart controls in print view

### DIFF
--- a/frontend/src/charts/Chart.svelte
+++ b/frontend/src/charts/Chart.svelte
@@ -56,6 +56,7 @@
   <slot />
   <button
     type="button"
+    class="show-charts"
     on:click={() => {
       showCharts.update((v) => !v);
     }}
@@ -76,3 +77,11 @@
     {/if}
   {/if}
 </div>
+
+<style>
+  @media print {
+    button.show-charts {
+      display: none;
+    }
+  }
+</style>

--- a/frontend/src/charts/ChartSwitcher.svelte
+++ b/frontend/src/charts/ChartSwitcher.svelte
@@ -72,4 +72,19 @@
   button:hover {
     color: var(--text-color-lighter);
   }
+
+  @media print {
+    button {
+      display: none;
+      border-left: none;
+    }
+
+    button + button {
+      border-left: none;
+    }
+
+    button.selected {
+      display: inline;
+    }
+  }
 </style>

--- a/frontend/src/charts/ModeSwitch.svelte
+++ b/frontend/src/charts/ModeSwitch.svelte
@@ -22,4 +22,10 @@
   label + label {
     margin-left: 0.125rem;
   }
+
+  @media print {
+    label {
+      display: none;
+    }
+  }
 </style>

--- a/frontend/src/charts/SelectCombobox.svelte
+++ b/frontend/src/charts/SelectCombobox.svelte
@@ -207,4 +207,10 @@
     color: var(--background);
     background-color: var(--link-color);
   }
+
+  @media print {
+    span {
+      display: none;
+    }
+  }
 </style>


### PR DESCRIPTION
This PR removes UX related to changing chart settings when printing a page.

*Print view before the PR:*
![image](https://github.com/beancount/fava/assets/208884/34450b51-2846-4ed4-bac4-074e95a23086)

*Print view after the PR:*
![image](https://github.com/beancount/fava/assets/208884/f6674615-4360-4238-8444-32f1f19ad696)

Related to #1747