### PR TITLE
core.file: improve newline handling and tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,7 @@ disable = [
     "protected-access",              # is checked by ruff (SLF001)
     "invalid-name",                  # is checked by ruff (N)
     "missing-docstring",             # is checked by ruff (D)
+    "redefined-outer-name",          # false positives for pytest fixtures
 ]
 
 [tool.pytest.ini_options]

--- a/src/fava/cli.py
+++ b/src/fava/cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import errno
+import logging
 import os
 from pathlib import Path
 
@@ -144,6 +145,7 @@ def main(
                 raise AddressInUse(port) from error
             raise click.Abort from error
     else:
+        logging.getLogger("fava").setLevel(logging.DEBUG)
         if profile:
             app.wsgi_app = ProfilerMiddleware(  # type: ignore[method-assign]
                 app.wsgi_app,

--- a/src/fava/core/__init__.py
+++ b/src/fava/core/__init__.py
@@ -185,7 +185,6 @@ class FavaLedger:
 
     __slots__ = (
         "_is_encrypted",
-        "_watcher",
         "accounts",
         "accounts",
         "all_entries",
@@ -205,6 +204,7 @@ class FavaLedger:
         "options",
         "prices",
         "query_shell",
+        "watcher",
     )
 
     #: List of all (unfiltered) entries.
@@ -263,7 +263,7 @@ class FavaLedger:
         #: A :class:`.AccountDict` module - details about the accounts.
         self.accounts = AccountDict(self)
 
-        self._watcher = Watcher()
+        self.watcher = Watcher()
 
         self.load_file()
 
@@ -294,7 +294,7 @@ class FavaLedger:
         self.errors.extend(errors)
 
         if not self._is_encrypted:
-            self._watcher.update(*self.paths_to_watch())
+            self.watcher.update(*self.paths_to_watch())
 
         # Call load_file of all modules.
         self.accounts.load_file()
@@ -329,7 +329,7 @@ class FavaLedger:
     @property
     def mtime(self) -> int:
         """The timestamp to the latest change of the underlying files."""
-        return self._watcher.last_checked
+        return self.watcher.last_checked
 
     @property
     def root_accounts(self) -> tuple[str, str, str, str, str]:
@@ -375,7 +375,7 @@ class FavaLedger:
         # We can't reload an encrypted file, so act like it never changes.
         if self._is_encrypted:
             return False
-        changed = self._watcher.check()
+        changed = self.watcher.check()
         if changed:
             self.load_file()
         return changed

--- a/src/fava/core/watcher.py
+++ b/src/fava/core/watcher.py
@@ -2,12 +2,61 @@
 
 from __future__ import annotations
 
+import abc
+import logging
 from os import walk
 from pathlib import Path
+from time import time_ns
 from typing import Iterable
 
+log = logging.getLogger(__name__)
 
-class Watcher:
+
+class WatcherBase(abc.ABC):
+    """ABC for Fava ledger file watchers."""
+
+    last_checked: int
+    """Timestamp of the latest change noticed by the file watcher."""
+
+    last_notified: int
+    """Timestamp of the latest change that the watcher was notified of."""
+
+    @abc.abstractmethod
+    def update(self, files: Iterable[Path], folders: Iterable[Path]) -> None:
+        """Update the folders/files to watch.
+
+        Args:
+            files: A list of file paths.
+            folders: A list of paths to folders.
+        """
+
+    def check(self) -> bool:
+        """Check for changes.
+
+        Returns:
+            `True` if there was a file change in one of the files or folders,
+            `False` otherwise.
+        """
+        latest_mtime = max(self._get_latest_mtime(), self.last_notified)
+        has_higher_mtime = latest_mtime > self.last_checked
+        if has_higher_mtime:
+            self.last_checked = latest_mtime
+        return has_higher_mtime
+
+    def notify(self, path: Path) -> None:
+        """Notify the watcher of a change to a path."""
+        try:
+            change_mtime = Path(path).stat().st_mtime_ns
+        except FileNotFoundError:
+            change_mtime = time_ns()
+        self.last_notified = max(self.last_notified, change_mtime)
+
+    @abc.abstractmethod
+    def _get_latest_mtime(self) -> int:
+        """Get the latest change mtime."""
+
+
+class Watcher(WatcherBase):
     """A simple file and folder watcher.
 
     For folders, only checks mtime of the folder and all subdirectories.
@@ -17,42 +66,26 @@ class Watcher:
     __slots__ = ("_files", "_folders", "last_checked")
 
     def __init__(self) -> None:
+        self.last_checked = 0
+        self.last_notified = 0
         self._files: list[Path] = []
         self._folders: list[Path] = []
-        self.last_checked = 0
 
     def update(self, files: Iterable[Path], folders: Iterable[Path]) -> None:
-        """Update the folders/files to watch.
-
-        Args:
-            files: A list of file paths.
-            folders: A list of paths to folders.
-        """
+        """Update the folders/files to watch."""
         self._files = list(files)
         self._folders = list(folders)
         self.check()
 
-    def check(self) -> bool:
-        """Check for changes.
-
-        Returns:
-            `True` if there was a file change in one of the files or folders,
-            `False` otherwise.
-        """
-        latest_mtime = 0
+    def _mtimes(self) -> Iterable[int]:
         for path in self._files:
             try:
-                mtime = path.stat().st_mtime_ns
+                yield path.stat().st_mtime_ns
             except FileNotFoundError:
-                return True
-            if mtime > latest_mtime:
-                latest_mtime = mtime
+                yield time_ns()
         for path in self._folders:
             for dirpath, _, _ in walk(path):
-                mtime = Path(dirpath).stat().st_mtime_ns
-                if mtime > latest_mtime:
-                    latest_mtime = mtime
+                yield Path(dirpath).stat().st_mtime_ns
 
-        changed = bool(latest_mtime != self.last_checked)
-        self.last_checked = latest_mtime
-        return changed
+    def _get_latest_mtime(self) -> int:
+        return max(self._mtimes())

--- a/tests/__snapshots__/test_core_file-test_render_entries
+++ b/tests/__snapshots__/test_core_file-test_render_entries
@@ -1,10 +1,11 @@
-2016-04-09 * "Uncle Boons" "" #trip-new-york-2016
-  Liabilities:US:Chase:Slate                       -52.22 USD
-  Expenses:Food:Restaurant                          52.22 USD
+2012-12-12 * "Payee" "Narration"
+    document: "file.pdf"
+    Expenses:Food                    10.00 EUR
+    Assets:Account1                 -10.00 EUR
 
-2016-05-04 * "BANK FEES" "Monthly bank fee"
-  Assets:US:BofA:Checking                           -4.00 USD
-  Expenses:Financial:Fees                            4.00 USD
+2012-12-13 * "Payee" "Narration"
+    ! Expenses:Food                  10.00 EUR
+    Assets:Account1                 -10.00 EUR
 
 2016-01-01 * "new payee" "narr"
   Expenses:Food                                       10.00 USD

--- a/tests/__snapshots__/test_json_api-test_api_imports.json
+++ b/tests/__snapshots__/test_json_api-test_api_imports.json
@@ -1,5 +1,10 @@
 [
   {
+    "basename": "edit-example.beancount",
+    "importers": [],
+    "name": "TEST_DATA_DIR/edit-example.beancount"
+  },
+  {
     "basename": "errors.beancount",
     "importers": [],
     "name": "TEST_DATA_DIR/errors.beancount"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import os
 import re
+import shutil
 from pathlib import Path
 from pprint import pformat
 from textwrap import dedent
@@ -173,6 +174,17 @@ def app(test_data_dir: Path) -> Flask:
         ],
         load=True,
     )
+    fava_app.testing = True
+    return fava_app
+
+
+@pytest.fixture()
+def app_in_tmp_dir(test_data_dir: Path, tmp_path: Path) -> Flask:
+    """Get a Fava Flask app in a tmp_dir."""
+    ledger_path = tmp_path / "edit-example.beancount"
+    shutil.copy(test_data_dir / "edit-example.beancount", ledger_path)
+    ledger_path.chmod(tmp_path.stat().st_mode)
+    fava_app = create_app([str(ledger_path)], load=True)
     fava_app.testing = True
     return fava_app
 

--- a/tests/data/edit-example.beancount
+++ b/tests/data/edit-example.beancount
@@ -1,0 +1,23 @@
+option "title" "Edit Example"
+option "operating_currency" "USD"
+plugin "beancount.plugins.auto_accounts"
+
+2014-01-04 * "Kin Soy" "Eating out with Sue"
+  Liabilities:US:Chase:Slate                       -38.48 USD
+  Expenses:Food:Restaurant                          38.48 USD
+
+2014-01-08 * "Chichipotle" "Eating out with Dan"
+  Liabilities:US:Chase:Slate                       -23.57 USD
+  Expenses:Food:Restaurant                          23.57 USD
+
+2014-01-10 * "Corner Deli" "Buying groceries"
+  Liabilities:US:Chase:Slate                       -73.28 USD
+  Expenses:Food:Groceries                           73.28 USD
+
+2014-01-11 * "Goba Goba" "Eating out with Bob"
+  Liabilities:US:Chase:Slate                       -30.94 USD
+  Expenses:Food:Restaurant                          30.94 USD
+
+2016-05-03 * "Chichipotle" "Eating out with Joe"
+  Liabilities:US:Chase:Slate                       -21.70 USD
+  Expenses:Food:Restaurant                          21.70 USD

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -190,7 +190,7 @@ def test_incognito(test_data_dir: Path) -> None:
     """Numbers get obfuscated in incognito mode."""
     app = create_app([test_data_dir / "example.beancount"], incognito=True)
     test_client = app.test_client()
-    result = test_client.get("/example/balance_sheet/")
+    result = test_client.get("/example/journal/")
     assert result.status_code == 200
     assert "XXX" in result.get_data(as_text=True)
 

--- a/tests/test_core_watcher.py
+++ b/tests/test_core_watcher.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 import time
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
+
+import pytest
 
 from fava.core.watcher import Watcher
 
@@ -9,48 +12,56 @@ if TYPE_CHECKING:  # pragma: no cover
     from pathlib import Path
 
 
-def test_watcher_file(tmp_path: Path) -> None:
+@dataclass
+class WatcherTestSet:
+    tmp_path: Path
+    file1: Path
+    file2: Path
+    folder: Path
+
+
+@pytest.fixture()
+def watcher_paths(tmp_path: Path) -> WatcherTestSet:
     file1 = tmp_path / "file1"
     file2 = tmp_path / "file2"
     file1.write_text("test")
     file2.write_text("test")
-
-    watcher = Watcher()
-    watcher.update([file1, file2], [])
-    assert not watcher.check()
-
-    # time.time is too precise
-    time.sleep(0.05)
-
-    file1.write_text("test2")
-
-    assert watcher.check()
-
-
-def test_watcher_deleted_file(tmp_path: Path) -> None:
-    file1 = tmp_path / "file1"
-    file1.write_text("test")
-
-    watcher = Watcher()
-    watcher.update([file1], [])
-    assert not watcher.check()
-
-    file1.unlink()
-    assert watcher.check()
-
-
-def test_watcher_folder(tmp_path: Path) -> None:
     folder = tmp_path / "folder"
     folder.mkdir()
-    (folder / "bar").mkdir()
+    return WatcherTestSet(
+        tmp_path=tmp_path, file1=file1, file2=file2, folder=folder
+    )
+
+
+def test_watcher_file(watcher_paths: WatcherTestSet) -> None:
+    watcher = Watcher()
+    watcher.update([watcher_paths.file1, watcher_paths.file2], [])
+    assert not watcher.check()
+    time.sleep(0.005)
+    watcher_paths.file1.write_text("test2")
+    assert watcher.check()
+
+
+def test_watcher_deleted_file(watcher_paths: WatcherTestSet) -> None:
+    watcher = Watcher()
+    watcher.update([watcher_paths.file1], [])
+    assert not watcher.check()
+    watcher_paths.file1.unlink()
+
+    time.sleep(0.005)
+    assert watcher.check()
+
+
+def test_watcher_folder(watcher_paths: WatcherTestSet) -> None:
+    (watcher_paths.folder / "bar").mkdir()
 
     watcher = Watcher()
-    watcher.update([], [folder])
+    watcher.update([], [watcher_paths.folder])
     assert not watcher.check()
 
     # time.time is too precise
-    time.sleep(0.05)
+    time.sleep(0.005)
 
-    (folder / "bar2").mkdir()
+    (watcher_paths.folder / "bar2").mkdir()
 
     assert watcher.check()


### PR DESCRIPTION
Improve some of the fava.core.file tests and only write to ledgers in
tmp_paths explicitly created for tests to avoid flakiness related to
that.

Also refactor the Watcher API to prepare for the watchfiles based file
watcher. Since these file change events are asynchronous, a method to
notify the file watcher of file changes that we trigger (all in
fava.core.file) is also added.

Fixes #1290
<!--
Hi, thank you for opening a PR!

Please ensure that your change passes tests and the various linters by running
`make test` and `make lint`. If testable, your changes should be covered by
unit tests.

Explain your changes below and link to related issues.
-->
