### PR TITLE
Remove price directive when deciding start date

### DIFF
--- a/src/fava/core/__init__.py
+++ b/src/fava/core/__init__.py
@@ -109,7 +109,7 @@ class FilteredLedger:
         self._date_first = None
         self._date_last = None
         for entry in self.entries:
-            if isinstance(entry, (Transaction,)):
+            if isinstance(entry, Transaction):
                 self._date_first = entry.date
                 break
         for entry in reversed(self.entries):

--- a/src/fava/core/__init__.py
+++ b/src/fava/core/__init__.py
@@ -109,7 +109,7 @@ class FilteredLedger:
         self._date_first = None
         self._date_last = None
         for entry in self.entries:
-            if isinstance(entry, (Transaction, Price)):
+            if isinstance(entry, (Transaction,)):
                 self._date_first = entry.date
                 break
         for entry in reversed(self.entries):


### PR DESCRIPTION
The present implementation shows a large empty plot before the first transaction. This PR corrects it.

Fixes #1754.
