### PR TITLE
Automatically add posting field when last posting is non-empty

### DIFF
--- a/frontend/src/entry-forms/Posting.svelte
+++ b/frontend/src/entry-forms/Posting.svelte
@@ -14,7 +14,6 @@
   export let date: string | undefined;
   export let move: (arg: { from: number; to: number }) => void;
   export let remove: () => void;
-  export let add: () => void;
 
   $: amount_number = posting.amount.replace(/[^\-?0-9.]/g, "");
   $: amountSuggestions = $currencies.map((c) => `${amount_number} ${c}`);
@@ -79,14 +78,6 @@
     bind:value={posting.amount}
   />
   <AddMetadataButton bind:meta={posting.meta} />
-  <button
-    type="button"
-    class="muted round add-row"
-    on:click={add}
-    title={_("Add posting")}
-  >
-    +
-  </button>
   <EntryMetadata bind:meta={posting.meta} />
 </div>
 
@@ -104,12 +95,8 @@
     cursor: initial;
   }
 
-  div .add-row {
-    display: none;
-  }
-
-  div:last-child .add-row {
-    display: initial;
+  div:last-child .remove-row {
+    visibility: hidden;
   }
 
   div :global(.amount) {

--- a/frontend/src/entry-forms/Transaction.svelte
+++ b/frontend/src/entry-forms/Transaction.svelte
@@ -91,6 +91,17 @@
       entry.postings = entry.postings;
     }
   }
+
+  $: {
+    const isEmpty = (posting: Posting | undefined) =>
+      posting !== undefined &&
+      posting.account.length === 0 &&
+      posting.amount.length === 0 &&
+      Object.keys(posting.meta).length === 0;
+    if (!isEmpty(entry.postings.at(entry.postings.length - 1))) {
+      addPosting();
+    }
+  }
 </script>
 
 <div>

--- a/frontend/src/entry-forms/Transaction.svelte
+++ b/frontend/src/entry-forms/Transaction.svelte
@@ -119,15 +119,6 @@
       />
       <AddMetadataButton bind:meta={entry.meta} />
     </label>
-    <button
-      type="button"
-      class="muted round"
-      on:click={addPosting}
-      title={_("Add posting")}
-      tabindex={-1}
-    >
-      p
-    </button>
   </div>
   <EntryMetadata bind:meta={entry.meta} />
   <div class="flex-row">
@@ -139,7 +130,6 @@
       {index}
       {suggestions}
       date={entry.date}
-      add={addPosting}
       move={movePosting}
       remove={() => {
         removePosting(posting);


### PR DESCRIPTION
This commit checks if information has been added to the last posting
when entering a transaction and adds an empty posting in this case.

I've run make check and make lint, but I'm not a typescript/svelte developer so please check the changes.

Partially fixes #1477. 