### PR TITLE
 Automatically add posting field when last posting is non-empty

### DIFF
--- a/frontend/src/entries.ts
+++ b/frontend/src/entries.ts
@@ -204,7 +204,7 @@ export class Transaction extends EntryBase {
     this.narration = "";
     this.tags = [];
     this.links = [];
-    this.postings = [emptyPosting(), emptyPosting()];
+    this.postings = [emptyPosting()];
   }
 
   toString(): string {

--- a/frontend/src/entries.ts
+++ b/frontend/src/entries.ts
@@ -13,12 +13,6 @@ import {
   union,
 } from "./lib/validation";
 
-export interface Posting {
-  account: string;
-  amount: string;
-  meta: EntryMetadata;
-}
-
 const entry_meta_validator = record(
   defaultValue(
     union(boolean, number, string),
@@ -26,27 +20,37 @@ const entry_meta_validator = record(
   ),
 );
 
-const postingValidator = object({
-  account: string,
-  amount: string,
-  meta: defaultValue(entry_meta_validator, () => ({})),
-});
+/** A posting. */
+export class Posting {
+  account: string;
+  amount: string;
+  meta: EntryMetadata;
+
+  constructor() {
+    this.account = "";
+    this.amount = "";
+    this.meta = {};
+  }
+
+  is_empty(): boolean {
+    return !this.account && !this.amount && is_empty(this.meta);
+  }
+
+  private static raw_validator = object({
+    account: string,
+    amount: string,
+    meta: defaultValue(entry_meta_validator, () => ({})),
+  });
+
+  static validator: Validator<Posting> = (json) =>
+    Posting.raw_validator(json).map((value) =>
+      Object.assign(new Posting(), value),
+    );
+}
 
 interface Amount {
   number: string;
   currency: string;
-}
-
-export function emptyPosting(): Posting {
-  return {
-    account: "",
-    amount: "",
-    meta: {},
-  };
-}
-
-export function isEmptyPosting(posting: Posting): boolean {
-  return !posting.account && !posting.amount && is_empty(posting.meta);
 }
 
 export type EntryMetadata = Record<string, string | boolean | number>;
@@ -223,7 +227,7 @@ export class Transaction extends EntryBase {
   toJSON(): this {
     return {
       ...this,
-      postings: this.postings.filter((p) => !isEmptyPosting(p)),
+      postings: this.postings.filter((p) => !p.is_empty()),
     };
   }
 
@@ -237,7 +241,7 @@ export class Transaction extends EntryBase {
     narration: optional_string,
     tags: array(string),
     links: array(string),
-    postings: array(postingValidator),
+    postings: array(Posting.validator),
   });
 
   static validator: Validator<Transaction> = (json) =>

--- a/frontend/src/entries.ts
+++ b/frontend/src/entries.ts
@@ -1,3 +1,4 @@
+import { is_empty } from "./lib/objects";
 import type { Validator } from "./lib/validation";
 import {
   array,
@@ -42,6 +43,10 @@ export function emptyPosting(): Posting {
     amount: "",
     meta: {},
   };
+}
+
+export function isEmptyPosting(posting: Posting): boolean {
+  return !posting.account && !posting.amount && is_empty(posting.meta);
 }
 
 export type EntryMetadata = Record<string, string | boolean | number>;
@@ -204,7 +209,7 @@ export class Transaction extends EntryBase {
     this.narration = "";
     this.tags = [];
     this.links = [];
-    this.postings = [emptyPosting()];
+    this.postings = [];
   }
 
   toString(): string {
@@ -215,7 +220,16 @@ export class Transaction extends EntryBase {
     );
   }
 
-  private static raw_validator = object<Omit<Transaction, "toString">>({
+  toJSON(): this {
+    return {
+      ...this,
+      postings: this.postings.filter((p) => !isEmptyPosting(p)),
+    };
+  }
+
+  private static raw_validator = object<
+    Omit<Transaction, "toString" | "toJSON">
+  >({
     ...validatorBase,
     t: constant("Transaction"),
     flag: string,

--- a/frontend/src/entry-forms/AccountInput.svelte
+++ b/frontend/src/entry-forms/AccountInput.svelte
@@ -15,7 +15,7 @@
   export let className: string | undefined = undefined;
 
   $: checkValidity = (val: string) =>
-    !$accounts.length || $accounts.includes(val) || val.length === 0
+    !$accounts.length || $accounts.includes(val) || !val
       ? ""
       : _("Should be one of the declared accounts");
 

--- a/frontend/src/entry-forms/AccountInput.svelte
+++ b/frontend/src/entry-forms/AccountInput.svelte
@@ -15,7 +15,7 @@
   export let className: string | undefined = undefined;
 
   $: checkValidity = (val: string) =>
-    !$accounts.length || $accounts.includes(val)
+    !$accounts.length || $accounts.includes(val) || val.length === 0
       ? ""
       : _("Should be one of the declared accounts");
 

--- a/frontend/src/entry-forms/Posting.svelte
+++ b/frontend/src/entry-forms/Posting.svelte
@@ -14,7 +14,6 @@
   export let date: string | undefined;
   export let move: (arg: { from: number; to: number }) => void;
   export let remove: () => void;
-  export let add: () => void;
 
   $: amount_number = posting.amount.replace(/[^\-?0-9.]/g, "");
   $: amountSuggestions = $currencies.map((c) => `${amount_number} ${c}`);
@@ -79,14 +78,6 @@
     bind:value={posting.amount}
   />
   <AddMetadataButton bind:meta={posting.meta} />
-  <button
-    type="button"
-    class="muted round add-row"
-    on:click={add}
-    title={_("Add posting")}
-  >
-    +
-  </button>
   <EntryMetadata bind:meta={posting.meta} />
 </div>
 
@@ -104,12 +95,8 @@
     cursor: initial;
   }
 
-  div .add-row {
-    display: none;
-  }
-
-  div:last-child .add-row {
-    display: initial;
+  div:last-child .remove-row {
+    visibility: hidden;
   }
 
   div :global(.amount) {

--- a/frontend/src/entry-forms/Posting.svelte
+++ b/frontend/src/entry-forms/Posting.svelte
@@ -103,10 +103,6 @@
     width: 220px;
   }
 
-  div:last-child :global(.amount) {
-    width: 192px;
-  }
-
   @media (width <= 767px) {
     div {
       padding-left: 0;

--- a/frontend/src/entry-forms/Transaction.svelte
+++ b/frontend/src/entry-forms/Transaction.svelte
@@ -91,6 +91,17 @@
       entry.postings = entry.postings;
     }
   }
+
+  $: {
+    const isEmpty = (posting: Posting | undefined) =>
+      posting !== undefined &&
+      posting.account.length === 0 &&
+      posting.amount.length === 0 &&
+      Object.keys(posting.meta).length === 0;
+    if (!isEmpty(entry.postings.at(entry.postings.length - 1))) {
+      addPosting();
+    }
+  }
 </script>
 
 <div>

--- a/frontend/src/entry-forms/Transaction.svelte
+++ b/frontend/src/entry-forms/Transaction.svelte
@@ -6,7 +6,7 @@
 <script lang="ts">
   import { get } from "../api";
   import AutocompleteInput from "../AutocompleteInput.svelte";
-  import { emptyPosting } from "../entries";
+  import { emptyPosting, isEmptyPosting } from "../entries";
   import type { Posting, Transaction } from "../entries";
   import { _ } from "../i18n";
   import { notify_err } from "../notifications";
@@ -21,10 +21,6 @@
 
   function removePosting(posting: Posting) {
     entry.postings = entry.postings.filter((p) => p !== posting);
-  }
-
-  function addPosting() {
-    entry.postings = entry.postings.concat(emptyPosting());
   }
 
   $: payee = entry.payee;
@@ -92,15 +88,9 @@
     }
   }
 
-  $: {
-    const isEmpty = (posting: Posting | undefined) =>
-      posting !== undefined &&
-      posting.account.length === 0 &&
-      posting.amount.length === 0 &&
-      Object.keys(posting.meta).length === 0;
-    if (!isEmpty(entry.postings.at(entry.postings.length - 1))) {
-      addPosting();
-    }
+  // Always have one empty posting at the end.
+  $: if (!entry.postings.some(isEmptyPosting)) {
+    entry.postings = entry.postings.concat(emptyPosting());
   }
 </script>
 

--- a/frontend/src/entry-forms/Transaction.svelte
+++ b/frontend/src/entry-forms/Transaction.svelte
@@ -119,15 +119,6 @@
       />
       <AddMetadataButton bind:meta={entry.meta} />
     </label>
-    <button
-      type="button"
-      class="muted round"
-      on:click={addPosting}
-      title={_("Add posting")}
-      tabindex={-1}
-    >
-      p
-    </button>
   </div>
   <EntryMetadata bind:meta={entry.meta} />
   <div class="flex-row">
@@ -139,7 +130,6 @@
       {index}
       {suggestions}
       date={entry.date}
-      add={addPosting}
       move={movePosting}
       remove={() => {
         removePosting(posting);

--- a/frontend/src/entry-forms/Transaction.svelte
+++ b/frontend/src/entry-forms/Transaction.svelte
@@ -6,8 +6,8 @@
 <script lang="ts">
   import { get } from "../api";
   import AutocompleteInput from "../AutocompleteInput.svelte";
-  import { emptyPosting, isEmptyPosting } from "../entries";
-  import type { Posting, Transaction } from "../entries";
+  import { Posting } from "../entries";
+  import type { Transaction } from "../entries";
   import { _ } from "../i18n";
   import { notify_err } from "../notifications";
   import { payees } from "../stores";
@@ -89,8 +89,8 @@
   }
 
   // Always have one empty posting at the end.
-  $: if (!entry.postings.some(isEmptyPosting)) {
-    entry.postings = entry.postings.concat(emptyPosting());
+  $: if (!entry.postings.some((p) => p.is_empty())) {
+    entry.postings = entry.postings.concat(new Posting());
   }
 </script>
 


### PR DESCRIPTION
This commit checks if information has been added to the last posting
when entering a transaction and adds an empty posting in this case.

I've run make test and make lint, but I'm not a typescript/svelte
developer so please check the changes.

I've divided the commits such that one adds the automatic posting part,
another removes the + and the p buttons since they seem to be useless
now, and another removes the default value of two postings. Feel free to
discard any ones if you want to keep the functionality.

Note that adding the automatic posting part also removes the 
'Allow entry to be empty' commit to work.

Also, it seems redundant to have both the p button and the + button.


Partially fixes https://github.com/beancount/fava/issues/1477.