### PR TITLE
_build_backend: add build_wheel

### DIFF
--- a/_build_backend.py
+++ b/_build_backend.py
@@ -64,6 +64,20 @@ def _compile_translations() -> None:
             write_mo(target.open("wb"), catalog)
 
 
+def build_wheel(  # type: ignore[no-redef]
+    wheel_directory: str,
+    config_settings: dict[str, str] | None = None,
+    metadata_directory: str | None = None,
+) -> str:
+    _compile_frontend()
+    _compile_translations()
+    return _build_meta_orig.build_wheel(
+        wheel_directory,
+        config_settings=config_settings,
+        metadata_directory=metadata_directory,
+    )
+
+
 def build_sdist(  # type: ignore[no-redef]
     sdist_directory: str,
     config_settings: dict[str, str] | None = None,


### PR DESCRIPTION
For direct wheel builds, the frontend code might not get built
otherwise if the build tool decides to create the wheel directly.

<!--
Hi, thank you for opening a PR!

Please ensure that your change passes tests and the various linters by running
`make test` and `make lint`. If testable, your changes should be covered by
unit tests.

Explain your changes below and link to related issues.
-->
