### PR TITLE
Sort accounts store.

### DIFF
--- a/frontend/src/stores/index.ts
+++ b/frontend/src/stores/index.ts
@@ -47,7 +47,7 @@ export const base_url = derived(ledgerData, (v) => v.base_url);
 export const extensions = derived(ledgerData, (v) => v.extensions);
 
 /** The ranked array of all accounts. */
-export const accounts = derived_array(ledgerData, (v) => v.accounts);
+export const accounts = derived_array(ledgerData, (v) => v.accounts.sort());
 
 /** Get the name (as given per metadata) of a currency. */
 export const currency_name = derived(


### PR DESCRIPTION
With this change, the accounts autocomplete (both in the sidebar and entry form) shows a sorted list of accounts.

I don't have a ton of experience with TS/Svelte so any pointers would be appreciated. Specifically, I don't know if it makes a difference whether sorting accounts, which is already a derived store, should be done (a) in place, (b) on a copy, or (c) upstream of the accounts store (maybe in the ledgerData store?). If you have thoughts, let me know, I'm happy to dive more into the Svelte docs and push a different solution.

This should fix  #1773