### PR TITLE
Continue to watch files that are replaced.

### DIFF
--- a/constraints-old.txt
+++ b/constraints-old.txt
@@ -115,6 +115,6 @@ uritemplate==4.1.1
     # via google-api-python-client
 urllib3==2.2.1
     # via requests
-watchfiles==0.19.0
+watchfiles==0.20.0
 werkzeug==2.2.0
     # via flask

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
     "markdown2>=2.3.0,<3",
     "ply",
     "simplejson>=3.16.0,<4",
-    "watchfiles>=0.19.0",
+    "watchfiles>=0.20.0",
 ]
 
 [project.urls]

--- a/tests/test_core_watcher.py
+++ b/tests/test_core_watcher.py
@@ -131,7 +131,7 @@ def test_watchfiles_watcher_recognises_change_to_previously_deleted_file(
         # Recreate deleted file
         # sleep to ensure file stamp is greater than time_ns() taken on
         #  previous FileNotFoundError
-        time.sleep(0.25)
+        time.sleep(0.005)
         watcher_paths.file1.write_text("test-value-2")
         assert _watcher_check_within_one_second(watcher)
         assert not watcher.check()

--- a/tests/test_core_watcher.py
+++ b/tests/test_core_watcher.py
@@ -131,7 +131,7 @@ def test_watchfiles_watcher_recognises_change_to_previously_deleted_file(
         # Recreate deleted file
         # sleep to ensure file stamp is greater than time_ns() taken on
         #  previous FileNotFoundError
-        time.sleep(0.005)
+        time.sleep(0.01)
         watcher_paths.file1.write_text("test-value-2")
         assert _watcher_check_within_one_second(watcher)
         assert not watcher.check()


### PR DESCRIPTION
Fix for #1778.

Continue to watch files are replaced, such as by saving in vi, by watching the parent directory instead. This moves more logic into the watcher, and is the fix suggested in https://github.com/samuelcolvin/watchfiles/issues/235#issuecomment-1633622058 . To preserve the existing behaviour for directory watching, the watch remains recursive.