### PR TITLE
change detection: fix for multiple clients/tabs

### DIFF
--- a/frontend/src/stores/mtime.ts
+++ b/frontend/src/stores/mtime.ts
@@ -14,7 +14,7 @@ export const ledger_mtime: Readable<bigint> = ledger_mtime_writable;
 export function set_mtime(text: string): void {
   const new_value = text.startsWith("X")
     ? // the timestamp is replaced by a sequence of `X` in incognito mode.
-      BigInt(Date.now())
+      BigInt(text.replaceAll("X", "1"))
     : BigInt(text);
   ledger_mtime_writable.update((v) => (new_value > v ? new_value : v));
 }


### PR DESCRIPTION
When multiple clients have Fava open, only the first one would
previously be informed about the change, since the ledger would only
reload once and return true in that request.

Use the mtime instead which is sent with every response to determine in
the client whether a change has happened

<!--
Hi, thank you for opening a PR!

Please ensure that your change passes tests and the various linters by running
`make test` and `make lint`. If testable, your changes should be covered by
unit tests.

Explain your changes below and link to related issues.
-->
