### PR TITLE
watcher: separate threads for file and folder watching

### DIFF
--- a/src/fava/core/watcher.py
+++ b/src/fava/core/watcher.py
@@ -11,10 +11,12 @@ from pathlib import Path
 from typing import Iterable
 from typing import TYPE_CHECKING
 
+from watchfiles import DefaultFilter
 from watchfiles import watch
 
 if TYPE_CHECKING:  # pragma: no cover
     import types
+    from typing import Callable
 
     from watchfiles.main import Change
 
@@ -23,33 +25,40 @@ log = logging.getLogger(__name__)
 
 
 class _WatchfilesThread(threading.Thread):
+    """Class for the watchfiles watcher threads.
+
+    We use two separated threads since we want to recursively watch directories
+    and for paths, we need to watch the parent directory (to check changes done
+    by file replacements by some editors) non-recursively (for performance).
+    """
+
     def __init__(
-        self, files: list[Path], folders: list[Path], mtime: int
+        self,
+        paths: set[Path],
+        mtime: int,
+        *,
+        is_relevant: Callable[[Change, str], bool] | None = None,
+        recursive: bool = False,
     ) -> None:
         super().__init__(daemon=True)
-        self._stop_event = threading.Event()
+        self.paths = paths
         self.mtime = mtime
-        self._file_set = {f.absolute() for f in files}
-        self._folder_set = {f.absolute() for f in folders}
+        self._is_relevant = is_relevant or DefaultFilter()
+        self._recursive = recursive
+        self._stop_event = threading.Event()
 
     def stop(self) -> None:
         """Set the stop event for watchfiles and join the thread."""
         self._stop_event.set()
         self.join()
 
-    def _is_relevant(self, _c: Change, path: str) -> bool:
-        return Path(path) in self._file_set or any(
-            Path(path).is_relative_to(d) for d in self._folder_set
-        )
-
     def run(self) -> None:
         """Watch for changes."""
         atexit.register(self.stop)
 
-        watch_paths = {f.parent for f in self._file_set} | self._folder_set
-
         for changes in watch(
-            *watch_paths,
+            *self.paths,
+            recursive=self._recursive,
             stop_event=self._stop_event,
             ignore_permission_denied=True,
             watch_filter=self._is_relevant,
@@ -63,6 +72,18 @@ class _WatchfilesThread(threading.Thread):
                     change_mtime = self.mtime + 1
                 self.mtime = max(change_mtime, self.mtime)
             log.debug("new mtime: %s", self.mtime)
+
+
+class _FilesWatchfilesThread(_WatchfilesThread):
+    def __init__(self, files: set[Path], mtime: int) -> None:
+        paths = {f.parent for f in files}
+
+        def is_relevant(_c: Change, path: str) -> bool:
+            return Path(path) in files
+
+        super().__init__(
+            paths, mtime, is_relevant=is_relevant, recursive=False
+        )
 
 
 class WatcherBase(abc.ABC):
@@ -115,24 +136,29 @@ class WatchfilesWatcher(WatcherBase):
     def __init__(self) -> None:
         self.last_checked = 0
         self.last_notified = 0
-        self._paths: tuple[list[Path], list[Path]] = ([], [])
-        self._thread: _WatchfilesThread | None = None
+        self._paths: tuple[set[Path], set[Path]] | None = None
+        self._watchers: tuple[_WatchfilesThread, _WatchfilesThread] | None = (
+            None
+        )
 
     def update(self, files: Iterable[Path], folders: Iterable[Path]) -> None:
         """Update the folders/files to watch."""
-        existing_files = [p for p in files if p.exists()]
-        existing_folders = [p for p in folders if p.is_dir()]
-        new_paths = (existing_files, existing_folders)
-        if self._thread and new_paths == self._paths:
+        files_set = {p.absolute() for p in files if p.exists()}
+        folders_set = {p.absolute() for p in folders if p.is_dir()}
+        new_paths = (files_set, folders_set)
+        if self._watchers and new_paths == self._paths:
             self.check()
             return
         self._paths = new_paths
-        if self._thread is not None:
-            self._thread.stop()
-        self._thread = _WatchfilesThread(
-            existing_files, existing_folders, self.last_checked
+        if self._watchers:
+            self._watchers[0].stop()
+            self._watchers[1].stop()
+        self._watchers = (
+            _FilesWatchfilesThread(files_set, self.last_checked),
+            _WatchfilesThread(folders_set, self.last_checked, recursive=True),
         )
-        self._thread.start()
+        self._watchers[0].start()
+        self._watchers[1].start()
         self.check()
 
     def __enter__(self) -> None:
@@ -144,11 +170,16 @@ class WatchfilesWatcher(WatcherBase):
         exc_value: BaseException | None,
         traceback: types.TracebackType | None,
     ) -> None:
-        if self._thread:
-            self._thread.stop()
+        if self._watchers:
+            self._watchers[0].stop()
+            self._watchers[1].stop()
 
     def _get_latest_mtime(self) -> int:
-        return self._thread.mtime if self._thread else 0
+        return (
+            max(self._watchers[0].mtime, self._watchers[1].mtime)
+            if self._watchers
+            else 0
+        )
 
 
 class Watcher(WatcherBase):


### PR DESCRIPTION
Fix #1792 
<!--
Hi, thank you for opening a PR!

Please ensure that your change passes tests and the various linters by running
`make test` and `make lint`. If testable, your changes should be covered by
unit tests.

Explain your changes below and link to related issues.
-->
