### PR TITLE
fix: make the link drop feature actually work

### DIFF
--- a/frontend/src/document-upload.ts
+++ b/frontend/src/document-upload.ts
@@ -20,7 +20,7 @@ import { notify, notify_err } from "./notifications";
  */
 function dragover(event: DragEvent, closestTarget: HTMLElement): void {
   if (
-    event.dataTransfer?.types.includes("Files") ??
+    event.dataTransfer?.types.includes("Files") || // eslint-disable-line @typescript-eslint/prefer-nullish-coalescing
     event.dataTransfer?.types.includes("text/uri-list")
   ) {
     closestTarget.classList.add("dragover");


### PR DESCRIPTION
<!--
Hi, thank you for opening a PR!

Please ensure that your change passes tests and the various linters by running
`make test` and `make lint`. If testable, your changes should be covered by
unit tests.

Explain your changes below and link to related issues.
-->
This was really all it took to make the feature fork.

- Tested this change via live editing in ChromeDebugger
- Confirmed it worked: dragging a (discovered) doc over a TX now added the `document` meta as expected


~~EDIT: although maybe, it shouldn't be an absolute path (only unique on the local machine)?~~ It works: _just needed to take care to drop on the **correct** (same account) posting leg_.


**Recalling the Use Case:**

- User knows how to put PDFs into account-wise folders
- Accountant knows how to book bank statements
- Accountant needs an easy way to link neighboring documents to the transactions [this feature fixed]
- Uploading has disadvantages:
  - Uploading from an input folder doesn't erase the document ("what did I already assign?" is harder to track)
  - A cognizant user can do a best-effort pre-classification for the accountant which is in any case conductive to efficiency