### PR TITLE
add toggle to include zero in line charts

### DIFF
--- a/frontend/src/charts/Chart.svelte
+++ b/frontend/src/charts/Chart.svelte
@@ -5,6 +5,7 @@
     barChartMode,
     chartToggledCurrencies,
     hierarchyChartMode,
+    includeZeroToggle,
     lineChartMode,
     showCharts,
     treemapCurrency,
@@ -48,6 +49,15 @@
     {#if chart.type === "hierarchy"}
       <ModeSwitch store={hierarchyChartMode} />
     {:else if chart.type === "linechart"}
+      <button
+        type="button"
+        class:muted={!$includeZeroToggle}
+        on:click={() => {
+          includeZeroToggle.update((v) => !v);
+        }}
+      >
+        Include zero
+      </button>
       <ModeSwitch store={lineChartMode} />
     {:else if chart.type === "barchart" && chart.hasStackedData}
       <ModeSwitch store={barChartMode} />

--- a/frontend/src/charts/LineChart.svelte
+++ b/frontend/src/charts/LineChart.svelte
@@ -6,11 +6,15 @@
   import { area, curveStepAfter, line } from "d3-shape";
   import type { Writable } from "svelte/store";
 
-  import { chartToggledCurrencies, lineChartMode } from "../stores/chart";
+  import {
+    chartToggledCurrencies,
+    includeZeroToggle,
+    lineChartMode,
+  } from "../stores/chart";
   import { ctx, short } from "../stores/format";
 
   import Axis from "./Axis.svelte";
-  import { currenciesScale, padExtent } from "./helpers";
+  import { currenciesScale, includeZero, padExtent } from "./helpers";
   import type { LineChart, LineChartDatum } from "./line";
   import type { TooltipFindNode } from "./tooltip";
   import { positionedTooltip } from "./tooltip";
@@ -38,7 +42,8 @@
     max(data, (s) => s.values[s.values.length - 1]?.date) ?? today,
   ] as const;
   $: x = scaleUtc([0, innerWidth]).domain(xExtent);
-  $: yExtent = extent(allValues, (v) => v.value);
+  $: valueExtent = extent(allValues, (v) => v.value);
+  $: yExtent = $includeZeroToggle ? includeZero(valueExtent) : valueExtent;
   // Span y-axis as max minus min value plus 5 percent margin
   $: y = scaleLinear([innerHeight, 0]).domain(padExtent(yExtent));
 

--- a/frontend/src/stores/chart.ts
+++ b/frontend/src/stores/chart.ts
@@ -41,6 +41,9 @@ export const lineChartMode = localStorageSyncedStore<"line" | "area">(
   ],
 );
 
+/** Whether to include zero in line charts or not. */
+export const includeZeroToggle = writable(false);
+
 /** The currently selected bar chart mode. */
 export const barChartMode = localStorageSyncedStore<"stacked" | "single">(
   "bar-chart-mode",


### PR DESCRIPTION
In line charts I sometimes want to include zero in the graph to see the "total" state, and so that small changes dont look like large changes.

To help with this I added an "Include zero" toggle to line charts, it looks like this:

Include zero not toggled:
![image](https://github.com/beancount/fava/assets/690778/d898ea36-a104-4b8c-ab7c-531a562e998e)

Include zero toggled:
![image](https://github.com/beancount/fava/assets/690778/b6085030-94ff-416a-8792-103fef971046)

If there are better ways toggle this in the UI I'm happy to update this PR.
