### PR TITLE
include zero in line charts for area mode

### DIFF
--- a/frontend/src/charts/LineChart.svelte
+++ b/frontend/src/charts/LineChart.svelte
@@ -10,7 +10,7 @@
   import { ctx, short } from "../stores/format";
 
   import Axis from "./Axis.svelte";
-  import { currenciesScale, padExtent } from "./helpers";
+  import { currenciesScale, includeZero, padExtent } from "./helpers";
   import type { LineChart, LineChartDatum } from "./line";
   import type { TooltipFindNode } from "./tooltip";
   import { positionedTooltip } from "./tooltip";
@@ -38,7 +38,9 @@
     max(data, (s) => s.values[s.values.length - 1]?.date) ?? today,
   ] as const;
   $: x = scaleUtc([0, innerWidth]).domain(xExtent);
-  $: yExtent = extent(allValues, (v) => v.value);
+  $: valueExtent = extent(allValues, (v) => v.value);
+  // Include zero in area charts so the entire area is shown, not a cropped part of it
+  $: yExtent = $lineChartMode === "area" ? includeZero(valueExtent) : valueExtent;
   // Span y-axis as max minus min value plus 5 percent margin
   $: y = scaleLinear([innerHeight, 0]).domain(padExtent(yExtent));
 

--- a/frontend/src/charts/LineChart.svelte
+++ b/frontend/src/charts/LineChart.svelte
@@ -40,7 +40,8 @@
   $: x = scaleUtc([0, innerWidth]).domain(xExtent);
   $: valueExtent = extent(allValues, (v) => v.value);
   // Include zero in area charts so the entire area is shown, not a cropped part of it
-  $: yExtent = $lineChartMode === "area" ? includeZero(valueExtent) : valueExtent;
+  $: yExtent =
+    $lineChartMode === "area" ? includeZero(valueExtent) : valueExtent;
   // Span y-axis as max minus min value plus 5 percent margin
   $: y = scaleLinear([innerHeight, 0]).domain(padExtent(yExtent));
 


### PR DESCRIPTION
This change makes the area mode in line charts always include zero. So that the area is not cropped.
In line mode the old behaviour (show 5% below lowest value) is kept.

This makes it easier to see how big a change in an account is in relation the the account size

Line
![bild](https://github.com/beancount/fava/assets/690778/2d1a6ce8-9647-41d5-8772-96a25b57ff8c)

Area
![bild](https://github.com/beancount/fava/assets/690778/8270ee2a-956e-41c3-a9c2-86e291ee23cd)

