### PR TITLE
lint: enable promise-function-async rule

### DIFF
--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -11,6 +11,7 @@ const misc = {
   ],
   "@typescript-eslint/consistent-type-imports": ON,
   "@typescript-eslint/explicit-module-boundary-types": ON,
+  "@typescript-eslint/promise-function-async": ON,
   "@typescript-eslint/strict-boolean-expressions": ON,
   curly: [ON, "all"],
   eqeqeq: [ON, "smart"],

--- a/frontend/src/extensions.ts
+++ b/frontend/src/extensions.ts
@@ -44,22 +44,25 @@ export class ExtensionApi {
   }
 
   /** GET an endpoint with parameters and return JSON. */
-  get(endpoint: string, params: Record<string, string>): Promise<unknown> {
+  async get(
+    endpoint: string,
+    params: Record<string, string>,
+  ): Promise<unknown> {
     return this.request(endpoint, "GET", params, undefined);
   }
 
   /** GET an endpoint with a body and return JSON. */
-  put(endpoint: string, body?: unknown): Promise<unknown> {
+  async put(endpoint: string, body?: unknown): Promise<unknown> {
     return this.request(endpoint, "PUT", undefined, body);
   }
 
   /** POST to an endpoint with a body and return JSON. */
-  post(endpoint: string, body?: unknown): Promise<unknown> {
+  async post(endpoint: string, body?: unknown): Promise<unknown> {
     return this.request(endpoint, "POST", undefined, body);
   }
 
   /** DELETE an endpoint and return JSON. */
-  delete(endpoint: string): Promise<unknown> {
+  async delete(endpoint: string): Promise<unknown> {
     return this.request(endpoint, "DELETE");
   }
 }

--- a/frontend/src/lib/fetch.ts
+++ b/frontend/src/lib/fetch.ts
@@ -12,7 +12,7 @@ import {
 class FetchError extends Error {}
 
 /** Wrapper around fetch with some default options */
-export function fetch(
+export async function fetch(
   input: string,
   init: RequestInit = {},
 ): Promise<Response> {

--- a/frontend/src/modals/DocumentUpload.svelte
+++ b/frontend/src/modals/DocumentUpload.svelte
@@ -28,7 +28,7 @@
 
   async function submit() {
     await Promise.all(
-      $files.map(({ dataTransferFile, name }) => {
+      $files.map(async ({ dataTransferFile, name }) => {
         const formData = new FormData();
         formData.append("account", $account);
         formData.append("hash", $hash);

--- a/frontend/src/reports/commodities/index.ts
+++ b/frontend/src/reports/commodities/index.ts
@@ -19,7 +19,7 @@ export const commodities = new Route<{
 }>(
   "commodities",
   CommoditiesSvelte,
-  (url) =>
+  async (url) =>
     get("commodities", getURLFilters(url)).then((cs) => {
       const charts = cs.map(({ base, quote, prices }) => {
         const name = `${base} / ${quote}`;

--- a/frontend/src/reports/documents/index.ts
+++ b/frontend/src/reports/documents/index.ts
@@ -9,7 +9,7 @@ import Documents from "./Documents.svelte";
 export const documents = new Route<{ documents: Document[] }>(
   "documents",
   Documents,
-  (url: URL) =>
+  async (url: URL) =>
     get("documents", getURLFilters(url)).then((data) => ({
       documents: data,
     })),

--- a/frontend/src/reports/editor/Editor.svelte
+++ b/frontend/src/reports/editor/Editor.svelte
@@ -121,7 +121,7 @@
 
 <form
   class="fixed-fullsize-container"
-  on:submit|preventDefault={() => save(editor)}
+  on:submit|preventDefault={async () => save(editor)}
 >
   <EditorMenu {file_path} {editor}>
     <SaveButton {changed} {saving} />

--- a/frontend/src/reports/editor/index.ts
+++ b/frontend/src/reports/editor/index.ts
@@ -14,7 +14,7 @@ export const editor = new Route<{
 }>(
   "editor",
   Editor,
-  (url: URL) =>
+  async (url: URL) =>
     Promise.all([
       get("source", {
         filename: url.searchParams.get("file_path") ?? "",

--- a/frontend/src/reports/events/index.ts
+++ b/frontend/src/reports/events/index.ts
@@ -11,7 +11,7 @@ export const events = new Route<{
 }>(
   "events",
   Events,
-  (url: URL) =>
+  async (url: URL) =>
     get("events", getURLFilters(url)).then((data) => ({ events: data })),
   () => _("Events"),
 );

--- a/frontend/src/reports/import/Import.svelte
+++ b/frontend/src/reports/import/Import.svelte
@@ -128,7 +128,7 @@
       return;
     }
     await Promise.all(
-      Array.from(fileUpload.files).map((file) => {
+      Array.from(fileUpload.files).map(async (file) => {
         const formData = new FormData();
         formData.append("file", file, file.name);
         return put("upload_import_file", formData).then(notify, (error) => {

--- a/frontend/src/reports/import/index.ts
+++ b/frontend/src/reports/import/index.ts
@@ -60,7 +60,7 @@ export function preprocessData(
 export const import_report = new Route(
   "import",
   ImportSvelte,
-  () =>
+  async () =>
     get("imports", undefined)
       .then(preprocessData)
       .then((data) => ({ data })),

--- a/frontend/src/reports/query/Query.svelte
+++ b/frontend/src/reports/query/Query.svelte
@@ -131,8 +131,10 @@
         {/if}
         <button
           type="button"
-          on:click|stopPropagation={() => deleteItem(history_item)}>x</button
+          on:click|stopPropagation={async () => deleteItem(history_item)}
         >
+          x
+        </button>
       </summary>
       <div>
         {#if result}

--- a/frontend/src/reports/tree_reports/index.ts
+++ b/frontend/src/reports/tree_reports/index.ts
@@ -10,20 +10,20 @@ import TrialBalance from "./TrialBalance.svelte";
 export const income_statement = new Route(
   "income_statement",
   IncomeStatement,
-  (url) => get("income_statement", getURLFilters(url)),
+  async (url) => get("income_statement", getURLFilters(url)),
   () => _("Income Statement"),
 );
 
 export const balance_sheet = new Route(
   "balance_sheet",
   BalanceSheet,
-  (url) => get("balance_sheet", getURLFilters(url)),
+  async (url) => get("balance_sheet", getURLFilters(url)),
   () => _("Balance Sheet"),
 );
 
 export const trial_balance = new Route(
   "trial_balance",
   TrialBalance,
-  (url) => get("trial_balance", getURLFilters(url)),
+  async (url) => get("trial_balance", getURLFilters(url)),
   () => _("Trial Balance"),
 );


### PR DESCRIPTION
Gives better visibility to async code and ensures they can only return a
rejected promise, not throw an Error, see
https://typescript-eslint.io/rules/promise-function-async/

<!--
Hi, thank you for opening a PR!

Please ensure that your change passes tests and the various linters by running
`make test` and `make lint`. If testable, your changes should be covered by
unit tests.

Explain your changes below and link to related issues.
-->
