### PR TITLE
add css improvements for journal on mobile devices

### DIFF
--- a/frontend/css/journal-table.css
+++ b/frontend/css/journal-table.css
@@ -231,3 +231,99 @@
   text-transform: lowercase;
   border-radius: 20px;
 }
+
+@media (width <= 767px) {
+  article {
+    padding: 1rem;
+  }
+
+  .flex-table.journal p {
+    flex-wrap: wrap;
+  }
+
+  .journal .head .flag {
+    flex-grow: 1;
+    text-align: left;
+  }
+
+  .journal .datecell {
+    order: 1;
+    width: 6rem;
+    text-align: left;
+  }
+
+  .journal .flag {
+    order: 2;
+  }
+
+  .journal .description {
+    flex: inherit;
+    order: 5;
+    width: 100%;
+    padding-left: 0;
+  }
+
+  .journal .indicators {
+    flex-grow: 1;
+    order: 3;
+  }
+
+  .journal .balance .indicators,
+  .journal .balance .change.num {
+    display: none;
+  }
+
+  .journal p > .num {
+    order: 4;
+  }
+
+  .journal .postings .datecell,
+  .journal .postings .flag {
+    display: none;
+  }
+
+  .journal .postings .description {
+    flex-grow: 1;
+    order: inherit;
+    width: inherit;
+  }
+
+  .journal .indicators span {
+    display: none;
+  }
+
+  .journal .indicators span:nth-child(-n + 2) {
+    display: initial;
+  }
+
+  .journal .indicators span:nth-child(3) {
+    display: inline;
+    border-radius: 3px 0 0 3px;
+  }
+
+  .journal .balance > p > .num,
+  .journal .budget > p > .description > .num {
+    position: absolute;
+    right: 1rem;
+    width: 40%;
+  }
+
+  .journal .budget .description > .num {
+    display: block;
+    margin-top: -3.7rem;
+  }
+
+  .journal .budget > p > .description > .num {
+    background: var(--background);
+  }
+
+  .journal .custom > p,
+  .journal .balance > p {
+    border-top: thin solid var(--entry-background);
+  }
+
+  .journal .metadata dt,
+  .journal .metadata dd {
+    margin-left: initial;
+  }
+}

--- a/frontend/css/journal-table.css
+++ b/frontend/css/journal-table.css
@@ -130,7 +130,7 @@
 }
 
 .journal .datecell {
-  width: 5.5rem;
+  width: 6rem;
   white-space: nowrap;
 }
 
@@ -233,12 +233,13 @@
 }
 
 @media (width <= 767px) {
-  article {
-    padding: 1rem;
+  .journal p {
+    flex-wrap: wrap;
   }
 
-  .flex-table.journal p {
-    flex-wrap: wrap;
+  /* show a colored top border for all entries */
+  .journal > li > p {
+    border-top: thin solid var(--entry-background);
   }
 
   .journal .head .flag {
@@ -246,35 +247,23 @@
     text-align: left;
   }
 
-  .journal .datecell {
-    order: 1;
-    width: 6rem;
-    text-align: left;
-  }
-
-  .journal .flag {
-    order: 2;
-  }
-
   .journal .description {
     flex: inherit;
-    order: 5;
+    order: 1; /* push to second row */
     width: 100%;
     padding-left: 0;
   }
 
   .journal .indicators {
     flex-grow: 1;
-    order: 3;
   }
 
-  .journal .balance .indicators,
+  .journal .balance .num {
+    width: 35%;
+  }
+
   .journal .balance .change.num {
     display: none;
-  }
-
-  .journal p > .num {
-    order: 4;
   }
 
   .journal .postings .datecell,
@@ -286,40 +275,6 @@
     flex-grow: 1;
     order: inherit;
     width: inherit;
-  }
-
-  .journal .indicators span {
-    display: none;
-  }
-
-  .journal .indicators span:nth-child(-n + 2) {
-    display: initial;
-  }
-
-  .journal .indicators span:nth-child(3) {
-    display: inline;
-    border-radius: 3px 0 0 3px;
-  }
-
-  .journal .balance > p > .num,
-  .journal .budget > p > .description > .num {
-    position: absolute;
-    right: 1rem;
-    width: 40%;
-  }
-
-  .journal .budget .description > .num {
-    display: block;
-    margin-top: -3.7rem;
-  }
-
-  .journal .budget > p > .description > .num {
-    background: var(--background);
-  }
-
-  .journal .custom > p,
-  .journal .balance > p {
-    border-top: thin solid var(--entry-background);
   }
 
   .journal .metadata dt,

--- a/frontend/css/layout.css
+++ b/frontend/css/layout.css
@@ -64,6 +64,10 @@ article:has(> .fixed-fullsize-container) {
 }
 
 @media (width <= 767px) {
+  article {
+    padding: 1em;
+  }
+
   body {
     display: block;
     font-size: 16px;


### PR DESCRIPTION
Hi I just tried to improve the mobile view of journals. You can consider this PR as a proposal to improve the look and feel, so any feedback and remarks are welcome!

My issue with the current look and feel is that it is difficult to read what is actually going on. For example like this:

<img src="https://github.com/beancount/fava/assets/95028228/2cbab4e7-f742-4e2d-a636-46d9bfe6166f" height="400">

The narrations and the payees are often shortened with `...`.

My suggestion would be to give the rows a second line. The first line has the date, flag, indicators and the prices, while in the second line it has the narrations or the accounts:

<img src="https://github.com/beancount/fava/assets/95028228/aefb32d9-b9b4-4d6a-8694-f0403fd45bb2" height="400">

As seen in the screenshot: budgets are not perfect yet, but it's a start. 
What do you think about that? 