### PR TITLE
support numerical comparison operators for amounts in filter

### DIFF
--- a/src/fava/help/filters.md
+++ b/src/fava/help/filters.md
@@ -36,7 +36,8 @@ the account name, or a regular expression matching the account name, e.g.
 This final filter allows you to filter entries by various attributes.
 
 - Filter by `#tag` or `^link`.
-- Filter by amount, such as `= 100.20` or `>= 100`.
+- Filter by amount, such as `= 100.20` or `>= 100` (comparing the absolute of
+  the units).
 - Filter by any entry attribute, such as payee `payee:"restaurant"` or narration
   `narration:'Dinner with Joe'`. The argument is a regular expression which
   needs to be quoted (with `'` or `"`) if it contains spaces or special
@@ -53,8 +54,9 @@ This final filter allows you to filter entries by various attributes.
   `any(id:'12', account:"Cash$")` for all entries that have at least one posting
   with metadata `id: 12` or account ending in `Cash`, or
   `all(-account:"^Expenses:Food")` to exclude all transactions having a posting
-  to the Expenses:Food account. To match by amount, you can use range operators,
-  e.g. `any(units > 80)`.
+  to the Expenses:Food account. To match by amount, you can use comparison
+  operators, e.g. `any(units > 80)` to filter for all entries where one posting
+  has a units with an absolute amount greater than 80.
 
 These filters can be combined by separating them by spaces to match all entries
 satisfying all given filters or by commas to match all entries satisfying at

--- a/src/fava/help/filters.md
+++ b/src/fava/help/filters.md
@@ -36,6 +36,7 @@ the account name, or a regular expression matching the account name, e.g.
 This final filter allows you to filter entries by various attributes.
 
 - Filter by `#tag` or `^link`.
+- Filter by amount, such as `= 100.20` or `>= 100`.
 - Filter by any entry attribute, such as payee `payee:"restaurant"` or narration
   `narration:'Dinner with Joe'`. The argument is a regular expression which
   needs to be quoted (with `'` or `"`) if it contains spaces or special
@@ -52,7 +53,8 @@ This final filter allows you to filter entries by various attributes.
   `any(id:'12', account:"Cash$")` for all entries that have at least one posting
   with metadata `id: 12` or account ending in `Cash`, or
   `all(-account:"^Expenses:Food")` to exclude all transactions having a posting
-  to the Expenses:Food account.
+  to the Expenses:Food account. To match by amount, you can use range operators,
+  e.g. `any(units > 80)`.
 
 These filters can be combined by separating them by spaces to match all entries
 satisfying all given filters or by commas to match all entries satisfying at

--- a/tests/test_core_filters.py
+++ b/tests/test_core_filters.py
@@ -14,6 +14,7 @@ from fava.core.filters import AdvancedFilter
 from fava.core.filters import FilterError
 from fava.core.filters import FilterSyntaxLexer
 from fava.core.filters import Match
+from fava.core.filters import MatchAmount
 from fava.core.filters import TimeFilter
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -28,6 +29,34 @@ def test_match() -> None:
     assert not Match("asdf")("fdsadfs")
     assert not Match("^asdf")("aasdfasdf")
     assert Match("(((")("(((")
+
+
+def test_match_amount() -> None:
+    one = Decimal(1)
+    two = Decimal(2)
+
+    one_amt = create.amount("1 EUR")
+    two_amt = create.amount("2 EUR")
+    three_amt = create.amount("3 EUR")
+
+    assert MatchAmount("=", one)(one_amt)
+    assert MatchAmount("=", one)(one_amt)
+
+    assert MatchAmount(">", two)(three_amt)
+    assert not MatchAmount(">", two)(two_amt)
+    assert not MatchAmount(">", two)(one_amt)
+
+    assert MatchAmount(">=", two)(three_amt)
+    assert MatchAmount(">=", two)(two_amt)
+    assert not MatchAmount(">=", two)(one_amt)
+
+    assert not MatchAmount("<", two)(three_amt)
+    assert not MatchAmount("<", two)(two_amt)
+    assert MatchAmount("<", two)(one_amt)
+
+    assert not MatchAmount("<=", two)(three_amt)
+    assert MatchAmount("<=", two)(two_amt)
+    assert MatchAmount("<=", two)(one_amt)
 
 
 def test_lexer_basic() -> None:

--- a/tests/test_core_filters.py
+++ b/tests/test_core_filters.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import datetime
+from decimal import Decimal
 from typing import TYPE_CHECKING
 
 import pytest
@@ -59,13 +60,18 @@ def test_lexer_literals_in_string() -> None:
 
 def test_lexer_key() -> None:
     lex = FilterSyntaxLexer().lex
-    data = 'payee:asdfasdf ^some_link somekey:"testtest" '
+    data = 'payee:asdfasdf ^some_link somekey:"testtest" units>80.2 '
     assert [(tok.type, tok.value) for tok in lex(data)] == [
         ("KEY", "payee"),
+        ("EQ_OP", ":"),
         ("STRING", "asdfasdf"),
         ("LINK", "some_link"),
         ("KEY", "somekey"),
+        ("EQ_OP", ":"),
         ("STRING", "testtest"),
+        ("KEY", "units"),
+        ("CMP_OP", ">"),
+        ("NUMBER", Decimal("80.2")),
     ]
 
 
@@ -75,11 +81,13 @@ def test_lexer_parentheses() -> None:
     assert [(tok.type, tok.value) for tok in lex(data)] == [
         ("(", "("),
         ("KEY", "payee"),
+        ("EQ_OP", ":"),
         ("STRING", "asdfasdf"),
         ("LINK", "some_link"),
         (")", ")"),
         ("(", "("),
         ("KEY", "somekey"),
+        ("EQ_OP", ":"),
         ("STRING", "testtest"),
         (")", ")"),
     ]
@@ -119,6 +127,10 @@ def test_filterexception() -> None:
         ('name:".*etf"', 4),
         ('name:".*etf$"', 3),
         ('any(overage:"GB$")', 1),
+        ("=26.87", 1),
+        (">=17500", 3),
+        (">=17500 <18000", 1),
+        ("any(units >= 17500)", 3),
     ],
 )
 def test_advanced_filter(


### PR DESCRIPTION
Support numerical comparison operators for amounts in filter
Resolves: #1297

This adds the following features to the filter DSL:
```
>= 100
any(units > 100)
```

I think this addresses your comments from a previous PR https://github.com/beancount/fava/pull/1307#issuecomment-986008505. In a previous iteration I used `any(units > "100 USD")`, however I think it is more straightforward and user friendly to leave the currency out when using comparison operators.