### PR TITLE
test: disable coverage for cli test

### DIFF
--- a/src/fava/cli.py
+++ b/src/fava/cli.py
@@ -18,7 +18,7 @@ from fava.util import simple_wsgi
 
 
 class AddressInUse(click.ClickException):  # noqa: D101
-    def __init__(self, port: int) -> None:
+    def __init__(self, port: int) -> None:  # pragma: no cover
         super().__init__(
             f"Cannot start Fava because port {port} is already in use."
             "\nPlease choose a different port with the '-p' option.",
@@ -33,7 +33,7 @@ class NonAbsolutePathError(click.UsageError):  # noqa: D101
 
 
 class NoFileSpecifiedError(click.UsageError):  # noqa: D101
-    def __init__(self) -> None:
+    def __init__(self) -> None:  # pragma: no cover
         super().__init__("No file specified")
 
 


### PR DESCRIPTION
It does not really provide much value there and seems to have quite some
impact, removing this reduces the running time of this test from ~10s
(out of a total of ~25s) to ~1s (when run with tox).

<!--
Hi, thank you for opening a PR!

Please ensure that your change passes tests and the various linters by running
`make test` and `make lint`. If testable, your changes should be covered by
unit tests.

Explain your changes below and link to related issues.
-->
