### PR TITLE
fix: Respect ordering of provided ledgers

### DIFF
--- a/src/fava/cli.py
+++ b/src/fava/cli.py
@@ -37,18 +37,23 @@ class NoFileSpecifiedError(click.UsageError):  # noqa: D101
         super().__init__("No file specified")
 
 
-def _add_env_filenames(filenames: tuple[str, ...]) -> set[str]:
+def _add_env_filenames(filenames: tuple[str, ...]) -> tuple[str, ...]:
     """Read additional filenames from BEANCOUNT_FILE."""
     env_filename = os.environ.get("BEANCOUNT_FILE")
     if not env_filename:
-        return set(filenames)
+        return filenames
 
     env_names = env_filename.split(os.pathsep)
     for name in env_names:
         if not Path(name).is_absolute():
             raise NonAbsolutePathError(name)
 
-    return set(filenames + tuple(env_names))
+    all_names = tuple(env_names) + filenames
+    return tuple(
+        name
+        for [index, name] in enumerate(all_names)
+        if index == all_names.index(name)
+    )
 
 
 @click.command(context_settings={"auto_envvar_prefix": "FAVA"})

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -29,17 +29,17 @@ def test__add_env_filenames(
     other = str(absolute_path / "other")
 
     monkeypatch.delenv("BEANCOUNT_FILE", raising=False)
-    assert _add_env_filenames((asdf,)) == {asdf}
+    assert _add_env_filenames((asdf,)) == (asdf,)
 
     monkeypatch.setenv("BEANCOUNT_FILE", "path")
     with pytest.raises(NonAbsolutePathError):
         _add_env_filenames((asdf,))
 
     monkeypatch.setenv("BEANCOUNT_FILE", absolute)
-    assert _add_env_filenames((asdf,)) == {absolute, asdf}
+    assert _add_env_filenames((asdf,)) == (absolute, asdf)
 
     monkeypatch.setenv("BEANCOUNT_FILE", os.pathsep.join([absolute, other]))
-    assert _add_env_filenames((asdf,)) == {absolute, other, asdf}
+    assert _add_env_filenames((asdf,)) == (absolute, other, asdf)
 
 
 @pytest.fixture


### PR DESCRIPTION
Previously the _add_env_filenames function converted the filenames to a set. As [sets are unordered](https://docs.python.org/3/tutorial/datastructures.html#sets), this prevented specifying order. Some bits of the code, notably the default "/" route, relied on order to determine which the default ledger was

The use of set() was first introduced in f33a63e35a1751001ac10fb992aba4e434ea7321. It's not entirely clear from the commit, but presumably it was intended to filter out duplicate items as this is a common pattern in Python. The type is hinted to be an Iterable[] and lists are used in other places, such as tests, so nothing requires using a set

To make test changes as minimal as possible, this commit makes the files included from environment variables be ordered *first*