### PR TITLE
default-file improvements

### DIFF
--- a/src/fava/core/fava_options.py
+++ b/src/fava/core/fava_options.py
@@ -119,12 +119,17 @@ def parse_option_custom_entry(  # noqa: PLR0912
     if key not in All_OPTS:
         raise UnknownOptionError(key)
 
+    value = entry.values[1].value if len(entry.values) > 1 else None
+
     if key == "default_file":
-        filename, _lineno = get_position(entry)
+        if value is None:
+            filename, _lineno = get_position(entry)
+        else:
+            filename = value
+
         options.default_file = filename
         return
 
-    value = entry.values[1].value
     if not isinstance(value, str):
         raise NotAStringOptionError(key)
 

--- a/src/fava/core/file.py
+++ b/src/fava/core/file.py
@@ -233,7 +233,10 @@ class FileModule(FavaModule):
             for entry in sorted(entries, key=_incomplete_sortkey):
                 path, updated_insert_options = insert_entry(
                     entry,
-                    self.ledger.beancount_file_path,
+                    (
+                        self.ledger.fava_options.default_file
+                        or self.ledger.beancount_file_path
+                    ),
                     insert_options=fava_options.insert_entry,
                     currency_column=fava_options.currency_column,
                     indent=fava_options.indent,

--- a/src/fava/help/options.md
+++ b/src/fava/help/options.md
@@ -113,7 +113,7 @@ a transaction, the account of the last posting is used) is matched against all
 of the matching options before the entry date. If the entry is a Transaction and
 no `insert-entry` option matches the account of the last posting the account of
 the second to last posting and so on will be tried. If no `insert-entry` option
-matches or none is given, the entry will be inserted at the end of the main
+matches or none is given, the entry will be inserted at the end of the default
 file.
 
 ---

--- a/src/fava/help/options.md
+++ b/src/fava/help/options.md
@@ -50,8 +50,8 @@ locale `en_IN` the number `1111111.33` will be rendered `11,11,111.33`,
 ## `default-file`
 
 Use this option to specify a default file for the editor to open. This option
-takes no value, the file the custom entry is in will be used as the default. If
-this option is not specified, Fava opens the main file by default.
+may optionally take a value of a filename to be the default. If you don't
+provide a filename, the file this custom option is in is used.
 
 ---
 

--- a/tests/test_core_fava_options.py
+++ b/tests/test_core_fava_options.py
@@ -27,6 +27,7 @@ def test_fava_options(load_doc_custom_entries: list[Custom]) -> None:
     2016-04-14 custom "fava-option" "collapse_pattern" "(invalid"
     2016-04-14 custom "fava-option" "fiscal-year-end" "01-11"
     2016-04-14 custom "fava-option" "conversion-currencies" "USD EUR HOOLI"
+    2016-06-14 custom "fava-option" "default-file" "/some/file/name"
     """
 
     options, errors = parse_options(load_doc_custom_entries)
@@ -50,3 +51,4 @@ def test_fava_options(load_doc_custom_entries: list[Custom]) -> None:
     assert options.collapse_pattern == [re.compile("Account:Name")]
     assert options.fiscal_year_end == FiscalYearEnd(1, 11)
     assert options.conversion_currencies == ("USD", "EUR", "HOOLI")
+    assert options.default_file == "/some/file/name"


### PR DESCRIPTION
1 of 2:
It's a common point of confusion that default-file does not set the
default file for insertions. This patch brings the behavior into line
with people's expectations.

BREAKING-CHANGE: If you are using default-file and expecting entries to be inserted to your main file, this will no longer happen
Fixes: #882
Refs: #1698, #822

---

2 of 2:
I autogenerate some fava config, and one option I'd like to specify is
the default file.

Unfortunately, this previously had to be specified in the file which
would become the default file, leading to a messy and fragile setup in
which my (readonly) configuration file would become the default if the
magical "default-file" line was ever removed from the user-editable
config.

This feature allows existing semantics around default-file to continue,
while also providing the ability to set it in some other file if the
existing options are unsuitable.