### PR TITLE
Add `--poll-watcher` flag.

### DIFF
--- a/src/fava/application.py
+++ b/src/fava/application.py
@@ -228,7 +228,7 @@ def _setup_filters(
             with load_file_lock:
                 if not fava_app.config["LEDGERS"]:
                     fava_app.config["LEDGERS"] = _ledger_slugs_dict(
-                        FavaLedger(filepath, fava_app.config["POLL_WATCHER"])
+                        FavaLedger(filepath, poll_watcher=fava_app.config["POLL_WATCHER"])
                         for filepath in fava_app.config["BEANCOUNT_FILES"]
                     )
         if g.beancount_file_slug:

--- a/src/fava/application.py
+++ b/src/fava/application.py
@@ -228,7 +228,7 @@ def _setup_filters(
             with load_file_lock:
                 if not fava_app.config["LEDGERS"]:
                     fava_app.config["LEDGERS"] = _ledger_slugs_dict(
-                        FavaLedger(filepath)
+                        FavaLedger(filepath, fava_app.config["POLL_WATCHER"])
                         for filepath in fava_app.config["BEANCOUNT_FILES"]
                     )
         if g.beancount_file_slug:
@@ -441,6 +441,7 @@ def create_app(
     load: bool = False,
     incognito: bool = False,
     read_only: bool = False,
+    poll_watcher: bool = False,
 ) -> Flask:
     """Create a Fava Flask application.
 
@@ -449,6 +450,7 @@ def create_app(
         load: Whether to load the Beancount files directly.
         incognito: Whether to run in incognito mode.
         read_only: Whether to run in read-only mode.
+        poll_watcher: Whether to use old poll watcher
     """
     fava_app = Flask("fava")
     fava_app.register_blueprint(json_api, url_prefix="/<bfile>/api")
@@ -462,10 +464,11 @@ def create_app(
     fava_app.config["HAVE_EXCEL"] = HAVE_EXCEL
     fava_app.config["BEANCOUNT_FILES"] = [str(f) for f in files]
     fava_app.config["INCOGNITO"] = incognito
+    fava_app.config["POLL_WATCHER"] = poll_watcher
 
     if load:
         fava_app.config["LEDGERS"] = _ledger_slugs_dict(
-            FavaLedger(filepath)
+            FavaLedger(filepath, poll_watcher)
             for filepath in fava_app.config["BEANCOUNT_FILES"]
         )
     else:

--- a/src/fava/application.py
+++ b/src/fava/application.py
@@ -468,7 +468,7 @@ def create_app(
 
     if load:
         fava_app.config["LEDGERS"] = _ledger_slugs_dict(
-            FavaLedger(filepath, poll_watcher)
+            FavaLedger(filepath, poll_watcher=poll_watcher)
             for filepath in fava_app.config["BEANCOUNT_FILES"]
         )
     else:

--- a/src/fava/application.py
+++ b/src/fava/application.py
@@ -228,7 +228,10 @@ def _setup_filters(
             with load_file_lock:
                 if not fava_app.config["LEDGERS"]:
                     fava_app.config["LEDGERS"] = _ledger_slugs_dict(
-                        FavaLedger(filepath, poll_watcher=fava_app.config["POLL_WATCHER"])
+                        FavaLedger(
+                            filepath,
+                            poll_watcher=fava_app.config["POLL_WATCHER"],
+                        )
                         for filepath in fava_app.config["BEANCOUNT_FILES"]
                     )
         if g.beancount_file_slug:

--- a/src/fava/cli.py
+++ b/src/fava/cli.py
@@ -97,6 +97,10 @@ def _add_env_filenames(filenames: tuple[str, ...]) -> set[str]:
     type=click.Path(),
     help="Output directory for profiling data.",
 )
+@click.option(
+    "--poll-watcher",
+    is_flag=True, help="Use old polling-based watcher."
+)
 @click.version_option(version=__version__, prog_name="fava")
 def main(
     *,
@@ -109,6 +113,7 @@ def main(
     debug: bool = False,
     profile: bool = False,
     profile_dir: str | None = None,
+    poll_watcher: bool = False,
 ) -> None:  # pragma: no cover
     """Start Fava for FILENAMES on http://<host>:<port>.
 
@@ -129,6 +134,7 @@ def main(
         all_filenames,
         incognito=incognito,
         read_only=read_only,
+        poll_watcher=poll_watcher,
     )
 
     if prefix:

--- a/src/fava/cli.py
+++ b/src/fava/cli.py
@@ -101,7 +101,7 @@ def _add_env_filenames(filenames: tuple[str, ...]) -> set[str]:
     "--poll-watcher", is_flag=True, help="Use old polling-based watcher."
 )
 @click.version_option(version=__version__, prog_name="fava")
-def main( # noqa: PLR0913
+def main(  # noqa: PLR0913
     *,
     filenames: tuple[str, ...] = (),
     port: int = 5000,

--- a/src/fava/cli.py
+++ b/src/fava/cli.py
@@ -98,8 +98,7 @@ def _add_env_filenames(filenames: tuple[str, ...]) -> set[str]:
     help="Output directory for profiling data.",
 )
 @click.option(
-    "--poll-watcher",
-    is_flag=True, help="Use old polling-based watcher."
+    "--poll-watcher", is_flag=True, help="Use old polling-based watcher."
 )
 @click.version_option(version=__version__, prog_name="fava")
 def main(

--- a/src/fava/cli.py
+++ b/src/fava/cli.py
@@ -101,7 +101,7 @@ def _add_env_filenames(filenames: tuple[str, ...]) -> set[str]:
     "--poll-watcher", is_flag=True, help="Use old polling-based watcher."
 )
 @click.version_option(version=__version__, prog_name="fava")
-def main(
+def main( # noqa: PLR0913
     *,
     filenames: tuple[str, ...] = (),
     port: int = 5000,

--- a/src/fava/core/__init__.py
+++ b/src/fava/core/__init__.py
@@ -223,7 +223,7 @@ class FavaLedger:
     #: Dict of list of all (unfiltered) entries by type.
     all_entries_by_type: EntriesByType
 
-    def __init__(self, path: str, poll_watcher: bool = False) -> None:
+    def __init__(self, path: str, *, poll_watcher: bool = False) -> None:
         #: The path to the main Beancount file.
         self.beancount_file_path = path
         self._is_encrypted = is_encrypted_file(path)

--- a/src/fava/core/__init__.py
+++ b/src/fava/core/__init__.py
@@ -44,7 +44,7 @@ from fava.core.misc import FavaMisc
 from fava.core.number import DecimalFormatModule
 from fava.core.query_shell import QueryShell
 from fava.core.tree import Tree
-from fava.core.watcher import WatchfilesWatcher
+from fava.core.watcher import WatchfilesWatcher, Watcher
 from fava.helpers import FavaAPIError
 from fava.util import listify
 from fava.util.date import dateranges
@@ -222,7 +222,7 @@ class FavaLedger:
     #: Dict of list of all (unfiltered) entries by type.
     all_entries_by_type: EntriesByType
 
-    def __init__(self, path: str) -> None:
+    def __init__(self, path: str, poll_watcher: bool = False) -> None:
         #: The path to the main Beancount file.
         self.beancount_file_path = path
         self._is_encrypted = is_encrypted_file(path)
@@ -260,7 +260,7 @@ class FavaLedger:
         #: A :class:`.AccountDict` module - details about the accounts.
         self.accounts = AccountDict(self)
 
-        self.watcher = WatchfilesWatcher()
+        self.watcher = WatchfilesWatcher() if not poll_watcher else Watcher()
 
         self.load_file()
 

--- a/src/fava/core/__init__.py
+++ b/src/fava/core/__init__.py
@@ -44,7 +44,8 @@ from fava.core.misc import FavaMisc
 from fava.core.number import DecimalFormatModule
 from fava.core.query_shell import QueryShell
 from fava.core.tree import Tree
-from fava.core.watcher import WatchfilesWatcher, Watcher
+from fava.core.watcher import Watcher
+from fava.core.watcher import WatchfilesWatcher
 from fava.helpers import FavaAPIError
 from fava.util import listify
 from fava.util.date import dateranges


### PR DESCRIPTION
This enables the use of the old, poll-based watcher. For cases where the`watchfiles` library (more likely, the underlying `Notify` library) isn't working correctly. See relevant issue #1849.

This small change adds support for using the old watcher based on polling the filesystem, instead of the new, `watchfiles`-based watcher. This is relevant for people (like me), for whom the new watcher doesn't work as expected. The support is via a simple command-line flag (`--poll-watcher`), which, when present, is propagated to the constructor of `FavaLedger`, where the decision to use either the old `Watcher` or the new `WatchfilesWatcher` is made based on that flag's value.