### PR TITLE
Show unrealized profit percentage in Holdings tab

### DIFF
--- a/frontend/src/reports/holdings/index.ts
+++ b/frontend/src/reports/holdings/index.ts
@@ -27,6 +27,7 @@ SELECT
     first(getprice(currency, cost_currency)) as price,
     cost(sum(position)) as book_value,
     value(sum(position)) as market_value,
+    safediv((abs(sum(number(value(position)))) - abs(sum(number(cost(position))))), sum(number(cost(position)))) * 100 as unrealized_profit_pct,
     cost_date as acquisition_date
 WHERE account_sortkey(account) ~ "^[01]"
 GROUP BY account, cost_date, currency, cost_currency, cost_number, account_sortkey(account)


### PR DESCRIPTION
The commit that introduced the unrealized profit/loss percentage column in the holdings tabs left out the primary Holdings tab for some unstated reason.

Issue: https://github.com/beancount/fava/issues/1384
Commit: https://github.com/beancount/fava/commit/971ae3757daeae8b8b407c8a28072adcc40055cd

I believe that seeing the unrealized profit or loss of each individual lot can be very useful:

![holdings](https://github.com/user-attachments/assets/56ac8dd2-0daa-4fed-ac85-81f3affe4b82)