### PR TITLE
frontend: AutocompleteInput: escape * in fuzzyfinding (#1846)

### DIFF
--- a/frontend/src/AutocompleteInput.svelte
+++ b/frontend/src/AutocompleteInput.svelte
@@ -72,6 +72,7 @@
       input != null && valueSelector != null
         ? valueSelector(suggestion, input)
         : suggestion;
+    value = value.replace("*", "\\*");
     dispatch("select", input);
     hidden = true;
   }


### PR DESCRIPTION
When inserting a suggestion, the value can have invalid characters, and in particular `*` which can easily be present on the payee: field or narration field.

Fixes #1846

<!--
Hi, thank you for opening a PR!

Please ensure that your change passes tests and the various linters by running
`make test` and `make lint`. If testable, your changes should be covered by
unit tests.

Explain your changes below and link to related issues.
-->
