### PR TITLE
Support mobile document uploads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ node_modules
 .env
 TODO
 npm-debug.log
+.venv

--- a/frontend/css/journal-table.css
+++ b/frontend/css/journal-table.css
@@ -54,6 +54,7 @@
 .journal .postings .num {
   overflow: auto;
   line-height: 16px;
+  margin-top: 4px;
 }
 
 .journal > li,
@@ -152,6 +153,7 @@
 
 .journal .show-postings .description {
   white-space: normal;
+  margin-top: 4px;
 }
 
 .journal .description .separator::before {
@@ -230,4 +232,27 @@
   color: var(--journal-metadata-indicator);
   text-transform: lowercase;
   border-radius: 20px;
+}
+
+.file-input-wrapper {
+  position: relative;
+}
+
+.file-input-wrapper svg {
+  fill: white;
+}
+
+.file-input-wrapper input[type="file"] {
+  bottom: 0;
+  height: 100%;
+  left: 0;
+  margin: 0;
+  opacity: 0;
+  padding: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
+  width: 100%;
+  cursor: pointer;
+  text-indent: -100px
 }

--- a/src/fava/templates/_journal_table.html
+++ b/src/fava/templates/_journal_table.html
@@ -135,7 +135,12 @@
         {% for posting in entry.postings %}
         <li{% if posting.flag %} class="{{ posting.flag|flag_to_type }}"{% endif %}>
             <p>
-                <span class="datecell"></span>
+                <span class="datecell">
+                  <span class="file-input-wrapper">
+                    <svg height="20px" id="Layer_1" style="enable-background:new 0 0 512 512;" version="1.1" viewBox="0 0 512 512" width="20px" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><g><g><polygon points="193.3,260.4 181.7,248.8 256.2,174.5 330.7,248.8 319,260.4 264.4,205.8 264.4,447.6 247.9,447.6 247.9,205.8       "/></g><g><path d="M399.3,183.6c0-1.2,0.2-2.4,0.2-3.6c0-64.3-52.8-116.4-116.8-116.4c-46.1,0-85.8,27.1-104.4,66.3    c-8.1-4.1-17.1-6.4-26.8-6.4c-29.6,0-54.1,23.6-58.9,52C57.4,187.6,32,222.2,32,261.8c0,49.7,40.1,90.2,89.6,90.2H213v-16h-90.6    c-40.9,0-74.2-33.5-74.2-74.6c0-31.8,20.2-61.2,50.2-71.6l8.4-2.9l1.5-8.8c3.6-21.6,22.1-39.3,43.9-39.3c6.9,0,13.7,1.6,19.9,4.8    l13.5,6.8l6.5-13.7c16.6-34.9,52.1-57.4,90.4-57.4c55.3,0,100.9,43.3,100.9,98.9c0,13.3-0.2,20.3-0.2,20.3l15.2,0.1    C435,199.1,464,232,464,268.9c0,36.8-29.8,66.9-66.5,67.1l-3.2,0H297v16h101h0c45,0,82-37.3,82-82.8    C480,223.7,444.5,183.7,399.3,183.6z"/></g></g></svg>
+                    <input type="file" class="posting-file-uploader" data-entry="{{ entry_hash }}" data-account-name="{{ posting.account }}" data-entry-date="{{ entry.date }}"/>
+                  </span>
+                </span>
                 <span class="flag">{{ posting.flag or '' }}</span>
                 <span class="description droptarget" data-entry="{{ entry_hash }}" data-account-name="{{ posting.account }}" data-entry-date="{{ entry.date }}">{{ account_link(posting.account) }}</span>
                 {# We want the output these amounts with the same precision as in the input file.


### PR DESCRIPTION
This adds support for mobile document uploads by exposing a file input in the postings section. This allows for easy upload of documents for a specific transaction and account. 

I considered adding a file input to the Context dialog, but that proved to be a dead-end since the entry hash changes on file upload. In order to support that, there would either need to be a way to re-calculate the hash after file upload and then reload the context dialog without disturbing unsaved changes, or a way to send the file upload and changes to the transactions in a single atomic PUT request. Those are both possible, but probably not worth the effort.

This alternative implementation has a bit better UX in my opinion, as it allows to easily associate a document with an account simply by clicking the file upload button next to the posting entry.

closes https://github.com/beancount/fava/issues/421