### PR TITLE
fix color of cursor in editor when using dark mode

### DIFF
--- a/frontend/css/editor.css
+++ b/frontend/css/editor.css
@@ -36,4 +36,8 @@
 .cm-editor .cm-selectionMatch {
   background-color: var(--editor-selectionmatch);
 }
+
+.cm-editor .cm-cursor {
+  border-left-color: var(--text-color-lighter);
+}
 /* stylelint-enable selector-class-pattern */


### PR DESCRIPTION
In dark mode the cursor was black which made it difficult to see, this PR sets the color such that it changes according to the theme.