### PR TITLE
Re-execute query on filter param change

### DIFF
--- a/frontend/src/helpers.ts
+++ b/frontend/src/helpers.ts
@@ -71,6 +71,14 @@ export function urlForSource(file_path: string, line: string): string {
     : urlFor("editor/", { file_path, line });
 }
 
+/** URL for one of Fava's reports (derived store to keep track of filter changes.). */
+export const urlForSynced = derived(
+  [base_url, searchParams],
+  ([$base_url, $searchParams]) =>
+    (report: string, params?: Record<string, string>): string =>
+      urlForInternal($base_url, $searchParams, report, params),
+);
+
 /** URL for the account report (derived store to keep track of filter changes.). */
 export const urlForAccount = derived(
   [base_url, searchParams],

--- a/frontend/src/reports/query/Query.svelte
+++ b/frontend/src/reports/query/Query.svelte
@@ -29,6 +29,12 @@
     }),
   );
 
+  onMount(() =>
+    filter_params.subscribe(() => {
+      rerun_all();
+    }),
+  );
+
   /** Submit the current query and load the result for it. */
   function submit() {
     const query = query_string;
@@ -55,6 +61,22 @@
         document.querySelector("article")?.scroll(0, 0);
       })
       .catch(log_error);
+  }
+
+  /* Resubmit all queries on global filter change */
+  function rerun_all() {
+    for (const query of Object.keys(results)) {
+      get("query", { query_string: query, ...$filter_params })
+        .then(
+          (res) => ok(res),
+          (error: unknown) =>
+            err(error instanceof Error ? error.message : "INTERNAL ERROR"),
+        )
+        .then((res) => {
+          results[query] = res;
+        })
+        .catch(log_error);
+    }
   }
 
   /** Delete the given query from the history and potentially clear it from the form. */

--- a/frontend/src/sidebar/AsideContents.svelte
+++ b/frontend/src/sidebar/AsideContents.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { urlFor } from "../helpers";
+  import { urlForSynced } from "../helpers";
   import { _ } from "../i18n";
   import { keyboardShortcut } from "../keyboard-shortcuts";
   import { errors, extensions, ledgerData } from "../stores";
@@ -31,7 +31,9 @@
       <ul class="submenu">
         {#each user_queries as { query_string, name }}
           <li>
-            <a href={urlFor("query/", { query_string })}>{truncate(name)}</a>
+            <a href={$urlForSynced("query/", { query_string })}
+              >{truncate(name)}</a
+            >
           </li>
         {/each}
       </ul>


### PR DESCRIPTION
<!--
Hi, thank you for opening a PR!

Please ensure that your change passes tests and the various linters by running
`make test` and `make lint`. If testable, your changes should be covered by
unit tests.

Explain your changes below and link to related issues.
-->

I discovered that since Fava 1.29, changing time or account filters on top-right corner doesn't update the current query anymore, despite the params in URL being changed.

This PR fixes the issue by re-submitting the query when filter_params are changed.