### PR TITLE
util: use types from wsgiref.types

### DIFF
--- a/src/fava/util/__init__.py
+++ b/src/fava/util/__init__.py
@@ -22,9 +22,9 @@ if TYPE_CHECKING:  # pragma: no cover
     from typing import Callable
     from typing import ParamSpec
     from typing import TypeVar
+    from wsgiref.types import StartResponse
+    from wsgiref.types import WSGIEnvironment
 
-    from _typeshed.wsgi import StartResponse
-    from _typeshed.wsgi import WSGIEnvironment
     from babel import Locale
     from flask.wrappers import Response
 


### PR DESCRIPTION
These were only added in 3.11, but it's fine if type checking only
works in more recent versions

<!--
Hi, thank you for opening a PR!

Please ensure that your change passes tests and the various linters by running
`make test` and `make lint`. If testable, your changes should be covered by
unit tests.

Explain your changes below and link to related issues.
-->
