### PR TITLE
Fix beancount3 duplicate logic

### DIFF
--- a/src/fava/core/ingest.py
+++ b/src/fava/core/ingest.py
@@ -307,6 +307,11 @@ def extract_from_file(
         entries.sort(key=_incomplete_sortkey)
     if isinstance(importer, Importer):
         importer.deduplicate(entries, existing=existing_entries)
+        for entry in entries:
+            # beangulp importers __duplicate__ metadata contains original entry
+            # and not True, so map it to True
+            if entry.meta.pop("__duplicate__", False):
+                entry.meta["__duplicate__"] = True
     return entries
 
 


### PR DESCRIPTION
With beancount3 the __duplicate__ field can now contain the original entry instead of "True", mapping this to the old "True" value for the rest of the import logic to work