### PR TITLE
import: interpret any non-false value as truish in duplicate metadata

### DIFF
--- a/frontend/src/entries.ts
+++ b/frontend/src/entries.ts
@@ -346,5 +346,5 @@ export const entryValidator: Validator<Entry> = tagged_union("t", {
  * Check whether the given entry is marked as duplicate (used in imports).
  */
 export function isDuplicate(e: Entry): boolean {
-  return e.meta.__duplicate__ === true;
+  return e.meta.__duplicate__ != null && e.meta.__duplicate__ !== false;
 }


### PR DESCRIPTION
beangulp sets the __duplicate__ metadata to reference the duplicated
transaction, so do not only check for `true` but for any value present
unless it's false. Even better future improvement would be to show the
duplicated entry (as a printed string possibl)

<!--
Hi, thank you for opening a PR!

Please ensure that your change passes tests and the various linters by running
`make test` and `make lint`. If testable, your changes should be covered by
unit tests.

Explain your changes below and link to related issues.
-->
