### PR TITLE
filters: Match metadata keys for postings as well

### DIFF
--- a/src/fava/core/filters.py
+++ b/src/fava/core/filters.py
@@ -361,9 +361,15 @@ class FilterSyntaxParser:
         def _key(entry: Directive) -> bool:
             if hasattr(entry, key):
                 return match(getattr(entry, key) or "")
-            if entry.meta is not None and key in entry.meta:
-                return match(entry.meta.get(key))
-            return False
+            return (
+                entry.meta is not None
+                and key in entry.meta
+                and match(entry.meta.get(key))
+            ) or any(
+                match(posting.meta.get(key))
+                for posting in getattr(entry, "postings", [])
+                if posting.meta is not None and key in posting.meta
+            )
 
         p[0] = _key
 

--- a/src/fava/help/filters.md
+++ b/src/fava/help/filters.md
@@ -45,9 +45,10 @@ This final filter allows you to filter entries by various attributes.
   for an exact match instead.
 - Search in payee and narration if no specific entry attribute is given, e.g.
   `"Cash withdrawal"`. For Note directives, the comment will be searched.
-- Filter for entries having certain metadata values: `document:"\.pdf$"`. Note
-  that if the entry has an attribute of the same name as the metadata key, the
-  filter will apply to the entry attribute, not the metadata value.
+- Filter for entries or postings having certain metadata values:
+  `document:"\.pdf$"`. Note that if the entry has an attribute of the same name
+  as the metadata key, the filter will apply to the entry attribute, not the
+  metadata value.
 - Exclude entries that match a filter by prepending a `-` to it, e.g. `-#tag` or
   `-(^link #tag)`.
 - To match entries by posting attributes, you can use `any()` and `all()`, e.g.,


### PR DESCRIPTION
This PR extends the metadata filtering to match against postings' metadata as well.

For instance, currently, when filtering for `key:""` or `key:"foo"`, the following transaction would not match as the filter only considers the metadata of the entry:

```beancount
2025-01-01 * "Transaction"
  Assets:A -10 CUR
    key: "foo"
  Expenses:B
```