### PR TITLE
feat: add fortnightly interval

### DIFF
--- a/frontend/src/format.ts
+++ b/frontend/src/format.ts
@@ -51,6 +51,12 @@ export const dateFormat: Record<Interval, DateFormatter> = {
   quarter: (date) =>
     `${date.getUTCFullYear().toString()}Q${(Math.floor(date.getUTCMonth() / 3) + 1).toString()}`,
   month: utcFormat("%b %Y"),
+  fortnight: (date) => {
+    const year = Number.parseInt(utcFormat("%G")(date));
+    const week = Number.parseInt(utcFormat("%V")(date));
+    const [w1, w2] = week % 2 === 0 ? [week - 1, week] : [week, week + 1];
+    return `${year.toString()}W${w1.toString().padStart(2, "0")}/${w2.toString().padStart(2, "0")}`;
+  },
   week: utcFormat("%YW%W"),
   day,
 };
@@ -61,6 +67,12 @@ export const timeFilterDateFormat: Record<Interval, DateFormatter> = {
   quarter: (date) =>
     `${date.getUTCFullYear().toString()}-Q${(Math.floor(date.getUTCMonth() / 3) + 1).toString()}`,
   month: utcFormat("%Y-%m"),
+  fortnight: (date) => {
+    const year = Number.parseInt(utcFormat("%G")(date));
+    const week = Number.parseInt(utcFormat("%V")(date));
+    const [w1, w2] = week % 2 === 0 ? [week - 1, week] : [week, week + 1];
+    return `${year.toString()}-W${w1.toString().padStart(2, "0")}/${w2.toString().padStart(2, "0")}`;
+  },
   week: utcFormat("%Y-W%W"),
   day,
 };

--- a/frontend/src/lib/interval.ts
+++ b/frontend/src/lib/interval.ts
@@ -1,6 +1,12 @@
 import { _ } from "../i18n";
 
-export type Interval = "year" | "quarter" | "month" | "week" | "day";
+export type Interval =
+  | "year"
+  | "quarter"
+  | "month"
+  | "fortnight"
+  | "week"
+  | "day";
 
 export const DEFAULT_INTERVAL: Interval = "month";
 
@@ -8,6 +14,7 @@ export const INTERVALS: Interval[] = [
   "year",
   "quarter",
   "month",
+  "fortnight",
   "week",
   "day",
 ];
@@ -22,6 +29,7 @@ export function intervalLabel(s: Interval): string {
     year: _("Yearly"),
     quarter: _("Quarterly"),
     month: _("Monthly"),
+    fortnight: _("Fortnightly"),
     week: _("Weekly"),
     day: _("Daily"),
   }[s];

--- a/frontend/test/format.test.ts
+++ b/frontend/test/format.test.ts
@@ -29,16 +29,19 @@ test("locale number formatting", () => {
 });
 
 test("time filter date formatting", () => {
-  const { day, month, week, quarter, year, ...rest } = timeFilterDateFormat;
+  const { day, week, fortnight, month, quarter, year, ...rest } =
+    timeFilterDateFormat;
   assert.equal(rest, {});
   const janfirst = new Date("2020-01-01");
   const date = new Date("2020-03-20");
   assert.is(day(janfirst), "2020-01-01");
   assert.is(day(date), "2020-03-20");
-  assert.is(month(janfirst), "2020-01");
-  assert.is(month(date), "2020-03");
   assert.is(week(janfirst), "2020-W00");
   assert.is(week(date), "2020-W11");
+  assert.is(fortnight(janfirst), "2020-W01/02");
+  assert.is(fortnight(date), "2020-W11/12");
+  assert.is(month(janfirst), "2020-01");
+  assert.is(month(date), "2020-03");
   assert.is(quarter(janfirst), "2020-Q1");
   assert.is(quarter(date), "2020-Q1");
   assert.is(year(janfirst), "2020");
@@ -46,16 +49,18 @@ test("time filter date formatting", () => {
 });
 
 test("human-readable date formatting", () => {
-  const { day, month, week, quarter, year, ...rest } = dateFormat;
+  const { day, week, fortnight, month, quarter, year, ...rest } = dateFormat;
   assert.equal(rest, {});
   const janfirst = new Date("2020-01-01");
   const date = new Date("2020-03-20");
   assert.is(day(janfirst), "2020-01-01");
   assert.is(day(date), "2020-03-20");
-  assert.is(month(janfirst), "Jan 2020");
-  assert.is(month(date), "Mar 2020");
   assert.is(week(janfirst), "2020W00");
   assert.is(week(date), "2020W11");
+  assert.is(fortnight(janfirst), "2020W01/02");
+  assert.is(fortnight(date), "2020W11/12");
+  assert.is(month(janfirst), "Jan 2020");
+  assert.is(month(date), "Mar 2020");
   assert.is(quarter(janfirst), "2020Q1");
   assert.is(quarter(date), "2020Q1");
   assert.is(year(janfirst), "2020");

--- a/src/fava/core/budgets.py
+++ b/src/fava/core/budgets.py
@@ -103,6 +103,7 @@ def parse_budgets(
     interval_map = {
         "daily": Interval.DAY,
         "weekly": Interval.WEEK,
+        "fortnightly": Interval.FORTNIGHT,
         "monthly": Interval.MONTH,
         "quarterly": Interval.QUARTER,
         "yearly": Interval.YEAR,

--- a/src/fava/help/budgets.md
+++ b/src/fava/help/budgets.md
@@ -14,13 +14,40 @@ Beancount file:
 If budgets are specified, Fava's reports and charts will display remaining
 budgets and related information.
 
-The budget directives can be specified `daily`, `weekly`, `fortnightly`,
-`monthly`, `quarterly` and `yearly`. The specified budget is valid until another
-budget directive for the account is specified. The budget is broken down to a
-daily budget, and summed up for a range of dates as needed.
+Each budget directive has an accunt for which the budget is specified, a
+frequency and amount of the budget, and a date from which the budget is valid. A
+budget directive remains valid until another budget directive for the account is
+specified. For example:
 
-This makes the budgets very flexible, allowing for a monthly budget, being taken
-over by a weekly budget, and so on.
+<pre><textarea is="beancount-textarea">
+2012-01-01 custom "budget" Expenses:Coffee       "daily"         4.00 EUR
+2013-01-01 custom "budget" Expenses:Coffee       "daily"         5.00 EUR
+2014-01-01 custom "budget" Expenses:Coffee       "weekly"        6.00 EUR</textarea></pre>
+
+In this example, the coffee budget is 4.00 EUR for 2012, then increases to 5.00
+EUR in 2013, and finally to 30 EUR per week in 2014.
+
+Fava supports the following frequencies for the budget:
+
+- `daily`
+- `weekly`
+  - The week align with ISO weeks, and start on Monday.
+- `fortnightly`
+  - Note that there are no standard conventions for dividing a year into
+    fortnights, and as such, Fava uses the following:
+    - The fortnight align with ISO weeks, with the first fortnight being W01 and
+      W02 of the year.
+    - For a year with 53 weeks, the last fortnight is W53 and W54 (equivalent to
+      the next year's W01). This unfortunately does result in overlapping
+      fortnights once every 7 years approximately.
+- `monthly`
+  - This is the calendar month, and Fava internally uses the number of days in
+    each month to calculate the monthly budget. As a result, February with 28
+    days will have a lower budget than January with 31 days.
+- `quarterly`
+  - Based on the calendar quarter, with the quarters starting on January 1,
+    April 1, July 1, and October 1.
+- `yearly`
 
 Fava displays budgets in both charts and reports. You can find a visualization
 of the global budget in the `Net Profit` and `Expenses` charts for the Income

--- a/src/fava/help/budgets.md
+++ b/src/fava/help/budgets.md
@@ -6,6 +6,7 @@ Beancount file:
 <pre><textarea is="beancount-textarea">
 2012-01-01 custom "budget" Expenses:Coffee       "daily"         4.00 EUR
 2013-01-01 custom "budget" Expenses:Books        "weekly"       20.00 EUR
+2013-01-01 custom "budget" Expenses:Fuel         "fortnightly"  60.00 EUR
 2014-02-10 custom "budget" Expenses:Groceries    "monthly"      40.00 EUR
 2015-05-01 custom "budget" Expenses:Electricity  "quarterly"    85.00 EUR
 2016-06-01 custom "budget" Expenses:Holiday      "yearly"     2500.00 EUR</textarea></pre>
@@ -13,10 +14,10 @@ Beancount file:
 If budgets are specified, Fava's reports and charts will display remaining
 budgets and related information.
 
-The budget directives can be specified `daily`, `weekly`, `monthly`, `quarterly`
-and `yearly`. The specified budget is valid until another budget directive for
-the account is specified. The budget is broken down to a daily budget, and
-summed up for a range of dates as needed.
+The budget directives can be specified `daily`, `weekly`, `fortnightly`,
+`monthly`, `quarterly` and `yearly`. The specified budget is valid until another
+budget directive for the account is specified. The budget is broken down to a
+daily budget, and summed up for a range of dates as needed.
 
 This makes the budgets very flexible, allowing for a monthly budget, being taken
 over by a weekly budget, and so on.

--- a/src/fava/translations/bg/LC_MESSAGES/messages.po
+++ b/src/fava/translations/bg/LC_MESSAGES/messages.po
@@ -432,6 +432,10 @@ msgid "Monthly"
 msgstr "Месечен"
 
 #: frontend/src/lib/interval.ts:25 src/fava/util/date.py:105
+msgid "Fortnightly"
+msgstr "На всеки две седмици"
+
+#: frontend/src/lib/interval.ts:25 src/fava/util/date.py:105
 msgid "Weekly"
 msgstr "Седмичен"
 
@@ -592,4 +596,3 @@ msgstr "Изтриване..."
 #: frontend/src/sidebar/AsideContents.svelte:60
 msgid "Add Journal Entry"
 msgstr ""
-

--- a/src/fava/translations/ca/LC_MESSAGES/messages.po
+++ b/src/fava/translations/ca/LC_MESSAGES/messages.po
@@ -432,6 +432,10 @@ msgid "Monthly"
 msgstr "Per mes"
 
 #: frontend/src/lib/interval.ts:25 src/fava/util/date.py:105
+msgid "Fortnightly"
+msgstr "Per quinzena"
+
+#: frontend/src/lib/interval.ts:25 src/fava/util/date.py:105
 msgid "Weekly"
 msgstr "Per setmana"
 
@@ -592,4 +596,3 @@ msgstr "S'està suprimint..."
 #: frontend/src/sidebar/AsideContents.svelte:60
 msgid "Add Journal Entry"
 msgstr ""
-

--- a/src/fava/translations/de/LC_MESSAGES/messages.po
+++ b/src/fava/translations/de/LC_MESSAGES/messages.po
@@ -432,6 +432,10 @@ msgid "Monthly"
 msgstr "Monatlich"
 
 #: frontend/src/lib/interval.ts:25 src/fava/util/date.py:105
+msgid "Fortnightly"
+msgstr "Zweiwöchentlich"
+
+#: frontend/src/lib/interval.ts:25 src/fava/util/date.py:105
 msgid "Weekly"
 msgstr "Wöchentlich"
 
@@ -592,4 +596,3 @@ msgstr "Wird gelöscht..."
 #: frontend/src/sidebar/AsideContents.svelte:60
 msgid "Add Journal Entry"
 msgstr "Journal-Eintrag hinzufügen"
-

--- a/src/fava/translations/fa/LC_MESSAGES/messages.po
+++ b/src/fava/translations/fa/LC_MESSAGES/messages.po
@@ -432,6 +432,10 @@ msgid "Monthly"
 msgstr "ماهانه"
 
 #: frontend/src/lib/interval.ts:25 src/fava/util/date.py:105
+msgid "Fortnightly"
+msgstr "هر دو هفته یکبار"
+
+#: frontend/src/lib/interval.ts:25 src/fava/util/date.py:105
 msgid "Weekly"
 msgstr "هفتگی"
 
@@ -592,4 +596,3 @@ msgstr ""
 #: frontend/src/sidebar/AsideContents.svelte:60
 msgid "Add Journal Entry"
 msgstr ""
-

--- a/src/fava/translations/fr/LC_MESSAGES/messages.po
+++ b/src/fava/translations/fr/LC_MESSAGES/messages.po
@@ -432,6 +432,10 @@ msgid "Monthly"
 msgstr "Mensuel"
 
 #: frontend/src/lib/interval.ts:25 src/fava/util/date.py:105
+msgid "Fortnightly"
+msgstr "Bimensuel"
+
+#: frontend/src/lib/interval.ts:25 src/fava/util/date.py:105
 msgid "Weekly"
 msgstr "Hebdomadaire"
 
@@ -592,4 +596,3 @@ msgstr "Suppression..."
 #: frontend/src/sidebar/AsideContents.svelte:60
 msgid "Add Journal Entry"
 msgstr ""
-

--- a/src/fava/translations/nl/LC_MESSAGES/messages.po
+++ b/src/fava/translations/nl/LC_MESSAGES/messages.po
@@ -432,6 +432,10 @@ msgid "Monthly"
 msgstr "Maandelijks"
 
 #: frontend/src/lib/interval.ts:25 src/fava/util/date.py:105
+msgid "Fortnightly"
+msgstr "Tweewekelijks"
+
+#: frontend/src/lib/interval.ts:25 src/fava/util/date.py:105
 msgid "Weekly"
 msgstr "Wekelijks"
 
@@ -592,4 +596,3 @@ msgstr ""
 #: frontend/src/sidebar/AsideContents.svelte:60
 msgid "Add Journal Entry"
 msgstr ""
-

--- a/src/fava/translations/pt_BR/LC_MESSAGES/messages.po
+++ b/src/fava/translations/pt_BR/LC_MESSAGES/messages.po
@@ -433,6 +433,10 @@ msgid "Monthly"
 msgstr "Mensal"
 
 #: frontend/src/lib/interval.ts:25 src/fava/util/date.py:105
+msgid "Fortnightly"
+msgstr "Quinzenal"
+
+#: frontend/src/lib/interval.ts:25 src/fava/util/date.py:105
 msgid "Weekly"
 msgstr "Semanal"
 
@@ -593,4 +597,3 @@ msgstr "Apagando..."
 #: frontend/src/sidebar/AsideContents.svelte:60
 msgid "Add Journal Entry"
 msgstr "Adicionar Entrada"
-

--- a/src/fava/translations/ru/LC_MESSAGES/messages.po
+++ b/src/fava/translations/ru/LC_MESSAGES/messages.po
@@ -431,6 +431,10 @@ msgid "Monthly"
 msgstr "По месяцам"
 
 #: frontend/src/lib/interval.ts:25 src/fava/util/date.py:105
+msgid "Fortnightly"
+msgstr "Каждые две недели"
+
+#: frontend/src/lib/interval.ts:25 src/fava/util/date.py:105
 msgid "Weekly"
 msgstr "По неделям"
 
@@ -591,4 +595,3 @@ msgstr ""
 #: frontend/src/sidebar/AsideContents.svelte:60
 msgid "Add Journal Entry"
 msgstr ""
-

--- a/src/fava/translations/sk/LC_MESSAGES/messages.po
+++ b/src/fava/translations/sk/LC_MESSAGES/messages.po
@@ -437,6 +437,10 @@ msgid "Monthly"
 msgstr "Mesačne"
 
 #: frontend/src/lib/interval.ts:25 src/fava/util/date.py:105
+msgid "Fortnightly"
+msgstr "Dvotýždenne"
+
+#: frontend/src/lib/interval.ts:25 src/fava/util/date.py:105
 msgid "Weekly"
 msgstr "Týždenne"
 
@@ -597,4 +601,3 @@ msgstr ""
 #: frontend/src/sidebar/AsideContents.svelte:60
 msgid "Add Journal Entry"
 msgstr ""
-

--- a/src/fava/translations/sv/LC_MESSAGES/messages.po
+++ b/src/fava/translations/sv/LC_MESSAGES/messages.po
@@ -432,6 +432,10 @@ msgid "Monthly"
 msgstr "Månatligt"
 
 #: frontend/src/lib/interval.ts:25 src/fava/util/date.py:105
+msgid "Fortnightly"
+msgstr "Var fjortonde dag"
+
+#: frontend/src/lib/interval.ts:25 src/fava/util/date.py:105
 msgid "Weekly"
 msgstr "Veckovis"
 
@@ -592,4 +596,3 @@ msgstr ""
 #: frontend/src/sidebar/AsideContents.svelte:60
 msgid "Add Journal Entry"
 msgstr ""
-

--- a/src/fava/translations/uk/LC_MESSAGES/messages.po
+++ b/src/fava/translations/uk/LC_MESSAGES/messages.po
@@ -432,6 +432,10 @@ msgid "Monthly"
 msgstr "Щомісячно"
 
 #: frontend/src/lib/interval.ts:25 src/fava/util/date.py:105
+msgid "Fortnightly"
+msgstr "двотижневий"
+
+#: frontend/src/lib/interval.ts:25 src/fava/util/date.py:105
 msgid "Weekly"
 msgstr "Щотижнево"
 
@@ -592,4 +596,3 @@ msgstr ""
 #: frontend/src/sidebar/AsideContents.svelte:60
 msgid "Add Journal Entry"
 msgstr ""
-

--- a/src/fava/translations/zh/LC_MESSAGES/messages.po
+++ b/src/fava/translations/zh/LC_MESSAGES/messages.po
@@ -432,6 +432,10 @@ msgid "Monthly"
 msgstr "按月"
 
 #: frontend/src/lib/interval.ts:25 src/fava/util/date.py:105
+msgid "Fortnightly"
+msgstr "按两周"
+
+#: frontend/src/lib/interval.ts:25 src/fava/util/date.py:105
 msgid "Weekly"
 msgstr "按周"
 
@@ -592,4 +596,3 @@ msgstr "正在删除..."
 #: frontend/src/sidebar/AsideContents.svelte:60
 msgid "Add Journal Entry"
 msgstr "添加日记账条目"
-

--- a/src/fava/translations/zh_Hant_TW/LC_MESSAGES/messages.po
+++ b/src/fava/translations/zh_Hant_TW/LC_MESSAGES/messages.po
@@ -433,6 +433,10 @@ msgid "Monthly"
 msgstr "月"
 
 #: frontend/src/lib/interval.ts:25 src/fava/util/date.py:105
+msgid "Fortnightly"
+msgstr "兩周"
+
+#: frontend/src/lib/interval.ts:25 src/fava/util/date.py:105
 msgid "Weekly"
 msgstr "週"
 
@@ -594,4 +598,3 @@ msgstr "正在删除..."
 #: frontend/src/sidebar/AsideContents.svelte:60
 msgid "Add Journal Entry"
 msgstr ""
-

--- a/src/fava/util/date.py
+++ b/src/fava/util/date.py
@@ -207,15 +207,7 @@ def get_prev_interval(  # noqa: PLR0911
     if interval is Interval.FORTNIGHT:
         year, week, _ = date.isocalendar()
         w1 = week - 1 if week % 2 == 0 else week
-        if w1 > 2:
-            return datetime.date.fromisocalendar(year, w1, 1)
-        # If we are in the first fortnight of the year, finding the last
-        # fortnight of the previous year is a bit tricky due to being either
-        # starting on week 51 or 53 (if the year has 53 weeks).
-        try:
-            return datetime.date.fromisocalendar(year - 1, 53, 1)
-        except ValueError:
-            return datetime.date.fromisocalendar(year - 1, 51, 1)
+        return datetime.date.fromisocalendar(year, w1, 1)
     if interval is Interval.WEEK:
         return date - timedelta(date.weekday())
     if interval is Interval.DAY:
@@ -400,8 +392,10 @@ def substitute(  # noqa: PLR0914
             )
 
         else:
-            msg = f"Unknown interval '{interval}'"
-            raise ValueError(msg)
+            # This is unreachable, but mypy doesn't know that as it cannot
+            # infer the values matched by the regex
+            msg = f"Unknown interval '{interval}'"  # pragma: no cover
+            raise ValueError(msg)  # pragma: no cover
     return string
 
 

--- a/tests/test_core_budgets.py
+++ b/tests/test_core_budgets.py
@@ -79,6 +79,18 @@ def test_budgets_weekly(budgets_doc: BudgetDict) -> None:
         assert budget["EUR"] == num
 
 
+def test_budgets_fortnightly(budgets_doc: BudgetDict) -> None:
+    """
+    2016-05-01 custom "budget" Expenses:Books "fortnightly" 42 EUR"""
+
+    for start, end, num in [
+        (date(2016, 5, 1), date(2016, 5, 2), Decimal(21) / 7),
+        (date(2016, 9, 1), date(2016, 9, 2), Decimal(21) / 7),
+    ]:
+        budget = calculate_budget(budgets_doc, "Expenses:Books", start, end)
+        assert budget["EUR"] == num
+
+
 def test_budgets_monthly(budgets_doc: BudgetDict) -> None:
     """
     2014-05-01 custom "budget" Expenses:Books "monthly" 100 EUR"""

--- a/tests/test_util_date.py
+++ b/tests/test_util_date.py
@@ -99,6 +99,13 @@ def test_get_next_interval(
         ("2016-12-31", Interval.YEAR, "2016-01-01"),
         ("9999-12-31", Interval.QUARTER, "9999-10-01"),
         ("9999-12-31", Interval.YEAR, "9999-01-01"),
+        # 53 week year
+        ("2020-12-31", Interval.WEEK, "2020-12-28"),
+        ("2021-01-01", Interval.WEEK, "2020-12-28"),
+        ("2021-01-04", Interval.WEEK, "2021-01-04"),
+        ("2020-12-31", Interval.FORTNIGHT, "2020-12-28"),
+        ("2021-01-01", Interval.FORTNIGHT, "2020-12-28"),
+        ("2021-01-04", Interval.FORTNIGHT, "2021-01-04"),
     ],
 )
 def test_get_prev_interval(
@@ -163,12 +170,17 @@ def test_interval_tuples() -> None:
     ],
 )
 def test_substitute(string: str, output: str) -> None:
-    # Mock the imported datetime.date in fava.util.date module
-    # Ref:
-    # http://www.voidspace.org.uk/python/mock/examples.html#partial-mocking
+    # Use a specific date to make the tests deterministic.
     with mock.patch("fava.util.date.local_today") as mock_date:
         mock_date.return_value = _to_date("2016-06-24")
         assert substitute(string) == output
+
+
+def test_substitute_invalid() -> None:
+    # Use a specific date to make the tests deterministic.
+    with mock.patch("fava.util.date.local_today") as mock_date:
+        mock_date.return_value = _to_date("2016-06-24")
+        assert substitute("asdasd") == "asdasd"
 
 
 @pytest.mark.parametrize(
@@ -228,6 +240,8 @@ def test_fiscal_substitute(
         ("2000-01-03", "2000-01-04", "2000-01-03"),
         ("2015-01-05", "2015-01-12", "2015-W01"),
         ("2025-01-06", "2025-01-13", "2025-W01"),
+        ("2014-12-29", "2015-01-12", "2015-W01/02"),
+        ("2024-12-30", "2025-01-13", "2025-W01/02"),
         ("2015-04-01", "2015-07-01", "2015-Q2"),
         ("2014-01-01", "2016-01-01", "2014 to 2015"),
         ("2014-01-01", "2016-01-01", "2014-2015"),

--- a/tests/test_util_date.py
+++ b/tests/test_util_date.py
@@ -35,6 +35,7 @@ def _to_date(string: str) -> date:
     [
         ("2016-01-01", Interval.DAY, "2016-01-01", "2016-01-01"),
         ("2016-01-04", Interval.WEEK, "2016W01", "2016-W01"),
+        ("2016-01-04", Interval.FORTNIGHT, "2016W01/02", "2016-W01/02"),
         ("2016-01-04", Interval.MONTH, "Jan 2016", "2016-01"),
         ("2016-01-04", Interval.QUARTER, "2016Q1", "2016-Q1"),
         ("2016-01-04", Interval.YEAR, "2016", "2016"),
@@ -58,11 +59,13 @@ def test_interval_format(
     [
         ("2016-01-01", Interval.DAY, "2016-01-02"),
         ("2016-01-01", Interval.WEEK, "2016-01-04"),
+        ("2016-01-01", Interval.FORTNIGHT, "2016-01-04"),
         ("2016-01-01", Interval.MONTH, "2016-02-01"),
         ("2016-01-01", Interval.QUARTER, "2016-04-01"),
         ("2016-01-01", Interval.YEAR, "2017-01-01"),
         ("2016-12-31", Interval.DAY, "2017-01-01"),
         ("2016-12-31", Interval.WEEK, "2017-01-02"),
+        ("2016-12-31", Interval.FORTNIGHT, "2017-01-02"),
         ("2016-12-31", Interval.MONTH, "2017-01-01"),
         ("2016-12-31", Interval.QUARTER, "2017-01-01"),
         ("2016-12-31", Interval.YEAR, "2017-01-01"),
@@ -84,11 +87,13 @@ def test_get_next_interval(
     [
         ("2016-01-01", Interval.DAY, "2016-01-01"),
         ("2016-01-01", Interval.WEEK, "2015-12-28"),
+        ("2016-01-01", Interval.FORTNIGHT, "2015-12-28"),
         ("2016-01-01", Interval.MONTH, "2016-01-01"),
         ("2016-01-01", Interval.QUARTER, "2016-01-01"),
         ("2016-01-01", Interval.YEAR, "2016-01-01"),
         ("2016-12-31", Interval.DAY, "2016-12-31"),
         ("2016-12-31", Interval.WEEK, "2016-12-26"),
+        ("2016-12-31", Interval.FORTNIGHT, "2016-12-19"),
         ("2016-12-31", Interval.MONTH, "2016-12-01"),
         ("2016-12-31", Interval.QUARTER, "2016-10-01"),
         ("2016-12-31", Interval.YEAR, "2016-01-01"),
@@ -147,6 +152,9 @@ def test_interval_tuples() -> None:
         ("(month)", "2016-06"),
         ("month+6", "2016-12"),
         ("(month+24)", "2018-06"),
+        ("fortnight", "2016-W25/26"),
+        ("fortnight+10", "2016-W45/46"),
+        ("fortnight+1000", "2054-W43/44"),
         ("week", "2016-W25"),
         ("week+20", "2016-W45"),
         ("week+2000", "2054-W42"),
@@ -158,9 +166,8 @@ def test_substitute(string: str, output: str) -> None:
     # Mock the imported datetime.date in fava.util.date module
     # Ref:
     # http://www.voidspace.org.uk/python/mock/examples.html#partial-mocking
-    with mock.patch("fava.util.date.datetime.date") as mock_date:
-        mock_date.today.return_value = _to_date("2016-06-24")
-        mock_date.side_effect = date
+    with mock.patch("fava.util.date.local_today") as mock_date:
+        mock_date.return_value = _to_date("2016-06-24")
         assert substitute(string) == output
 
 


### PR DESCRIPTION
In some countries (such as Australia), it is very common for wages to be paid on a fortnightly basis, that is, every 2 weeks. As a result, a number of other expenses are also paid on a fortnightly basis.

This commit extends the `Interval` enum by adding a `FORTNIGHT` option. I have added a test for that, and have updated the translations where possible (not that other than for English and French, the other translations may be suboptimal).

~As part of this commit, I have also taken the opportunity to fix a confusion between ISO weeks and calendar weeks as the two do not always match, and `2025-W01` is the ISO format indicating the week starting on December 30 2024. Let me know if you want me to split out this particular change into a separate PR.~ EDIT: I have moved this into #1956.

Resolves: #1939