### PR TITLE
lint: drop pylint

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -6,8 +6,6 @@ altgraph==0.17.4
     # via pyinstaller
 anyio==4.8.0
     # via watchfiles
-astroid==3.3.8
-    # via pylint
 babel==2.17.0
     # via
     #   fava (pyproject.toml)
@@ -61,8 +59,6 @@ coverage==7.6.10
     # via pytest-cov
 cryptography==44.0.0
     # via secretstorage
-dill==0.3.9
-    # via pylint
 distlib==0.3.9
     # via virtualenv
 docutils==0.21.2
@@ -108,8 +104,6 @@ importlib-metadata==8.6.1
     #   twine
 iniconfig==2.0.0
     # via pytest
-isort==6.0.0
-    # via pylint
 itsdangerous==2.2.0
     # via flask
 jaraco-classes==3.4.0
@@ -149,8 +143,6 @@ markupsafe==3.0.2
     # via
     #   jinja2
     #   werkzeug
-mccabe==0.7.0
-    # via pylint
 mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.6.0
@@ -181,7 +173,6 @@ packaging==24.2
     #   twine
 platformdirs==4.3.6
     # via
-    #   pylint
     #   tox
     #   virtualenv
 pluggy==1.5.0
@@ -217,8 +208,6 @@ pyinstaller==6.11.1
     # via fava (pyproject.toml)
 pyinstaller-hooks-contrib==2025.1
     # via pyinstaller
-pylint==3.3.4
-    # via fava (pyproject.toml)
 pyproject-api==1.9.0
     # via tox
 pyproject-hooks==1.2.0
@@ -304,13 +293,10 @@ tomli==2.2.1
     #   build
     #   coverage
     #   mypy
-    #   pylint
     #   pyproject-api
     #   pytest
     #   sphinx
     #   tox
-tomlkit==0.13.2
-    # via pylint
 tox==4.24.1
     # via
     #   fava (pyproject.toml)
@@ -326,10 +312,8 @@ types-simplejson==3.19.0.20241221
 typing-extensions==4.12.2
     # via
     #   anyio
-    #   astroid
     #   beautifulsoup4
     #   mypy
-    #   pylint
     #   rich
     #   tox
     #   tox-uv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,6 @@ dev = [
     "mypy>=1.14",
     "pre-commit>=4",
     "pyinstaller>=6",
-    "pylint>=3.2",
     "pytest>=8",
     "pytest-cov>=6",
     "requests>=2",
@@ -119,30 +118,6 @@ preview = true
 [tool.mypy]
 mypy_path = "stubs"
 strict = true
-
-[tool.pylint.'messages control']
-disable = [
-    "too-few-public-methods",
-    "too-many-branches",              # is checked by ruff (PLR0912)
-    "too-many-instance-attributes",
-    "too-many-locals",                # is checked by ruff (PLR0914)
-    "duplicate-code",
-    "unused-argument",                # is checked by ruff (ARG001)
-    "stop-iteration-return",
-    "ungrouped-imports",
-    "invalid-unary-operand-type",    # type-checking like, had false-positives
-    "not-an-iterable",               # type-checking like, had false-positives
-    "unsubscriptable-object",        # type-checking like, had false-positives
-    "broad-except",                  # is checked by ruff (BLE)
-    "too-many-return-statements",    # is checked by ruff (PLR0911)
-    "too-many-arguments",            # is checked by ruff (PLR0913)
-    "too-many-positional-arguments", # is checked by ruff (PLR0917)
-    "redefined-builtin",             # is checked by ruff (A002)
-    "protected-access",              # is checked by ruff (SLF001)
-    "invalid-name",                  # is checked by ruff (N)
-    "missing-docstring",             # is checked by ruff (D)
-    "redefined-outer-name",          # false positives for pytest fixtures
-]
 
 [tool.pytest.ini_options]
 filterwarnings = "ignore:.*locked_cached_property.*deprecated:DeprecationWarning"
@@ -196,3 +171,32 @@ max-args = 9
 "tests/test_*.py" = ["D", "PLC2701", "S101", "SLF001"]
 "tests/data/import_config.py" = ["D", "INP"]
 "src/fava/core/filters.py" = ["D"]
+
+# pylint is not run as part of linting for Fava anymore but we keep these disables
+# around for devs who might have pylint automatically run by their editors to avoid
+# a ton of pylint warnings
+# mypy with strict settings handles most of the whole-project analysis where pylint
+# still shines - the simpler rules are mostly covered by ruff
+[tool.pylint.'messages control']
+disable = [
+    "too-few-public-methods",
+    "too-many-branches",              # is checked by ruff (PLR0912)
+    "too-many-instance-attributes",
+    "too-many-locals",                # is checked by ruff (PLR0914)
+    "duplicate-code",
+    "unused-argument",                # is checked by ruff (ARG001)
+    "stop-iteration-return",
+    "ungrouped-imports",
+    "invalid-unary-operand-type",    # type-checking like, had false-positives
+    "not-an-iterable",               # type-checking like, had false-positives
+    "unsubscriptable-object",        # type-checking like, had false-positives
+    "broad-except",                  # is checked by ruff (BLE)
+    "too-many-return-statements",    # is checked by ruff (PLR0911)
+    "too-many-arguments",            # is checked by ruff (PLR0913)
+    "too-many-positional-arguments", # is checked by ruff (PLR0917)
+    "redefined-builtin",             # is checked by ruff (A002)
+    "protected-access",              # is checked by ruff (SLF001)
+    "invalid-name",                  # is checked by ruff (N)
+    "missing-docstring",             # is checked by ruff (D)
+    "redefined-outer-name",          # false positives for pytest fixtures
+]

--- a/tox.ini
+++ b/tox.ini
@@ -40,7 +40,6 @@ commands =
 [testenv:lint]
 deps =
     mypy
-    pylint
     pytest
     setuptools
     types-setuptools
@@ -48,7 +47,6 @@ deps =
     -c constraints.txt
 commands =
     mypy src/fava tests _build_backend.py
-    pylint src/fava tests _build_backend.py
 
 [testenv:pyinstaller]
 deps =


### PR DESCRIPTION
pylint doesn't add much since we have mypy and ruff but is quite slow
and this shaves about 10s off of `make lint` on my machine

<!--
Hi, thank you for opening a PR!

Please ensure that your change passes tests and the various linters by running
`make test` and `make lint`. If testable, your changes should be covered by
unit tests.

Explain your changes below and link to related issues.
-->
