### PR TITLE
click indicators on non-transactions to toggle metadata

### DIFF
--- a/frontend/css/journal-table.css
+++ b/frontend/css/journal-table.css
@@ -77,7 +77,12 @@
 .journal.show-metadata .metadata,
 .journal.show-postings .postings,
 .transaction.show-postings .postings,
-.transaction.show-postings .metadata {
+.transaction.show-postings .metadata,
+.balance.show-metadata .metadata,
+.note.show-metadata .metadata,
+.open.show-metadata .metadata,
+/*note: metadata for custom entries seems to only be implemetned for budgets at this time */
+.custom.show-metadata .metadata {
   display: block;
 }
 

--- a/frontend/css/journal-table.css
+++ b/frontend/css/journal-table.css
@@ -81,7 +81,7 @@
 .balance.show-metadata .metadata,
 .note.show-metadata .metadata,
 .open.show-metadata .metadata,
-/*note: metadata for custom entries seems to only be implemetned for budgets at this time */
+/* note: metadata for custom entries seems to only be implemetned for budgets at this time */
 .custom.show-metadata .metadata {
   display: block;
 }

--- a/frontend/src/journal/index.ts
+++ b/frontend/src/journal/index.ts
@@ -62,9 +62,15 @@ function handleClick({ target }: Event): void {
     }
   } else if (target.closest(".indicators")) {
     // Toggle postings and metadata by clicking on indicators.
-    const entry = target.closest(".transaction");
+    let entry = target.closest(".transaction");
     if (entry) {
       entry.classList.toggle("show-postings");
+    } else {
+      // 
+      entry = target.closest(".balance,.note,.open,.custom")
+      if (entry) {
+        entry.classList.toggle("show-metadata");
+      }
     }
   }
 }

--- a/frontend/src/journal/index.ts
+++ b/frontend/src/journal/index.ts
@@ -64,9 +64,10 @@ function handleClick({ target }: Event): void {
     // Toggle postings and metadata by clicking on indicators.
     let entry = target.closest(".transaction");
     if (entry) {
+      // show-postings applies to both postings and metadata for transactions
       entry.classList.toggle("show-postings");
     } else {
-      //
+      // show-metadata applies to metadata for other entries
       entry = target.closest(".balance,.note,.open,.custom");
       if (entry) {
         entry.classList.toggle("show-metadata");

--- a/frontend/src/journal/index.ts
+++ b/frontend/src/journal/index.ts
@@ -66,8 +66,8 @@ function handleClick({ target }: Event): void {
     if (entry) {
       entry.classList.toggle("show-postings");
     } else {
-      // 
-      entry = target.closest(".balance,.note,.open,.custom")
+      //
+      entry = target.closest(".balance,.note,.open,.custom");
       if (entry) {
         entry.classList.toggle("show-metadata");
       }


### PR DESCRIPTION
Hello fava team,

I tried my hand at hacking a bit and got some desired functionality working pretty good I'd say.  Let me know what you think.  I ran `make test` and `make lint` and I think both passed but `make lint` ended with his and I'm not sure what the `Error 1` refers to:

```
...

stylelint................................................................Passed
eslint...................................................................Passed
make: *** [Makefile:45: lint] Error 1
(fava) PS C:\git\fava>
```

Anyhow, this change simply makes it possible to expand the non-transaction rows in the journal that have meta-data, as I understand that is supported for almost all directives I believe.  I'm handling it for balance, note, open, and custom entries.  For custom, it only worked in the case of budget...I think because metadata elements aren't created otherwise.  Also, I think I had trouble getting it to work for pad.  Anyway, I'm not necessarily looking for this to be pulled into main as much as I'm trying to get a little experience with the code base and ask for some feedback.

Thanks!