### PR TITLE
Do not filter out non-Transaction entries

### DIFF
--- a/src/fava/core/filters.py
+++ b/src/fava/core/filters.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 
 import ply.yacc  # type: ignore[import-untyped]
 from beancount.core import account
+from beancount.core.data import Transaction
 from beancount.ops.summarize import clamp_opt
 
 from fava.beans.account import get_entry_accounts
@@ -445,7 +446,11 @@ class AdvancedFilter(EntryFilter):
 
     def apply(self, entries: Sequence[Directive]) -> Sequence[Directive]:
         include = self._include
-        return [entry for entry in entries if include(entry)]
+        return [
+            entry
+            for entry in entries
+            if include(entry) or not isinstance(entry, Transaction)
+        ]
 
 
 class AccountFilter(EntryFilter):
@@ -472,4 +477,5 @@ class AccountFilter(EntryFilter):
                 account.has_component(name, value) or match(name)
                 for name in get_entry_accounts(entry)
             )
+            or not isinstance(entry, Transaction)
         ]

--- a/tests/__snapshots__/test_application-test_client_side_reports
+++ b/tests/__snapshots__/test_application-test_client_side_reports
@@ -21,7 +21,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 5809
+        "lineno": 5808
       },
       "uptodate_status": null
     },
@@ -34,7 +34,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 3760
+        "lineno": 3759
       },
       "uptodate_status": null
     },
@@ -143,7 +143,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 4968
+        "lineno": 4967
       },
       "uptodate_status": null
     },
@@ -172,8 +172,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 2970,
-        "number": "882882"
+        "lineno": 2970
       },
       "uptodate_status": null
     },
@@ -186,8 +185,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 2963,
-        "number": "882882"
+        "lineno": 2964
       },
       "uptodate_status": null
     },
@@ -200,8 +198,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 2961,
-        "number": "882882"
+        "lineno": 2963
       },
       "uptodate_status": null
     },
@@ -227,7 +224,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 5064
+        "lineno": 5063
       },
       "uptodate_status": null
     },
@@ -240,7 +237,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 5063
+        "lineno": 5062
       },
       "uptodate_status": null
     },
@@ -253,7 +250,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 5057
+        "lineno": 5056
       },
       "uptodate_status": null
     },
@@ -266,7 +263,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 5056
+        "lineno": 5055
       },
       "uptodate_status": null
     },
@@ -279,7 +276,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 5054
+        "lineno": 5053
       },
       "uptodate_status": null
     },
@@ -292,7 +289,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 5055
+        "lineno": 5054
       },
       "uptodate_status": null
     },
@@ -305,7 +302,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 3764
+        "lineno": 3763
       },
       "uptodate_status": null
     },
@@ -318,7 +315,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 3762
+        "lineno": 3761
       },
       "uptodate_status": null
     },
@@ -331,7 +328,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 3763
+        "lineno": 3762
       },
       "uptodate_status": null
     },
@@ -344,7 +341,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 3765
+        "lineno": 3764
       },
       "uptodate_status": null
     },
@@ -357,7 +354,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 5060
+        "lineno": 5059
       },
       "uptodate_status": null
     },
@@ -370,7 +367,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 5061
+        "lineno": 5060
       },
       "uptodate_status": null
     },
@@ -383,7 +380,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 5062
+        "lineno": 5061
       },
       "uptodate_status": null
     },
@@ -396,7 +393,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 5059
+        "lineno": 5058
       },
       "uptodate_status": null
     },
@@ -409,7 +406,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 4977
+        "lineno": 4976
       },
       "uptodate_status": null
     },
@@ -422,7 +419,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 4976
+        "lineno": 4975
       },
       "uptodate_status": null
     },
@@ -435,7 +432,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 4974
+        "lineno": 4973
       },
       "uptodate_status": null
     },
@@ -448,7 +445,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 4975
+        "lineno": 4974
       },
       "uptodate_status": null
     },
@@ -461,7 +458,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 4978
+        "lineno": 4977
       },
       "uptodate_status": null
     },
@@ -474,7 +471,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 4980
+        "lineno": 4979
       },
       "uptodate_status": null
     },
@@ -487,7 +484,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 4979
+        "lineno": 4978
       },
       "uptodate_status": null
     },
@@ -500,7 +497,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 5008
+        "lineno": 5007
       },
       "uptodate_status": null
     },
@@ -513,7 +510,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 5007
+        "lineno": 5006
       },
       "uptodate_status": null
     },
@@ -526,7 +523,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 5005
+        "lineno": 5004
       },
       "uptodate_status": null
     },
@@ -539,7 +536,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 5006
+        "lineno": 5005
       },
       "uptodate_status": null
     },
@@ -552,7 +549,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 5009
+        "lineno": 5008
       },
       "uptodate_status": null
     },
@@ -565,7 +562,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 5011
+        "lineno": 5010
       },
       "uptodate_status": null
     },
@@ -578,7 +575,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 5010
+        "lineno": 5009
       },
       "uptodate_status": null
     },
@@ -591,7 +588,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 5039
+        "lineno": 5038
       },
       "uptodate_status": null
     },
@@ -604,7 +601,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 5038
+        "lineno": 5037
       },
       "uptodate_status": null
     },
@@ -617,7 +614,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 5036
+        "lineno": 5035
       },
       "uptodate_status": null
     },
@@ -630,7 +627,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 5037
+        "lineno": 5036
       },
       "uptodate_status": null
     },
@@ -643,7 +640,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 5040
+        "lineno": 5039
       },
       "uptodate_status": null
     },
@@ -656,7 +653,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 5042
+        "lineno": 5041
       },
       "uptodate_status": null
     },
@@ -669,7 +666,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 5041
+        "lineno": 5040
       },
       "uptodate_status": null
     },
@@ -682,7 +679,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 5058
+        "lineno": 5057
       },
       "uptodate_status": null
     },
@@ -695,7 +692,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 3761
+        "lineno": 3760
       },
       "uptodate_status": null
     },
@@ -708,7 +705,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 3758
+        "lineno": 3757
       },
       "uptodate_status": null
     },
@@ -734,7 +731,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 3757
+        "lineno": 3756
       },
       "uptodate_status": null
     },
@@ -747,7 +744,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 3759
+        "lineno": 3758
       },
       "uptodate_status": null
     },
@@ -786,7 +783,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 4967
+        "lineno": 4966
       },
       "uptodate_status": null
     },

--- a/tests/__snapshots__/test_internal_api-test_get_ledger_data.json
+++ b/tests/__snapshots__/test_internal_api-test_get_ledger_data.json
@@ -9,7 +9,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 5809
+        "lineno": 5808
       },
       "uptodate_status": null
     },
@@ -22,7 +22,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 3760
+        "lineno": 3759
       },
       "uptodate_status": null
     },
@@ -131,7 +131,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 4968
+        "lineno": 4967
       },
       "uptodate_status": null
     },
@@ -160,8 +160,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 2970,
-        "number": "882882"
+        "lineno": 2970
       },
       "uptodate_status": null
     },
@@ -174,8 +173,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 2963,
-        "number": "882882"
+        "lineno": 2964
       },
       "uptodate_status": null
     },
@@ -188,8 +186,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 2961,
-        "number": "882882"
+        "lineno": 2963
       },
       "uptodate_status": null
     },
@@ -215,7 +212,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 5064
+        "lineno": 5063
       },
       "uptodate_status": null
     },
@@ -228,7 +225,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 5063
+        "lineno": 5062
       },
       "uptodate_status": null
     },
@@ -241,7 +238,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 5057
+        "lineno": 5056
       },
       "uptodate_status": null
     },
@@ -254,7 +251,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 5056
+        "lineno": 5055
       },
       "uptodate_status": null
     },
@@ -267,7 +264,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 5054
+        "lineno": 5053
       },
       "uptodate_status": null
     },
@@ -280,7 +277,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 5055
+        "lineno": 5054
       },
       "uptodate_status": null
     },
@@ -293,7 +290,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 3764
+        "lineno": 3763
       },
       "uptodate_status": null
     },
@@ -306,7 +303,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 3762
+        "lineno": 3761
       },
       "uptodate_status": null
     },
@@ -319,7 +316,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 3763
+        "lineno": 3762
       },
       "uptodate_status": null
     },
@@ -332,7 +329,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 3765
+        "lineno": 3764
       },
       "uptodate_status": null
     },
@@ -345,7 +342,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 5060
+        "lineno": 5059
       },
       "uptodate_status": null
     },
@@ -358,7 +355,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 5061
+        "lineno": 5060
       },
       "uptodate_status": null
     },
@@ -371,7 +368,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 5062
+        "lineno": 5061
       },
       "uptodate_status": null
     },
@@ -384,7 +381,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 5059
+        "lineno": 5058
       },
       "uptodate_status": null
     },
@@ -397,7 +394,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 4977
+        "lineno": 4976
       },
       "uptodate_status": null
     },
@@ -410,7 +407,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 4976
+        "lineno": 4975
       },
       "uptodate_status": null
     },
@@ -423,7 +420,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 4974
+        "lineno": 4973
       },
       "uptodate_status": null
     },
@@ -436,7 +433,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 4975
+        "lineno": 4974
       },
       "uptodate_status": null
     },
@@ -449,7 +446,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 4978
+        "lineno": 4977
       },
       "uptodate_status": null
     },
@@ -462,7 +459,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 4980
+        "lineno": 4979
       },
       "uptodate_status": null
     },
@@ -475,7 +472,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 4979
+        "lineno": 4978
       },
       "uptodate_status": null
     },
@@ -488,7 +485,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 5008
+        "lineno": 5007
       },
       "uptodate_status": null
     },
@@ -501,7 +498,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 5007
+        "lineno": 5006
       },
       "uptodate_status": null
     },
@@ -514,7 +511,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 5005
+        "lineno": 5004
       },
       "uptodate_status": null
     },
@@ -527,7 +524,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 5006
+        "lineno": 5005
       },
       "uptodate_status": null
     },
@@ -540,7 +537,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 5009
+        "lineno": 5008
       },
       "uptodate_status": null
     },
@@ -553,7 +550,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 5011
+        "lineno": 5010
       },
       "uptodate_status": null
     },
@@ -566,7 +563,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 5010
+        "lineno": 5009
       },
       "uptodate_status": null
     },
@@ -579,7 +576,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 5039
+        "lineno": 5038
       },
       "uptodate_status": null
     },
@@ -592,7 +589,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 5038
+        "lineno": 5037
       },
       "uptodate_status": null
     },
@@ -605,7 +602,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 5036
+        "lineno": 5035
       },
       "uptodate_status": null
     },
@@ -618,7 +615,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 5037
+        "lineno": 5036
       },
       "uptodate_status": null
     },
@@ -631,7 +628,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 5040
+        "lineno": 5039
       },
       "uptodate_status": null
     },
@@ -644,7 +641,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 5042
+        "lineno": 5041
       },
       "uptodate_status": null
     },
@@ -657,7 +654,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 5041
+        "lineno": 5040
       },
       "uptodate_status": null
     },
@@ -670,7 +667,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 5058
+        "lineno": 5057
       },
       "uptodate_status": null
     },
@@ -683,7 +680,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 3761
+        "lineno": 3760
       },
       "uptodate_status": null
     },
@@ -696,7 +693,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 3758
+        "lineno": 3757
       },
       "uptodate_status": null
     },
@@ -722,7 +719,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 3757
+        "lineno": 3756
       },
       "uptodate_status": null
     },
@@ -735,7 +732,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 3759
+        "lineno": 3758
       },
       "uptodate_status": null
     },
@@ -774,7 +771,7 @@
       },
       "meta": {
         "filename": "TEST_DATA_DIR/long-example.beancount",
-        "lineno": 4967
+        "lineno": 4966
       },
       "uptodate_status": null
     },

--- a/tests/__snapshots__/test_json_api-test_api-events.json
+++ b/tests/__snapshots__/test_json_api-test_api-events.json
@@ -4,7 +4,7 @@
     "description": "BayBook, 1501 Billow Rd, Benlo Park, CA",
     "meta": {
       "filename": "TEST_DATA_DIR/long-example.beancount",
-      "lineno": 3767
+      "lineno": 3766
     },
     "t": "Event",
     "type": "employer"

--- a/tests/__snapshots__/test_json_api-test_api_context-2.json
+++ b/tests/__snapshots__/test_json_api-test_api_context-2.json
@@ -8,7 +8,7 @@
     "date": "1980-05-12",
     "meta": {
       "filename": "TEST_DATA_DIR/long-example.beancount",
-      "lineno": 5057
+      "lineno": 5056
     },
     "t": "Open"
   },

--- a/tests/__snapshots__/test_json_api-test_api_context.json
+++ b/tests/__snapshots__/test_json_api-test_api_context.json
@@ -96,7 +96,7 @@
     "links": [],
     "meta": {
       "filename": "TEST_DATA_DIR/long-example.beancount",
-      "lineno": 3737
+      "lineno": 3736
     },
     "narration": "Investing 40% of cash in VBMPX",
     "payee": "",
@@ -106,7 +106,7 @@
         "amount": "15.957 VBMPX {30.08 USD, 2016-05-09}",
         "meta": {
           "filename": "TEST_DATA_DIR/long-example.beancount",
-          "lineno": 3738
+          "lineno": 3737
         }
       },
       {
@@ -114,7 +114,7 @@
         "amount": "-479.99 USD",
         "meta": {
           "filename": "TEST_DATA_DIR/long-example.beancount",
-          "lineno": 3739
+          "lineno": 3738
         }
       }
     ],

--- a/tests/data/long-example.beancount
+++ b/tests/data/long-example.beancount
@@ -2941,10 +2941,12 @@ option "operating_currency" "USD"
   Income:US:ETrade:Gains                            66.08 USD
 
 2016-03-17 * "Dividends on portfolio"
+    number: "882882"
   Assets:US:ETrade:Cash                            119.06 USD
   Income:US:ETrade:Dividends                      -119.06 USD
 
 2016-04-30 * "Buy shares of GLD"
+    number: "882882"
   Assets:US:ETrade:Cash                          -1807.72 USD
   Assets:US:ETrade:GLD                                 17 GLD {105.81 USD}
   Expenses:Financial:Commissions                     8.95 USD
@@ -2959,16 +2961,13 @@ option "operating_currency" "USD"
 * Vanguard Investments
 
 2014-01-01 open Assets:US:Vanguard:VBMPX                     VBMPX
-  number: "882882"
 2014-01-01 open Assets:US:Vanguard:RGAGX                     RGAGX
-  number: "882882"
 2014-01-01 open Assets:US:Vanguard                            USD
   address: "P.O. Box 1110, Valley Forge, PA 19482-1110"
   institution: "Vanguard Group"
   phone: "+1.800.523.1188"
 2014-01-01 open Income:US:BayBook:Match401k                   USD
 2014-01-01 open Assets:US:Vanguard:Cash                       USD
-  number: "882882"
 
 2014-01-03 * "Employer match for contribution"
   Assets:US:Vanguard:Cash                          600.00 USD


### PR DESCRIPTION
See https://github.com/beancount/fava/issues/1623. The behaviour of filtering out non-Transaction entries along with Transaction ones is rather limiting at the moment. If advanced or account filters are specified, most of the times most of non-Transaction entries are filtered out from the ledger and at least for me this seemed counter-intuitive and potentially led to conclusions made on misleading data while browsing through various views on the ledger.

This is particularly prominent with the price entries when using multiple currencies in the ledger frequently and relying on automatic conversions. While using the popular https://github.com/andreasgerstmayr/fava-dashboards plugin or (for example) running BQL plugins from Fava that causes missing transactions (due to ```CONVERT(SUM(position), '{{currency}}', LAST(date))``` not working).

As mentioned in the linked issue, I am not aware of any workaround to preserve (for example) price entries while applying filters to other transactions. One could imagine a filter option for entries like ```type:Price``` that you could add as an OR to the advanced filter (but not to the account filter), and it would be one way to address the problem. But then I'd need to add it to most of the queries I do since it would personally make sense for me all of the time. In any slice of my data there would be 2 or 3 different currencies that I'd need to convert to a common basis to do meaningful analysis.

These below are also a few statements that I believe to make sense, although of course I may miss some details and counter-arguments.
1) Preserving non-Transaction entries while applying filters to Transactions would not cause unexpected behaviour in overwhelming majority of the cases.
2) Filtering non-Transaction entries is not much needed in practice while working with the ledger. At least in my almost 2-year experience I haven't faced a practical case that required it.
3) Filtering by time for non-Transaction entries still may make sense, although I'm not sure and don't have a particular opinion about this. I still can't think of practical cases and maybe for consistency that would need to be changed as well.

Hence, I suggest this pull request as a RFC. I tested it locally for some time and it works better than the Fava's current behaviour for my personal needs at least. I'm able to set and interlink more useful dashboards for a personal ledger.

The tests have been adjusted accordingly. I had to remove 4 checks related to an ```open``` directive properties. If they were based on any practical use-case, would be happy to return / make adjustments that make sense.