### PR TITLE
Adding account and importer to match with beangulp

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -180,7 +180,7 @@ max-args = 9
 "docs/**" = ["D", "INP"]
 "tests/conftest.py" = ["S101"]
 "tests/test_*.py" = ["D", "PLC2701", "S101", "SLF001"]
-"tests/data/import_config.py" = ["D", "INP"]
+"tests/data/import_config.py" = ["D", "INP", "S101"]
 "src/fava/core/filters.py" = ["D"]
 
 # pylint is not run as part of linting for Fava anymore but we keep these disables

--- a/src/fava/core/ingest.py
+++ b/src/fava/core/ingest.py
@@ -457,11 +457,10 @@ class IngestModule(FavaModule):
             raise ImporterExtractError from exc
 
         for hook_fn in self.hooks:
-            new_entries_list: HookOutput = []
             annotations = get_annotations(hook_fn)
             if any("Importer" in a for a in annotations.values()):
                 importer_info = importer.file_import_info(path)
-                new_entries_list = [
+                new_entries_list: HookOutput = [
                     (
                         filename,
                         new_entries,

--- a/src/fava/help/import.md
+++ b/src/fava/help/import.md
@@ -7,15 +7,21 @@ for more information on how to write importers.
 
 You can override the hooks that should be run for your importers by specifying a
 variable `HOOKS` with the a list of hooks to apply to the list of
-`(filename, entries)` tuples. By default Beancount's duplicates detector hook
-will be run.
+`(filename: str, entries: list[Directive])` tuples. On Beancount version 2 the
+duplicates detector hook will be run by default and no hooks will run by default
+on Beancount version 3. If you want to use beangulp-style hooks that take list
+of
+`(filename: str, entries: list[Directive], account: str, importer: Importer)`-tuples,
+you can annotate them with the appropriate Python types which Fava will detect
+and call with these 4-tuples.
 
 Set the `import-config` option to point to your import config and set
 `import-dirs` to the directories that contain the files that you want to import.
 And if you wish to save new entries elsewhere than main file - use
 `insert-entry` option.
 
-Fava currently only supports entries of type `Transaction` and `Balance`. Set
-the special metadata key `__source__` to display the corresponding text
-(CSV-row, XML-fragment, etc.) for the entry in the list of entries to import.
-Note that this metadata will be stripped before saving the entry to file.
+Fava currently only supports entries of type `Transaction`, `Balance`, and
+`Note`. Set the special metadata key `__source__` to display the corresponding
+text (CSV-row, XML-fragment, etc.) for the entry in the list of entries to
+import. Note that this metadata (and all other metadata keys starting with an
+underscore) will be stripped before saving the entry to file.

--- a/tests/data/import_config.py
+++ b/tests/data/import_config.py
@@ -138,23 +138,23 @@ class TestImporterThatErrorsOnExtract(TestImporter):
 
 
 def _example_noop_importer_legacy_hook(
-    entries: list[tuple[str, list[Directive]]],
-    existing: Sequence[Directive],  # noqa: ARG001
+    files_entries: list[tuple[str, list[Directive]]],
+    _existing: Sequence[Directive],
 ) -> list[tuple[str, list[Directive]]]:
-    for e in entries:
-        assert len(e) == 2  # noqa: S101
-    return entries
+    for e in files_entries:
+        assert len(e) == 2
+    return files_entries
 
 
 def _example_noop_importer_hook(
-    entries: list[
+    files_entries_accounts_importers: list[
         tuple[str, list[Directive], str, BeanImporterProtocol | Importer]
     ],
-    existing: Sequence[Directive],  # noqa: ARG001
+    _existing: Sequence[Directive],
 ) -> list[tuple[str, list[Directive], str, BeanImporterProtocol | Importer]]:
-    for e in entries:
-        assert len(e) == 4  # noqa: S101
-    return entries
+    for e in files_entries_accounts_importers:
+        assert len(e) == 4
+    return files_entries_accounts_importers
 
 
 HOOKS = [_example_noop_importer_legacy_hook, _example_noop_importer_hook]

--- a/tests/data/import_config.py
+++ b/tests/data/import_config.py
@@ -20,7 +20,6 @@ if TYPE_CHECKING:  # pragma: no cover
 
     from fava.beans.abc import Directive
     from fava.beans.ingest import FileMemo
-    from fava.core.ingest import HookOutput
 
 DATE = datetime.date(2022, 12, 12)
 
@@ -138,14 +137,27 @@ class TestImporterThatErrorsOnExtract(TestImporter):
         raise TypeError
 
 
-def _example_noop_importer_hook(
-    entries: HookOutput,
+def _example_noop_importer_legacy_hook(
+    entries: list[tuple[str, list[Directive]]],
     existing: Sequence[Directive],  # noqa: ARG001
-) -> HookOutput:
+) -> list[tuple[str, list[Directive]]]:
+    for e in entries:
+        assert len(e) == 2  # noqa: S101
     return entries
 
 
-HOOKS = [_example_noop_importer_hook]
+def _example_noop_importer_hook(
+    entries: list[
+        tuple[str, list[Directive], str, BeanImporterProtocol | Importer]
+    ],
+    existing: Sequence[Directive],  # noqa: ARG001
+) -> list[tuple[str, list[Directive], str, BeanImporterProtocol | Importer]]:
+    for e in entries:
+        assert len(e) == 4  # noqa: S101
+    return entries
+
+
+HOOKS = [_example_noop_importer_legacy_hook, _example_noop_importer_hook]
 
 
 with suppress(ImportError):  # pragma: no cover


### PR DESCRIPTION
Beangulp also adds the account and the importer to the result (which can e.g. used by hooks). See e.g. https://github.com/beancount/beangulp/blob/master/examples/import.py