### PR TITLE
Add missing deps in the docker image; tell pip to ignore the fact we are running as root

### DIFF
--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:alpine as builder
 
-RUN apk add --update libxml2-dev libxslt-dev gcc musl-dev g++
-RUN pip install --prefix="/install" fava
+RUN apk add --update libxml2-dev libxslt-dev gcc musl-dev g++ bison flex
+RUN pip install --root-user-action ignore --prefix="/install" fava
 
 FROM python:alpine
 


### PR DESCRIPTION
<!--
Hi, thank you for opening a PR!

Please ensure that your change passes tests and the various linters by running
`make test` and `make lint`. If testable, your changes should be covered by
unit tests.

Explain your changes below and link to related issues.
-->

I was trying to build the Docker container image and ran into various issues with building, namely:

- missing dependency: bison
- missing dependency: flex
- pip install erroring out because it's running as root

Fixed the first two by adding the deps to the `apk install` command, and fixed the latter with the `--root-user-action ignore` flag to the `pip install`.