### PR TITLE
logging: set default level to warn

### DIFF
--- a/src/fava/cli.py
+++ b/src/fava/cli.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import errno
-import logging
 import os
 from pathlib import Path
 
@@ -14,6 +13,7 @@ from werkzeug.middleware.profiler import ProfilerMiddleware
 
 from fava import __version__
 from fava.application import create_app
+from fava.util import setup_debug_logging
 from fava.util import simple_wsgi
 
 
@@ -161,7 +161,7 @@ def main(  # noqa: PLR0913
                 raise AddressInUse(port) from error
             raise click.Abort from error
     else:
-        logging.getLogger("fava").setLevel(logging.DEBUG)
+        setup_debug_logging()
         if profile:
             app.wsgi_app = ProfilerMiddleware(  # type: ignore[method-assign]
                 app.wsgi_app,

--- a/src/fava/util/__init__.py
+++ b/src/fava/util/__init__.py
@@ -36,8 +36,14 @@ def filter_api_changed(record: logging.LogRecord) -> bool:  # pragma: no cover
 
 def setup_logging() -> None:
     """Set up logging for Fava."""
-    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    logging.basicConfig(level=logging.WARNING, format="%(message)s")
     logging.getLogger("werkzeug").addFilter(filter_api_changed)
+
+
+def setup_debug_logging() -> None:
+    """Set up debug level logging for Fava."""
+    logging.getLogger().setLevel(logging.DEBUG)
+    logging.getLogger("watchfiles").setLevel(logging.INFO)
 
 
 def get_translations(locale: Locale) -> str | None:


### PR DESCRIPTION
When running from the CLI in debug mode, set it to debug instead (except
for watchfiles, which has rather noisy debug logs).

Fix #1952 
<!--
Hi, thank you for opening a PR!

Please ensure that your change passes tests and the various linters by running
`make test` and `make lint`. If testable, your changes should be covered by
unit tests.

Explain your changes below and link to related issues.
-->
