### PR TITLE
query: use all prices when running queries

### DIFF
--- a/src/fava/application.py
+++ b/src/fava/application.py
@@ -400,7 +400,7 @@ def _setup_routes(fava_app: Flask) -> None:  # noqa: PLR0915
     def download_query(result_format: str) -> Response:
         """Download a query result."""
         name, data = g.ledger.query_shell.query_to_file(
-            g.filtered.entries,
+            g.filtered.entries_with_all_prices,
             request.args.get("query_string", ""),
             result_format,
         )

--- a/src/fava/core/__init__.py
+++ b/src/fava/core/__init__.py
@@ -33,6 +33,7 @@ from fava.core.commodities import CommoditiesModule
 from fava.core.conversion import cost_or_value
 from fava.core.extensions import ExtensionModule
 from fava.core.fava_options import parse_options
+from fava.core.file import _incomplete_sortkey
 from fava.core.file import FileModule
 from fava.core.file import get_entry_slice
 from fava.core.filters import AccountFilter
@@ -150,6 +151,13 @@ class FilteredLedger:
         if date_range:
             return date_range.end_inclusive
         return None
+
+    @cached_property
+    def entries_with_all_prices(self) -> Sequence[Directive]:
+        """The filtered entries, with all prices added back in for queries."""
+        entries = [*self.entries, *self.ledger.all_entries_by_type.Price]
+        entries.sort(key=_incomplete_sortkey)
+        return entries
 
     @cached_property
     def root_tree(self) -> Tree:

--- a/src/fava/json_api.py
+++ b/src/fava/json_api.py
@@ -284,7 +284,7 @@ def get_payee_accounts(payee: str) -> Sequence[str]:
 def get_query(query_string: str) -> QueryResultTable | QueryResultText:
     """Run a Beancount query."""
     return g.ledger.query_shell.execute_query_serialised(
-        g.filtered.entries, query_string
+        g.filtered.entries_with_all_prices, query_string
     )
 
 

--- a/src/fava/templates/statistics.html
+++ b/src/fava/templates/statistics.html
@@ -12,7 +12,7 @@
     {{ _('Postings per Account') }}
     (<a href="{{ url_for('report', report_name='query', query_string=postings_per_account) }}">Query</a>)
   </h3>
-  <svelte-component type="query-table"><script type="application/json">{{ledger.query_shell.execute_query_serialised(g.filtered.entries, postings_per_account)|tojson}}</script></svelte-component>
+  <svelte-component type="query-table"><script type="application/json">{{ledger.query_shell.execute_query_serialised(g.filtered.entries_with_all_prices, postings_per_account)|tojson}}</script></svelte-component>
 </div>
 
 {% set status_sortorder = { 'red': 5, 'yellow': 4, 'green': 3, '': 2 } %}

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -32,6 +32,11 @@ def test_filtered_ledger(
     small_example_ledger: FavaLedger,
 ) -> None:
     filtered = FilteredLedger(small_example_ledger, account="NONE")
+    assert not filtered.entries
+    assert (
+        filtered.entries_with_all_prices
+        == small_example_ledger.all_entries_by_type.Price
+    )
     assert filtered.prices("EUR", "USD")
     assert filtered.prices("UNKNOWN1", "UNKNOWN2") == []
     assert filtered.date_range is None


### PR DESCRIPTION
For conversions in Fava, the full price map was already used, so this
makes queries using BQL's `CONVERT` also have access to all prices.

Fixes #1623 
Ref #1969 
<!--
Hi, thank you for opening a PR!

Please ensure that your change passes tests and the various linters by running
`make test` and `make lint`. If testable, your changes should be covered by
unit tests.

Explain your changes below and link to related issues.
-->
