### PR TITLE
Feature/icycle charts

### DIFF
--- a/frontend/src/charts/HierarchyContainer.svelte
+++ b/frontend/src/charts/HierarchyContainer.svelte
@@ -2,6 +2,7 @@
   import { _ } from "../i18n";
   import { hierarchyChartMode } from "../stores/chart";
   import type { HierarchyChart } from "./hierarchy";
+  import Icycle from "./Icycle.svelte";
   import Sunburst from "./Sunburst.svelte";
   import Treemap from "./Treemap.svelte";
 
@@ -30,18 +31,27 @@
   </svg>
 {:else if treemap && $treemap_currency}
   <Treemap data={treemap} currency={$treemap_currency} {width} />
-{:else if mode === "sunburst"}
+{:else if mode === "sunburst" || mode === "icycle"}
   <svg viewBox={`0 0 ${width.toString()} 500`}>
     {#each [...data] as [chart_currency, d], i (chart_currency)}
       <g
         transform={`translate(${((width * i) / currencies.length).toString()},0)`}
       >
-        <Sunburst
-          data={d}
-          currency={chart_currency}
-          width={width / currencies.length}
-          height={500}
-        />
+        {#if mode === "sunburst"}
+          <Sunburst
+            data={d}
+            currency={chart_currency}
+            width={width / currencies.length}
+            height={500}
+          />
+        {:else if mode === "icycle"}
+          <Icycle
+            data={d}
+            currency={chart_currency}
+            width={width / currencies.length}
+            height={500}
+          />
+        {/if}
       </g>
     {/each}
   </svg>

--- a/frontend/src/charts/Icycle.svelte
+++ b/frontend/src/charts/Icycle.svelte
@@ -1,0 +1,114 @@
+<script lang="ts">
+  import type { HierarchyRectangularNode } from "d3-hierarchy";
+  import { partition } from "d3-hierarchy";
+  import { scaleLinear, scaleSqrt } from "d3-scale";
+  import { arc } from "d3-shape";
+  import { untrack } from "svelte";
+
+  import { formatPercentage } from "../format";
+  import { urlForAccount } from "../helpers";
+  import { ctx } from "../stores/format";
+  import { sunburstScale } from "./helpers";
+  import type {
+    AccountHierarchyDatum,
+    AccountHierarchyNode,
+  } from "./hierarchy";
+
+  interface Props {
+    data: AccountHierarchyNode;
+    currency: string;
+    width: number;
+    height: number;
+  }
+
+  let { data, currency, width, height }: Props = $props();
+
+  let radius = $derived(Math.min(width, height) / 2);
+
+  let root = $derived(partition<AccountHierarchyDatum>()(data));
+  let nodes = $derived(
+    root.descendants().filter((d) => !d.data.dummy && d.depth > 0),
+  );
+
+  let current: AccountHierarchyNode | null = $state(null);
+
+  $effect.pre(() => {
+    // if-expression to run on each change of chart
+    // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+    data;
+    untrack(() => {
+      current = null;
+    });
+  });
+
+  function balanceText(d: AccountHierarchyNode): string {
+    const val = d.value ?? 0;
+    const total = root.value ?? 0;
+    return total
+      ? `${$ctx.amount(val, currency)} (${formatPercentage(val / total)})`
+      : $ctx.amount(val, currency);
+  }
+
+  const x = scaleLinear([0, 2 * Math.PI]);
+  let y = $derived(scaleSqrt([0, radius]));
+  let arcShape = $derived(
+    arc<HierarchyRectangularNode<AccountHierarchyDatum>>()
+      .startAngle((d) => x(d.x0))
+      .endAngle((d) => x(d.x1))
+      .innerRadius((d) => y(d.y0))
+      .outerRadius((d) => y(d.y1)),
+  );
+</script>
+
+<g
+  {width}
+  {height}
+  transform={`translate(${(width / 2).toString()},${(height / 2).toString()})`}
+  onmouseleave={() => {
+    current = null;
+  }}
+  role="img"
+>
+  <circle style="opacity:0" r={radius} />
+  <text class="account" text-anchor="middle">
+    {(current ?? root).data.account}
+  </text>
+  <text class="balance" dy="1.2em" text-anchor="middle">
+    {balanceText(current ?? root)}
+  </text>
+  {#each nodes as d}
+    <a href={$urlForAccount(d.data.account)} aria-label={d.data.account}>
+      <path
+        onmouseover={() => {
+          current = d;
+        }}
+        onfocus={() => {
+          current = d;
+        }}
+        class:half={current && !current.data.account.startsWith(d.data.account)}
+        fill-rule="evenodd"
+        fill={$sunburstScale(d.data.account)}
+        d={arcShape(d)}
+        role="img"
+      />
+    </a>
+  {/each}
+</g>
+
+<style>
+  .half {
+    opacity: 0.5;
+  }
+
+  .account {
+    fill: var(--text-color);
+  }
+
+  .balance {
+    font-family: var(--font-family-monospaced);
+  }
+
+  path {
+    cursor: pointer;
+  }
+</style>

--- a/frontend/src/stores/chart.ts
+++ b/frontend/src/stores/chart.ts
@@ -17,7 +17,11 @@ export const showCharts = writable(true);
 /** This store is used to switch to the same chart (as identified by name) on navigation. */
 export const lastActiveChartName = writable<string | null>(null);
 
-const hierarchy_chart_mode_validator = constants("treemap", "sunburst");
+const hierarchy_chart_mode_validator = constants(
+  "treemap",
+  "sunburst",
+  "icycle",
+);
 type HierarchyChartMode = ValidationT<typeof hierarchy_chart_mode_validator>;
 
 /** The currently selected hierarchy chart mode. */
@@ -28,6 +32,7 @@ export const hierarchyChartMode = localStorageSyncedStore<HierarchyChartMode>(
   () => [
     ["treemap", _("Treemap")],
     ["sunburst", _("Sunburst")],
+    ["icycle", _("Icycle")],
   ],
 );
 


### PR DESCRIPTION
<!--
Hi, thank you for opening a PR!

Please ensure that your change passes tests and the various linters by running
`make test` and `make lint`. If testable, your changes should be covered by
unit tests.

Explain your changes below and link to related issues.
-->
I took a stab at implementing #1964.  Most of the code is copied either from the sunburst or treemap, and merged together to get a working icycle chart.  It appears to work with Income and Expenses on the income statement, as well as Assets, Liabilities, and Equity on the balance statement.

Example image from the example.beancount:

![image](https://github.com/user-attachments/assets/c9f985a0-3adf-4051-bd4c-75b128f7e937)

I am not a svelte/typescript dev so please modify or suggest anything...

(aside - I kept the colormap used by the sunburst chart, but I feel like there are much better color map options for this...)
