### PR TITLE
date intervals exact

### DIFF
--- a/src/fava/core/__init__.py
+++ b/src/fava/core/__init__.py
@@ -171,12 +171,14 @@ class FilteredLedger:
         tree.cap(self.ledger.options, self.ledger.fava_options.unrealized)
         return tree
 
-    @listify
-    def interval_ranges(self, interval: Interval) -> Iterable[DateRange]:
+    def interval_ranges(self, interval: Interval) -> Sequence[DateRange]:
         """Yield date ranges corresponding to interval boundaries."""
         if not self._date_first or not self._date_last:
             return []
-        return dateranges(self._date_first, self._date_last, interval)
+        complete = not self.date_range
+        return dateranges(
+            self._date_first, self._date_last, interval, complete=complete
+        )
 
     def prices(self, base: str, quote: str) -> Sequence[tuple[date, Decimal]]:
         """List all prices."""

--- a/src/fava/util/date.py
+++ b/src/fava/util/date.py
@@ -516,14 +516,6 @@ def number_of_days_in_period(interval: Interval, date: datetime.date) -> int:
         return 1
     if interval is Interval.WEEK:
         return 7
-    if interval is Interval.MONTH:
-        date = datetime.date(date.year, date.month, 1)
-        return (get_next_interval(date, Interval.MONTH) - date).days
-    if interval is Interval.QUARTER:
-        quarter = (date.month - 1) / 3 + 1
-        date = datetime.date(date.year, int(quarter) * 3 - 2, 1)
-        return (get_next_interval(date, Interval.QUARTER) - date).days
-    if interval is Interval.YEAR:
-        date = datetime.date(date.year, 1, 1)
-        return (get_next_interval(date, Interval.YEAR) - date).days
-    return assert_never(interval)  # pragma: no cover
+    start = get_prev_interval(date, interval)
+    end = get_next_interval(start, interval)
+    return (end - start).days


### PR DESCRIPTION
- **util.date: simplify number_of_days_in_period**
- **add code to get exact interval ends and use it if time filter is set**

<!--
Hi, thank you for opening a PR!

Please ensure that your change passes tests and the various linters by running
`make test` and `make lint`. If testable, your changes should be covered by
unit tests.

Explain your changes below and link to related issues.
-->
