### PR TITLE
tree-table: add application-wide store of toggled accounts

### DIFF
--- a/frontend/src/journal/JournalFilters.svelte
+++ b/frontend/src/journal/JournalFilters.svelte
@@ -2,6 +2,7 @@
   import { _, format } from "../i18n";
   import type { KeySpec } from "../keyboard-shortcuts";
   import { keyboardShortcut } from "../keyboard-shortcuts";
+  import { toggle } from "../lib/set";
   import { journalShow } from "../stores/journal";
 
   const toggleText = _("Toggle %(type)s entries");
@@ -47,15 +48,12 @@
 <script lang="ts">
   let shownSet = $derived(new Set($journalShow));
 
-  function toggle(type: string) {
+  function toggle_type(type: string) {
     journalShow.update((show) => {
       const set = new Set(show);
-      const toggle_func = set.has(type)
-        ? set.delete.bind(set)
-        : set.add.bind(set);
-      toggle_func(type);
+      toggle(set, type);
       // Also toggle all entries that have `type` as their supertype.
-      buttons.filter((b) => b[4] === type).forEach((b) => toggle_func(b[0]));
+      buttons.filter((b) => b[4] === type).forEach((b) => toggle(set, b[0]));
       return [...set].sort();
     });
   }
@@ -75,7 +73,7 @@
       use:keyboardShortcut={shortcut}
       class:inactive={!active(type, supertype)}
       onclick={() => {
-        toggle(type);
+        toggle_type(type);
       }}
     >
       {button_text}

--- a/frontend/src/lib/set.ts
+++ b/frontend/src/lib/set.ts
@@ -1,0 +1,11 @@
+/**
+ * Toggle an element in a set (mutating and returning it).
+ */
+export function toggle<T>(set: Set<T>, element: T): Set<T> {
+  if (set.has(element)) {
+    set.delete(element);
+  } else {
+    set.add(element);
+  }
+  return set;
+}

--- a/frontend/src/reports/documents/Accounts.svelte
+++ b/frontend/src/reports/documents/Accounts.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { leaf } from "../../lib/account";
   import type { TreeNode } from "../../lib/tree";
+  import { toggle_account, toggled_accounts } from "../../stores/accounts";
   import Accounts from "./Accounts.svelte";
   import { selectedAccount } from "./stores";
 
@@ -10,9 +11,10 @@
   }
 
   let { node, move }: Props = $props();
+  let account = $derived(node.name);
 
-  let expanded = $state(true);
   let drag = $state(false);
+  let is_toggled = $derived($toggled_accounts.has(account));
 
   let hasChildren = $derived(node.children.length > 0);
   let selected = $derived($selectedAccount === node.name);
@@ -43,7 +45,7 @@
   }
 </script>
 
-{#if node.name}
+{#if account}
   <p
     ondragenter={dragenter}
     ondragover={dragenter}
@@ -51,9 +53,9 @@
       drag = false;
     }}
     ondrop={drop}
-    title={node.name}
+    title={account}
     class="droptarget"
-    data-account-name={node.name}
+    data-account-name={account}
     class:selected
     class:drag
   >
@@ -61,26 +63,26 @@
       <button
         type="button"
         class="unset toggle"
-        onclick={(ev) => {
-          expanded = !expanded;
-          ev.stopPropagation();
-        }}>{expanded ? "▾" : "▸"}</button
+        onclick={(event) => {
+          toggle_account(account, event);
+          event.stopPropagation();
+        }}>{is_toggled ? "▸" : "▾"}</button
       >
     {/if}
     <button
       type="button"
       class="unset leaf"
       onclick={() => {
-        $selectedAccount = selected ? "" : node.name;
-      }}>{leaf(node.name)}</button
+        $selectedAccount = selected ? "" : account;
+      }}>{leaf(account)}</button
     >
     {#if node.count > 0}
       <span class="count"> {node.count}</span>
     {/if}
   </p>
 {/if}
-{#if hasChildren}
-  <ul hidden={!expanded}>
+{#if hasChildren && !is_toggled}
+  <ul>
     {#each node.children as child (child.name)}
       <li>
         <Accounts node={child} {move} />

--- a/frontend/src/stores/accounts.ts
+++ b/frontend/src/stores/accounts.ts
@@ -1,13 +1,95 @@
-import { derived } from "svelte/store";
+import type { Readable } from "svelte/store";
+import { derived, get as store_get, writable } from "svelte/store";
 
 import { _ } from "../i18n";
-import { account_details, fava_options, options } from ".";
+import { isDescendant, parent } from "../lib/account";
+import { derived_array } from "../lib/store";
+import { account_details, accounts_internal, fava_options, options } from ".";
 
-/** Whether an account should be collapsed in the account trees. */
-export const collapse_account = derived(fava_options, ($fava_options) => {
-  const matchers = $fava_options.collapse_pattern.map((p) => new RegExp(p));
-  return (name: string) => matchers.some((p) => p.test(name));
-});
+// a derived_array to avoid recreating collapsed_accounts too often.
+const collapse_patterns = derived_array(
+  fava_options,
+  ($fava_options) => $fava_options.collapse_pattern,
+);
+
+/** The accounts that are toggled via the collapse-pattern option. */
+const collapsed_accounts: Readable<readonly string[]> = derived(
+  [collapse_patterns, accounts_internal],
+  ([$collapse_patterns, $accounts_internal]) => {
+    const matchers = $collapse_patterns.map((pattern) => new RegExp(pattern));
+    return $accounts_internal.filter((account: string) =>
+      matchers.some((matcher) => matcher.test(account)),
+    );
+  },
+);
+
+// The accounts that were manually toggled.
+// `true` stands for 'toggled' and `false` for 'open'.
+const explicitly_toggled = writable<ReadonlyMap<string, boolean>>(new Map());
+
+/** The accounts that are toggled in trees. */
+export const toggled_accounts: Readable<ReadonlySet<string>> = derived(
+  [collapsed_accounts, explicitly_toggled],
+  ([$collapsed_accounts, $explicitly_toggled]) => {
+    const toggled = new Set($collapsed_accounts);
+    for (const [account, is_toggled] of $explicitly_toggled) {
+      if (is_toggled) {
+        toggled.add(account);
+      } else {
+        toggled.delete(account);
+      }
+    }
+    return toggled;
+  },
+);
+
+/**
+ * Toggle an account.
+ *
+ * If opening and it is a Shift-Click, deeply open all descendants.
+ * If opening and it is a Ctrl- or Meta-Click, open direct children.
+ */
+export function toggle_account(account: string, event: MouseEvent): void {
+  const $toggled_accounts = store_get(toggled_accounts);
+  const $accounts_internal = store_get(accounts_internal);
+  const is_opening = $toggled_accounts.has(account);
+
+  explicitly_toggled.update(($explicitly_toggled) => {
+    const new_explicitly_toggled = new Map($explicitly_toggled);
+    new_explicitly_toggled.set(account, !is_opening);
+    if (is_opening) {
+      if (event.shiftKey) {
+        $accounts_internal
+          .filter((a) => a !== account && isDescendant(a, account))
+          .forEach((child) => {
+            new_explicitly_toggled.set(child, false);
+          });
+      } else if (event.ctrlKey || event.metaKey) {
+        $accounts_internal
+          .filter((a) => parent(a) === account)
+          .forEach((child) => {
+            new_explicitly_toggled.set(child, true);
+          });
+      }
+    }
+    return new_explicitly_toggled;
+  });
+}
+
+/** Deeply expand all children of the account. */
+export function expand_all(account: string): void {
+  const $toggled_accounts = store_get(toggled_accounts);
+
+  explicitly_toggled.update(($explicitly_toggled) => {
+    const new_explicitly_toggled = new Map($explicitly_toggled);
+    [...$toggled_accounts]
+      .filter((a) => isDescendant(a, account))
+      .forEach((descendant) => {
+        new_explicitly_toggled.set(descendant, false);
+      });
+    return new_explicitly_toggled;
+  });
+}
 
 /** Whether the balances for an account should be inverted. */
 export const invert_account = derived(

--- a/frontend/src/stores/index.ts
+++ b/frontend/src/stores/index.ts
@@ -1,6 +1,8 @@
+import { sort } from "d3-array";
 import { derived, writable } from "svelte/store";
 
 import type { BeancountError, LedgerData } from "../api/validators";
+import { parent } from "../lib/account";
 import { DEFAULT_INTERVAL } from "../lib/interval";
 import { derived_array } from "../lib/store";
 
@@ -52,6 +54,16 @@ export const accounts_set = derived(
   accounts,
   ($accounts) => new Set($accounts),
 );
+/** All non-leaf accounts. */
+export const accounts_internal = derived_array(accounts, ($accounts) => {
+  const res = new Set<string>();
+  for (let account of $accounts) {
+    while ((account = parent(account))) {
+      res.add(account);
+    }
+  }
+  return sort(res);
+});
 
 /** Get the name (as given per metadata) of a currency. */
 export const currency_name = derived(

--- a/frontend/src/tree-table/AccountCellHeader.svelte
+++ b/frontend/src/tree-table/AccountCellHeader.svelte
@@ -3,10 +3,22 @@
     Header for the account column.
 -->
 <script lang="ts">
-  import { _ } from "../i18n";
-  import { getTreeTableContext } from "./helpers";
+  import { some } from "d3-array";
 
-  const { toggled } = getTreeTableContext();
+  import { _ } from "../i18n";
+  import { isDescendant } from "../lib/account";
+  import { expand_all, toggled_accounts } from "../stores/accounts";
+
+  interface Props {
+    /** The account this tree is rendered for. */
+    account: string;
+  }
+
+  let { account }: Props = $props();
+
+  const toggled_children = $derived(
+    some($toggled_accounts, (a) => isDescendant(a, account)),
+  );
 
   const help_title = _(
     "Hold Shift while clicking to expand all children.\n" +
@@ -15,13 +27,13 @@
 </script>
 
 <span title={help_title}>
-  {#if $toggled.size}
+  {#if toggled_children}
     <button
       type="button"
       class="link"
       title={_("Expand all accounts")}
       onclick={() => {
-        toggled.set(new Set());
+        expand_all(account);
       }}
     >
       {_("Expand all")}

--- a/frontend/src/tree-table/IntervalTreeTable.svelte
+++ b/frontend/src/tree-table/IntervalTreeTable.svelte
@@ -6,10 +6,9 @@
   import type { AccountTreeNode } from "../charts/hierarchy";
   import { urlForAccount } from "../helpers";
   import type { NonEmptyArray } from "../lib/array";
-  import { collapse_account } from "../stores/accounts";
   import { currentTimeFilterDateFormat } from "../stores/format";
   import AccountCellHeader from "./AccountCellHeader.svelte";
-  import { get_collapsed, get_not_shown, setTreeTableContext } from "./helpers";
+  import { get_not_shown, setTreeTableNotShownContext } from "./helpers";
   import IntervalTreeTableNode from "./IntervalTreeTableNode.svelte";
 
   interface Props {
@@ -25,11 +24,8 @@
 
   let { trees, dates, budgets, accumulate }: Props = $props();
 
-  // Initialize context.
-  // toggled is computed once on initialisation; not_shown is kept updated.
-  const toggled = writable(get_collapsed(trees[0], $collapse_account));
   const not_shown = writable(new Set<string>());
-  setTreeTableContext({ toggled, not_shown });
+  setTreeTableNotShownContext(not_shown);
 
   $effect(() => {
     $not_shown = intersection(
@@ -57,7 +53,7 @@
 <ol class="flex-table tree-table-new">
   <li class="head">
     <p>
-      <AccountCellHeader />
+      <AccountCellHeader {account} />
       {#each time_filters as [title, time] (time)}
         <span class="num other">
           <a href={$urlForAccount(account, { time })}>

--- a/frontend/src/tree-table/IntervalTreeTableNode.svelte
+++ b/frontend/src/tree-table/IntervalTreeTableNode.svelte
@@ -4,10 +4,11 @@
   import type { NonEmptyArray } from "../lib/array";
   import { is_empty } from "../lib/objects";
   import { currency_name } from "../stores";
+  import { toggled_accounts } from "../stores/accounts";
   import { ctx } from "../stores/format";
   import AccountCell from "./AccountCell.svelte";
   import Diff from "./Diff.svelte";
-  import { getTreeTableContext } from "./helpers";
+  import { getTreeTableNotShownContext } from "./helpers";
   import IntervalTreeTableNode from "./IntervalTreeTableNode.svelte";
 
   interface Props {
@@ -19,13 +20,13 @@
 
   let { nodes, budgets }: Props = $props();
 
-  const { toggled, not_shown } = getTreeTableContext();
+  const not_shown = getTreeTableNotShownContext();
 
   let [node] = $derived(nodes);
   let { account, children } = $derived(node);
   let account_budgets = $derived(budgets[account]);
 
-  let is_toggled = $derived($toggled.has(account));
+  let is_toggled = $derived($toggled_accounts.has(account));
 </script>
 
 <li>

--- a/frontend/src/tree-table/TreeTable.svelte
+++ b/frontend/src/tree-table/TreeTable.svelte
@@ -4,9 +4,9 @@
   import type { AccountTreeNode } from "../charts/hierarchy";
   import { _ } from "../i18n";
   import { currency_name, operating_currency } from "../stores";
-  import { collapse_account, invert_account } from "../stores/accounts";
+  import { invert_account } from "../stores/accounts";
   import AccountCellHeader from "./AccountCellHeader.svelte";
-  import { get_collapsed, get_not_shown, setTreeTableContext } from "./helpers";
+  import { get_not_shown, setTreeTableNotShownContext } from "./helpers";
   import TreeTableNode from "./TreeTableNode.svelte";
 
   interface Props {
@@ -17,12 +17,10 @@
   }
 
   let { tree, end }: Props = $props();
+  let account = $derived(tree.account);
 
-  // Initialize context.
-  // toggled is computed once on initialisation; not_shown is kept updated.
-  const toggled = writable(get_collapsed(tree, $collapse_account));
   const not_shown = writable(new Set<string>());
-  setTreeTableContext({ toggled, not_shown });
+  setTreeTableNotShownContext(not_shown);
 
   $effect(() => {
     $not_shown = $get_not_shown(tree, end);
@@ -35,15 +33,15 @@
 >
   <li class="head">
     <p>
-      <AccountCellHeader />
+      <AccountCellHeader {account} />
       {#each $operating_currency as currency (currency)}
         <span class="num" title={$currency_name(currency)}>{currency}</span>
       {/each}
       <span class="num other">{_("Other")}</span>
     </p>
   </li>
-  {#each tree.account === "" ? tree.children : [tree] as n (n.account)}
-    <TreeTableNode node={n} invert={$invert_account(n.account) ? -1 : 1} />
+  {#each account === "" ? tree.children : [tree] as node (node.account)}
+    <TreeTableNode {node} invert={$invert_account(node.account) ? -1 : 1} />
   {/each}
 </ol>
 

--- a/frontend/src/tree-table/TreeTableNode.svelte
+++ b/frontend/src/tree-table/TreeTableNode.svelte
@@ -2,10 +2,11 @@
   import type { AccountTreeNode } from "../charts/hierarchy";
   import { is_empty } from "../lib/objects";
   import { currency_name, operating_currency } from "../stores";
+  import { toggled_accounts } from "../stores/accounts";
   import { ctx } from "../stores/format";
   import AccountCell from "./AccountCell.svelte";
   import Diff from "./Diff.svelte";
-  import { getTreeTableContext } from "./helpers";
+  import { getTreeTableNotShownContext } from "./helpers";
   import TreeTableNode from "./TreeTableNode.svelte";
 
   interface Props {
@@ -17,11 +18,11 @@
 
   let { node, invert }: Props = $props();
 
-  const { toggled, not_shown } = getTreeTableContext();
+  const not_shown = getTreeTableNotShownContext();
 
   let { account, children } = $derived(node);
 
-  let is_toggled = $derived($toggled.has(account));
+  let is_toggled = $derived($toggled_accounts.has(account));
 
   let has_balance = $derived(!is_empty(node.balance));
   /** Whether to show the balance (or balance_children) */

--- a/frontend/src/tree-table/helpers.ts
+++ b/frontend/src/tree-table/helpers.ts
@@ -1,5 +1,5 @@
 import { getContext, setContext } from "svelte";
-import type { Readable, Writable } from "svelte/store";
+import type { Readable } from "svelte/store";
 import { derived } from "svelte/store";
 
 import type { AccountTreeNode } from "../charts/hierarchy";
@@ -9,17 +9,13 @@ import { is_closed_account } from "../stores/accounts";
 
 const key = Symbol("tree-table");
 
-interface TreeTableContext {
-  /** The accounts for which the decsendants are currently hidden. */
-  readonly toggled: Writable<ReadonlySet<string>>;
-  /** The accounts that should not be shown. */
-  readonly not_shown: Readable<ReadonlySet<string>>;
-}
+/** The accounts that should not be shown. */
+type NotShown = Readable<ReadonlySet<string>>;
 
-export const setTreeTableContext = (ctx: TreeTableContext): TreeTableContext =>
+export const setTreeTableNotShownContext = (ctx: NotShown): NotShown =>
   setContext(key, ctx);
 
-export const getTreeTableContext = (): TreeTableContext => getContext(key);
+export const getTreeTableNotShownContext = (): NotShown => getContext(key);
 
 /** Recursively build set of accounts that should not be shown. */
 export const get_not_shown = derived(
@@ -56,19 +52,3 @@ export const get_not_shown = derived(
       return not_shown;
     },
 );
-
-/** Determine the accounts that should initially be collapsed. */
-export function get_collapsed(
-  root: AccountTreeNode,
-  $collapse_account: (s: string) => boolean,
-): Set<string> {
-  const s = new Set<string>();
-  const get_collapsed_recursive = ({ children, account }: AccountTreeNode) => {
-    if (children.length && $collapse_account(account)) {
-      s.add(account);
-    }
-    children.forEach(get_collapsed_recursive);
-  };
-  get_collapsed_recursive(root);
-  return s;
-}

--- a/frontend/test/set.test.ts
+++ b/frontend/test/set.test.ts
@@ -1,0 +1,12 @@
+import { test } from "uvu";
+import assert from "uvu/assert";
+
+import { toggle } from "../src/lib/set";
+
+test("toggle set elements", () => {
+  assert.equal(toggle(new Set([0, 1]), 0), new Set([1]));
+  assert.equal(toggle(new Set(["0", 1]), 0), new Set(["0", 0, 1]));
+  assert.equal(toggle(new Set([0, 1]), 2), new Set([0, 1, 2]));
+});
+
+test.run();


### PR DESCRIPTION
This means we store it across page navigations and can more easily
access it in various reports (and possibly also the charts in the
future).

Also adjust the documents report to use this store.

<!--
Hi, thank you for opening a PR!

Please ensure that your change passes tests and the various linters by running
`make test` and `make lint`. If testable, your changes should be covered by
unit tests.

Explain your changes below and link to related issues.
-->
