### PR TITLE
chore: remove unused prettierrc - mdformat is used for markdown now

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,8 +40,7 @@ repos:
       - id: eslint
         name: eslint
         language: node
-        entry:
-          ./frontend/node_modules/eslint/bin/eslint.js --config
+        entry: ./frontend/node_modules/eslint/bin/eslint.js --config
           frontend/eslint.config.mjs --fix --max-warnings 0
         require_serial: true
         types_or: ["javascript", "svelte", "ts"]

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
-src/fava/**/*.html
-tests/__snapshots__/*
+**/*.html
+**/*.md
+tests/__snapshots__/*.json

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,3 +1,0 @@
-{
-  "proseWrap": "always"
-}

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,7 +6,6 @@ exclude .editorconfig
 exclude .gitignore
 exclude .pre-commit-config.yaml
 exclude .prettierignore
-exclude .prettierrc.json
 prune .github
 
 graft src/fava/static


### PR DESCRIPTION
<!--
Hi, thank you for opening a PR!

Please ensure that your change passes tests and the various linters by running
`make test` and `make lint`. If testable, your changes should be covered by
unit tests.

Explain your changes below and link to related issues.
-->
