### PR TITLE
test-js: adjust to allow testing of Svelte components

### DIFF
--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           python-version: "3.12"
       - uses: astral-sh/setup-uv@v6
+      - run: touch src/fava/static/app.js
       - run: make docs
       - if: github.repository == 'beancount/fava'
         uses: actions/configure-pages@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,4 +75,5 @@ jobs:
         with:
           python-version: "3.13"
       - uses: astral-sh/setup-uv@v6
+      - run: touch src/fava/static/app.js
       - run: make mypy

--- a/frontend/build.ts
+++ b/frontend/build.ts
@@ -1,8 +1,9 @@
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
 import chokidar from "chokidar";
 import { context } from "esbuild";
 import svelte from "esbuild-svelte";
-
-import { compilerOptions } from "./tsconfig.json";
 
 /**
  * Create a debounced function.
@@ -43,7 +44,7 @@ async function runBuild(dev: boolean) {
       }),
     ],
     sourcemap: dev,
-    target: compilerOptions.target,
+    target: "esnext",
   });
   console.log("starting build");
   await ctx.rebuild();
@@ -76,7 +77,10 @@ async function runBuild(dev: boolean) {
   }
 }
 
-if (require.main === module) {
+const filename = fileURLToPath(import.meta.url);
+const is_main = resolve(process.argv[1] ?? "") === filename;
+
+if (is_main) {
   const dev = process.argv.includes("--watch");
   runBuild(dev).catch((e: unknown) => {
     console.error(e);

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -49,18 +49,16 @@
         "@types/d3-shape": "^3.0.2",
         "@types/d3-time": "^3.0.0",
         "@types/d3-time-format": "^4.0.0",
-        "@types/eslint__js": "^8.42.3",
-        "@types/js-yaml": "^4.0.5",
+        "@types/jsdom": "^21.1.7",
         "@types/node": "^22.1.0",
         "c8": "^10.1.2",
         "chokidar": "^4.0.0",
         "esbuild": "^0.25.0",
-        "esbuild-register": "^3.0.0",
         "esbuild-svelte": "^0.9.0",
         "eslint": "^9.27.0",
         "eslint-plugin-simple-import-sort": "^12.1.1",
         "eslint-plugin-svelte": "^3.1.0",
-        "js-yaml": "^4.1.0",
+        "jsdom": "^26.1.0",
         "postcss-html": "^1.0.1",
         "prettier": "^3.0.0",
         "prettier-plugin-svelte": "^3.0.0",
@@ -73,6 +71,9 @@
         "typescript-svelte-plugin": "^0.3.47",
         "uvu": "^0.5.1",
         "watchlist": "^0.3.1"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -86,6 +87,20 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -209,6 +224,78 @@
         "crelt": "^1.0.6",
         "style-mod": "^4.1.0",
         "w3c-keyname": "^2.2.4"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.0.2.tgz",
+      "integrity": "sha512-JqWH1vsgdGcw2RR6VliXXdA0/59LttzlU8UlRT/iUUsEeWfYq8I+K0yhihEUTTHLRm1EXvpsCx3083EU15ecsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.0.10.tgz",
+      "integrity": "sha512-TiJ5Ajr6WRd1r8HSiwJvZBiJOqtH86aHpUjq5aEKWHiII2Qfjqd/HCWKPOW8EP4vcspXbHnXrwIDlu5savQipg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.0.2",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
       }
     },
     "node_modules/@csstools/css-parser-algorithms": {
@@ -1299,27 +1386,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/eslint": {
-      "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
-      "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "*",
-        "@types/json-schema": "*"
-      }
-    },
-    "node_modules/@types/eslint__js": {
-      "version": "8.42.3",
-      "resolved": "https://registry.npmjs.org/@types/eslint__js/-/eslint__js-8.42.3.tgz",
-      "integrity": "sha512-alfG737uhmPdnvkrLdZLcEKJ/B8s9Y4hrZ+YAdzUeoArBlSUERA2E87ROfOaS4jd/C45fzOoZzidLc1IPwLqOw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/eslint": "*"
-      }
-    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1333,12 +1399,17 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/js-yaml": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
-      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+    "node_modules/@types/jsdom": {
+      "version": "21.1.7",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-21.1.7.tgz",
+      "integrity": "sha512-yOriVnggzrnQ3a9OKOCxaVuSug3w3/SbOj5i7VwXWZEyUNl3bLF9V3MfxGbZKuwqJOQyRfqXyROBB1CoZLFWzA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "parse5": "^7.0.0"
+      }
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
@@ -1356,6 +1427,13 @@
       "dependencies": {
         "undici-types": "~6.21.0"
       }
+    },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.34.0",
@@ -1640,6 +1718,16 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
+      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/ajv": {
@@ -2073,6 +2161,20 @@
         "node": ">=4"
       }
     },
+    "node_modules/cssstyle": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.4.0.tgz",
+      "integrity": "sha512-W0Y2HOXlPkb2yaKrCVRjinYKciu/qSLEmK0K9mcfDei3zwlnHFEHAs/Du3cIRwPqY+J4JsiBzUjoHyc8RsJ03A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/d3-array": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
@@ -2212,6 +2314,20 @@
         "node": ">=12"
       }
     },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
@@ -2229,6 +2345,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.5.0.tgz",
+      "integrity": "sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/dedent-js": {
       "version": "1.0.1",
@@ -2422,19 +2545,6 @@
         "@esbuild/win32-arm64": "0.25.5",
         "@esbuild/win32-ia32": "0.25.5",
         "@esbuild/win32-x64": "0.25.5"
-      }
-    },
-    "node_modules/esbuild-register": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/esbuild-register/-/esbuild-register-3.6.0.tgz",
-      "integrity": "sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.3.4"
-      },
-      "peerDependencies": {
-        "esbuild": ">=0.12 <1"
       }
     },
     "node_modules/esbuild-svelte": {
@@ -3049,6 +3159,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -3087,6 +3210,47 @@
         "domhandler": "^5.0.3",
         "domutils": "^3.0.1",
         "entities": "^4.4.0"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/ieee754": {
@@ -3223,6 +3387,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-reference": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
@@ -3312,6 +3483,46 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+      "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.2.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.5.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.16",
+        "parse5": "^7.2.1",
+        "rrweb-cssom": "^0.8.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.1.1",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.1.1",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/json-buffer": {
@@ -3630,6 +3841,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/nwsapi": {
+      "version": "2.2.20",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.20.tgz",
+      "integrity": "sha512-/ieB+mDe4MrrKMT8z+mQL8klXydZWGR5Dowt4RAGKbJ3kIGEx3X4ljUo+6V73IXtUPWgfOlU5B9MlGxFO5T+cA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -3717,6 +3935,32 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/pascal-case": {
@@ -4104,6 +4348,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -4139,6 +4390,26 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/semver": {
@@ -4652,6 +4923,13 @@
       "integrity": "sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==",
       "dev": true
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/table": {
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/table/-/table-6.9.0.tgz",
@@ -4734,6 +5012,26 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -4745,6 +5043,32 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/ts-api-utils": {
@@ -4892,6 +5216,19 @@
       "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
       "license": "MIT"
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/watchlist": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/watchlist/-/watchlist-0.3.1.tgz",
@@ -4913,6 +5250,53 @@
       "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.25.6.tgz",
       "integrity": "sha512-WG+/YGbxw8r+rLlzzhV+OvgiOJCWdIpOucG3qBf3RCBFMkGDb1CanUi2BxCxjnkpzU3/hLWPT8VO5EKsMk9Fxg==",
       "license": "MIT"
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -5057,6 +5441,45 @@
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
+    },
+    "node_modules/ws": {
+      "version": "8.18.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.2.tgz",
+      "integrity": "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,13 +2,31 @@
   "name": "fava",
   "private": true,
   "version": "1.0.0",
+  "type": "module",
   "scripts": {
-    "build": "node -r esbuild-register build.ts",
-    "dev": "node -r esbuild-register build.ts --watch",
-    "sync-pre-commit": "node -r esbuild-register sync-pre-commit.ts",
-    "sync-github-actions": "node -r esbuild-register sync-github-actions.ts",
-    "test": "c8 --all --src src -r html uvu -r esbuild-register test",
+    "build": "node --import ./setup.mjs build.ts",
+    "dev": "node --import ./setup.mjs build.ts --watch",
+    "sync-pre-commit": "node --import ./setup.mjs sync-pre-commit.ts",
+    "sync-github-actions": "node --import ./setup.mjs sync-github-actions.ts",
+    "test": "c8 node --conditions browser --import ./setup.mjs ./node_modules/uvu/bin.js test",
     "test:watch": "watchlist --eager src test -- npm test"
+  },
+  "engines": {
+    "node": ">=22"
+  },
+  "c8": {
+    "all": true,
+    "extension": [
+      ".mjs",
+      ".svelte",
+      ".ts"
+    ],
+    "reporter": [
+      "html"
+    ],
+    "src": [
+      "src"
+    ]
   },
   "devDependencies": {
     "@eslint/js": "^9.14.0",
@@ -24,18 +42,16 @@
     "@types/d3-shape": "^3.0.2",
     "@types/d3-time": "^3.0.0",
     "@types/d3-time-format": "^4.0.0",
-    "@types/eslint__js": "^8.42.3",
-    "@types/js-yaml": "^4.0.5",
+    "@types/jsdom": "^21.1.7",
     "@types/node": "^22.1.0",
     "c8": "^10.1.2",
     "chokidar": "^4.0.0",
     "esbuild": "^0.25.0",
-    "esbuild-register": "^3.0.0",
     "esbuild-svelte": "^0.9.0",
     "eslint": "^9.27.0",
     "eslint-plugin-simple-import-sort": "^12.1.1",
     "eslint-plugin-svelte": "^3.1.0",
-    "js-yaml": "^4.1.0",
+    "jsdom": "^26.1.0",
     "postcss-html": "^1.0.1",
     "prettier": "^3.0.0",
     "prettier-plugin-svelte": "^3.0.0",

--- a/frontend/setup.mjs
+++ b/frontend/setup.mjs
@@ -1,0 +1,47 @@
+import { readFileSync } from "node:fs";
+import { registerHooks } from "node:module";
+import { fileURLToPath } from "node:url";
+
+import { transformSync } from "esbuild";
+import { compile } from "svelte/compiler";
+
+registerHooks({
+  load(url, context, nextLoad) {
+    if (url.endsWith(".ts")) {
+      const filename = fileURLToPath(url);
+      const raw_source = readFileSync(filename, "utf8");
+      const result = transformSync(raw_source, {
+        loader: "ts",
+        sourcefile: filename,
+        sourcemap: "inline",
+      });
+      const source = result.code;
+      return { format: "module", source, shortCircuit: true };
+    } else if (url.endsWith(".svelte")) {
+      const filename = fileURLToPath(url);
+      const raw_source = readFileSync(filename, "utf8");
+      const result = compile(raw_source, { filename });
+      const source = `${result.js.code}\n//# sourceMappingURL=${result.js.map.toUrl()}`;
+      return { format: "module", source, shortCircuit: true };
+    }
+
+    return nextLoad(url, context);
+  },
+  resolve(specifier, context, nextResolve) {
+    if (specifier.startsWith(".") && !specifier.endsWith(".ts")) {
+      try {
+        // Resolve dir imports that are not supported by ES imports
+        return nextResolve(specifier + "/index.ts", context);
+      } catch {
+        try {
+          // Try adding .ts extension
+          return nextResolve(specifier + ".ts", context);
+        } catch {
+          // Fall back to original resolution
+        }
+      }
+    }
+
+    return nextResolve(specifier, context);
+  },
+});

--- a/frontend/src/keyboard-shortcuts.ts
+++ b/frontend/src/keyboard-shortcuts.ts
@@ -148,8 +148,6 @@ function keydown(event: KeyboardEvent): void {
   }
 }
 
-document.addEventListener("keydown", keydown);
-
 /** A type to specify a platform-dependent keyboard shortcut. */
 export type KeySpec =
   | KeyCombo
@@ -248,9 +246,11 @@ export const keyboardShortcut: Action<HTMLElement, KeySpec | undefined> = (
 };
 
 /**
- * Register the keys to show/hide the tooltips
+ * Register the keys to show/hide the tooltips and register the global keydown handler.
  */
 export function initGlobalKeyboardShortcuts(): void {
+  document.addEventListener("keydown", keydown);
+
   bindKey("?", () => {
     const hide = showTooltips();
     const once = () => {

--- a/frontend/sync-github-actions.ts
+++ b/frontend/sync-github-actions.ts
@@ -4,10 +4,17 @@
 
 import { readdir, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { object, string } from "./src/lib/validation";
 
-const workflows = join(__dirname, "..", ".github", "workflows");
+const workflows = join(
+  fileURLToPath(import.meta.url),
+  "..",
+  "..",
+  ".github",
+  "workflows",
+);
 const action_regex = /uses: ([-/\w]+)@(\S+)/g;
 const release_validator = object({ tag_name: string });
 

--- a/frontend/test/AutocompleteInput.test.ts
+++ b/frontend/test/AutocompleteInput.test.ts
@@ -1,0 +1,45 @@
+import { equal, ok } from "node:assert/strict";
+
+import { flushSync, mount } from "svelte";
+import { test } from "uvu";
+
+import AutocompleteInput from "../src/AutocompleteInput.svelte";
+import { setup_jsdom } from "./dom";
+
+test.before.each(setup_jsdom);
+
+test("AutocompleteInput: renders no suggestions if none match", () => {
+  mount(AutocompleteInput, {
+    target: document.body,
+    props: {
+      value: "nomatch",
+      placeholder: "test placeholder",
+      suggestions: ["apple", "banana", "cherry"],
+    },
+  });
+  flushSync();
+  const input = document.body.querySelector("input");
+  ok(input instanceof HTMLInputElement);
+  equal(input.value, "nomatch");
+  const ul = document.body.querySelector("ul");
+  ok(!ul);
+});
+
+test("AutocompleteInput: renders with matching suggestions", () => {
+  mount(AutocompleteInput, {
+    target: document.body,
+    props: {
+      value: "app",
+      placeholder: "test placeholder",
+      suggestions: ["apple", "banana", "cherry"],
+    },
+  });
+  flushSync();
+  const input = document.body.querySelector("input");
+  ok(input instanceof HTMLInputElement);
+  equal(input.value, "app");
+  const ul = document.body.querySelector("ul");
+  equal(ul?.firstElementChild?.textContent, "apple");
+});
+
+test.run();

--- a/frontend/test/account.test.ts
+++ b/frontend/test/account.test.ts
@@ -1,5 +1,5 @@
 import { test } from "uvu";
-import assert from "uvu/assert";
+import * as assert from "uvu/assert";
 
 import {
   ancestors,

--- a/frontend/test/array.test.ts
+++ b/frontend/test/array.test.ts
@@ -1,5 +1,5 @@
 import { test } from "uvu";
-import assert from "uvu/assert";
+import * as assert from "uvu/assert";
 
 import { is_non_empty, move } from "../src/lib/array";
 

--- a/frontend/test/charts.test.ts
+++ b/frontend/test/charts.test.ts
@@ -1,7 +1,6 @@
 import { test } from "uvu";
-import assert from "uvu/assert";
+import * as assert from "uvu/assert";
 
-import { parseChartData } from "../src/charts";
 import { bar } from "../src/charts/bar";
 import {
   colors10,
@@ -11,6 +10,7 @@ import {
   padExtent,
 } from "../src/charts/helpers";
 import { hierarchy, HierarchyChart } from "../src/charts/hierarchy";
+import { parseChartData } from "../src/charts/index";
 import { balances, LineChart } from "../src/charts/line";
 import { ScatterPlot, scatterplot } from "../src/charts/scatterplot";
 import { loadJSONSnapshot } from "./helpers";

--- a/frontend/test/dom.ts
+++ b/frontend/test/dom.ts
@@ -1,0 +1,24 @@
+import { JSDOM } from "jsdom";
+
+let ran_once = false;
+
+/** Setup jsdom to allow browser-code to run. */
+export function setup_jsdom(): void {
+  if (!ran_once) {
+    const { window } = new JSDOM("", { url: "http://localhost:3000" });
+    const window_keys = Object.getOwnPropertyNames(window).filter(
+      (key) => !key.startsWith("_") && !(key in global),
+    );
+    // @ts-expect-error Unexpected in Node
+    global.window = window;
+    for (const key of window_keys) {
+      // @ts-expect-error Unexpected in Node
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      global[key] = window[key];
+    }
+    ran_once = true;
+  }
+  window.document.title = "";
+  window.document.head.innerHTML = "";
+  window.document.body.innerHTML = "";
+}

--- a/frontend/test/editor.test.ts
+++ b/frontend/test/editor.test.ts
@@ -1,7 +1,7 @@
 import { setDiagnosticsEffect } from "@codemirror/lint";
 import { EditorState } from "@codemirror/state";
 import { test } from "uvu";
-import assert from "uvu/assert";
+import * as assert from "uvu/assert";
 
 import {
   replaceContents,

--- a/frontend/test/end-to-end-validation.test.ts
+++ b/frontend/test/end-to-end-validation.test.ts
@@ -1,6 +1,6 @@
 import { get as store_get } from "svelte/store";
 import { test } from "uvu";
-import assert from "uvu/assert";
+import * as assert from "uvu/assert";
 
 import { getAPIValidators } from "../src/api/validators";
 import { chartContext } from "../src/charts/context";
@@ -9,8 +9,8 @@ import {
   sunburstScale,
   treemapScale,
 } from "../src/charts/helpers";
-import { currencies, ledgerData } from "../src/stores";
 import { conversions } from "../src/stores/chart";
+import { currencies, ledgerData } from "../src/stores/index";
 import { initialiseLedgerData, loadJSONSnapshot } from "./helpers";
 
 test.before(initialiseLedgerData);

--- a/frontend/test/entries.test.ts
+++ b/frontend/test/entries.test.ts
@@ -1,5 +1,5 @@
 import { test } from "uvu";
-import assert from "uvu/assert";
+import * as assert from "uvu/assert";
 
 import {
   Amount,
@@ -11,7 +11,7 @@ import {
   Note,
   Posting,
   Transaction,
-} from "../src/entries";
+} from "../src/entries/index";
 import { Position } from "../src/entries/position";
 import { formatter_context } from "../src/format";
 

--- a/frontend/test/equals.test.ts
+++ b/frontend/test/equals.test.ts
@@ -1,5 +1,5 @@
 import { test } from "uvu";
-import assert from "uvu/assert";
+import * as assert from "uvu/assert";
 
 import { shallow_equal } from "../src/lib/equals";
 

--- a/frontend/test/events.test.ts
+++ b/frontend/test/events.test.ts
@@ -1,5 +1,5 @@
 import { test } from "uvu";
-import assert from "uvu/assert";
+import * as assert from "uvu/assert";
 
 import { Events } from "../src/lib/events";
 

--- a/frontend/test/format.test.ts
+++ b/frontend/test/format.test.ts
@@ -1,5 +1,5 @@
 import { test } from "uvu";
-import assert from "uvu/assert";
+import * as assert from "uvu/assert";
 
 import {
   dateFormat,

--- a/frontend/test/fuzzy.test.ts
+++ b/frontend/test/fuzzy.test.ts
@@ -1,5 +1,5 @@
 import { test } from "uvu";
-import assert from "uvu/assert";
+import * as assert from "uvu/assert";
 
 import { fuzzyfilter, fuzzytest, fuzzywrap } from "../src/lib/fuzzy";
 

--- a/frontend/test/helpers.ts
+++ b/frontend/test/helpers.ts
@@ -1,15 +1,24 @@
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { ledgerDataValidator } from "../src/api/validators";
 import { parseJSON } from "../src/lib/json";
-import { ledgerData } from "../src/stores";
+import { ledgerData } from "../src/stores/index";
 
 /** Load the Python test snapshot output with the given name and parse as JSON. */
 export async function loadJSONSnapshot(
   name: `${string}.json`,
 ): Promise<unknown> {
-  const path = join(__dirname, "..", "..", "tests", "__snapshots__", name);
+  const path = join(
+    fileURLToPath(import.meta.url),
+    "..",
+    "..",
+    "..",
+    "tests",
+    "__snapshots__",
+    name,
+  );
   return parseJSON(await readFile(path, "utf8")).unwrap();
 }
 

--- a/frontend/test/misc.test.ts
+++ b/frontend/test/misc.test.ts
@@ -1,5 +1,5 @@
 import { test } from "uvu";
-import assert from "uvu/assert";
+import * as assert from "uvu/assert";
 
 import { is_non_empty, last_element } from "../src/lib/array";
 import { errorWithCauses } from "../src/lib/errors";

--- a/frontend/test/objects.test.ts
+++ b/frontend/test/objects.test.ts
@@ -1,5 +1,5 @@
 import { test } from "uvu";
-import assert from "uvu/assert";
+import * as assert from "uvu/assert";
 
 import { is_empty } from "../src/lib/objects";
 

--- a/frontend/test/parser.test.ts
+++ b/frontend/test/parser.test.ts
@@ -1,9 +1,10 @@
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 import type { Tree } from "@lezer/common";
 import { TreeFragment } from "@lezer/common";
 import { test } from "uvu";
-import assert from "uvu/assert";
+import * as assert from "uvu/assert";
 import { Language as TSLanguage, Parser as TSParser } from "web-tree-sitter";
 
 import {
@@ -15,7 +16,8 @@ import { is_non_empty } from "../src/lib/array";
 async function load(): Promise<TSParser> {
   await TSParser.init();
   const path = join(
-    __dirname,
+    fileURLToPath(import.meta.url),
+    "..",
     "..",
     "src",
     "codemirror",

--- a/frontend/test/paths.test.ts
+++ b/frontend/test/paths.test.ts
@@ -1,5 +1,5 @@
 import { test } from "uvu";
-import assert from "uvu/assert";
+import * as assert from "uvu/assert";
 
 import { basename, documentHasAccount, ext } from "../src/lib/paths";
 

--- a/frontend/test/result.test.ts
+++ b/frontend/test/result.test.ts
@@ -1,5 +1,5 @@
 import { test } from "uvu";
-import assert from "uvu/assert";
+import * as assert from "uvu/assert";
 
 import type { Result } from "../src/lib/result";
 import { collect, Err, err, Ok, ok } from "../src/lib/result";

--- a/frontend/test/set.test.ts
+++ b/frontend/test/set.test.ts
@@ -1,5 +1,5 @@
 import { test } from "uvu";
-import assert from "uvu/assert";
+import * as assert from "uvu/assert";
 
 import { toggle } from "../src/lib/set";
 

--- a/frontend/test/store.test.ts
+++ b/frontend/test/store.test.ts
@@ -1,6 +1,6 @@
 import { writable } from "svelte/store";
 import { test } from "uvu";
-import assert from "uvu/assert";
+import * as assert from "uvu/assert";
 
 import { derived_array } from "../src/lib/store";
 

--- a/frontend/test/tree.test.ts
+++ b/frontend/test/tree.test.ts
@@ -1,5 +1,5 @@
 import { test } from "uvu";
-import assert from "uvu/assert";
+import * as assert from "uvu/assert";
 
 import { stratify } from "../src/lib/tree";
 

--- a/frontend/test/urls.test.ts
+++ b/frontend/test/urls.test.ts
@@ -1,9 +1,9 @@
 import { get as store_get } from "svelte/store";
 import { test } from "uvu";
-import assert from "uvu/assert";
+import * as assert from "uvu/assert";
 
 import { getUrlPath, urlForAccount, urlForInternal } from "../src/helpers";
-import { base_url } from "../src/stores";
+import { base_url } from "../src/stores/index";
 import { initialiseLedgerData } from "./helpers";
 
 test.before(initialiseLedgerData);

--- a/frontend/test/validation.test.ts
+++ b/frontend/test/validation.test.ts
@@ -1,5 +1,5 @@
 import { test } from "uvu";
-import assert from "uvu/assert";
+import * as assert from "uvu/assert";
 
 import {
   boolean,

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -16,7 +16,7 @@
     "src/**/*.ts",
     "src/**/*.svelte",
     "test/**/*.ts",
-    "*.config.cjs",
-    "*.config.mjs"
+    "*.cjs",
+    "*.mjs"
   ]
 }


### PR DESCRIPTION
- add setup script that calls registerHooks. This keeps the existing
  behaviour and allows importing svelte components in tests.
- Add a trivial test for the AutocompleteInput component

Also simplify sync-pre-commit script

<!--
Hi, thank you for opening a PR!

Please ensure that your change passes tests and the various linters by running
`make test` and `make lint`. If testable, your changes should be covered by
unit tests.

Explain your changes below and link to related issues.
-->
