### PR TITLE
lint: add biome config and use if for some filetypes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,6 +16,6 @@ indent_size = 4
 [Makefile]
 indent_style = tab
 
-[*.{ts,json,css,html,svelte}]
+[*.{css,html,json,svelte,ts,yaml,js,mjs,cjs}]
 indent_style = space
 indent_size = 2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,13 +14,18 @@ repos:
         args: ["--wrap", "80"]
         additional_dependencies:
           - mdformat-gfm
+  - repo: https://github.com/biomejs/pre-commit
+    rev: v2.0.6
+    hooks:
+      - id: biome-check
+        args: ["--error-on-warnings"]
   - repo: local
     hooks:
       - id: prettier
         name: prettier
         language: node
         entry: prettier --write --list-different
-        types_or: ["css", "javascript", "json", "svelte", "yaml", "ts"]
+        types_or: ["svelte", "yaml"]
         require_serial: true
         additional_dependencies:
           - "prettier@3.6.2"

--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ run-example:
 .PHONY: bql-grammar
 bql-grammar: .venv contrib/scripts.py
 	uv run --group scripts contrib/scripts.py generate-bql-grammar-json
-	-uv run pre-commit run prettier --files frontend/src/codemirror/bql-grammar.ts
+	-uv run pre-commit run --files frontend/src/codemirror/bql-grammar.ts
 
 # Build the distribution (sdist and wheel).
 .PHONY: dist

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.0.6/schema.json",
+  "files": {
+    "includes": [
+      "**",
+      "!**/src/fava/**/*.html",
+      "!**/tests/__snapshots__/**/*.json"
+    ]
+  },
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "formatter": {
+    "includes": ["**", "!**/frontend/src/**/*.svelte"],
+    "useEditorconfig": true
+  },
+  "assist": { "actions": { "source": { "organizeImports": "off" } } },
+  "linter": {
+    "rules": {
+      "recommended": true,
+      "complexity": {
+        "noForEach": "off"
+      },
+      "suspicious": {
+        "noExplicitAny": "off"
+      },
+      "style": {
+        "noNonNullAssertion": "off"
+      }
+    }
+  },
+  "overrides": [
+    {
+      "includes": ["**/*.svelte"],
+      "linter": {
+        "rules": {
+          "correctness": {
+            "noUnusedImports": "off",
+            "noUnusedVariables": "off"
+          },
+          "style": {
+            "useConst": "off",
+            "useImportType": "off"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/frontend/css/journal-table.css
+++ b/frontend/css/journal-table.css
@@ -73,10 +73,16 @@
 .journal.show-note .note,
 .journal.show-open .open,
 .journal.show-pad .pad,
-.journal.show-query .query,
+.journal.show-query .query {
+  display: block;
+}
+
 /* Show metadata and postings if it was toggled for the whole journal. */
 .journal.show-metadata .metadata,
-.journal.show-postings .postings,
+.journal.show-postings .postings {
+  display: block;
+}
+
 /* Show metadata and postings where it was explicitly toggled with the indicators. */
 .journal > li.show-full-entry .postings,
 .journal > li.show-full-entry .metadata {

--- a/frontend/prettier.config.cjs
+++ b/frontend/prettier.config.cjs
@@ -1,7 +1,6 @@
 /** @type {import("prettier").Options} */
 const config = {
   plugins: [require.resolve("prettier-plugin-svelte")],
-  proseWrap: "always",
 };
 
 module.exports = config;

--- a/frontend/src/charts/SelectCombobox.svelte
+++ b/frontend/src/charts/SelectCombobox.svelte
@@ -98,6 +98,7 @@
       const option = o ?? options[index];
       if (option != null) {
         if (
+          // biome-ignore lint/complexity/useOptionalChain: clashes with strict-boolean-expressions rule
           multiple_select != null &&
           multiple_select(option) &&
           values.every(multiple_select)

--- a/frontend/src/lib/validation.ts
+++ b/frontend/src/lib/validation.ts
@@ -281,9 +281,11 @@ export function isJsonObject(json: unknown): json is Record<string, unknown> {
 /**
  * Validator for an object with some given properties.
  */
-export function object<T>(validators: {
-  [t in keyof T]: Validator<T[t]>;
-}): Validator<T> {
+export function object<T>(
+  validators: {
+    [t in keyof T]: Validator<T[t]>;
+  },
+): Validator<T> {
   return (json) => {
     if (isJsonObject(json)) {
       const obj: Partial<T> = {};


### PR DESCRIPTION
Biome does not support svelte template or yaml formatting so keep
prettier in place for those. For Typescript there was only one place
where the formatting changed, so it is very close to prettier.

Performance is great and it brings some useful linting rules as well.
For linting we still keep eslint though, it is no match for the
type-aware rules of typescript-eslint.

<!--
Hi, thank you for opening a PR!

Please ensure that your change passes tests and the various linters by running
`make test` and `make lint`. If testable, your changes should be covered by
unit tests.

Explain your changes below and link to related issues.
-->
