### PR TITLE
use flex for journal table

### DIFF
--- a/frontend/css/journal-table.css
+++ b/frontend/css/journal-table.css
@@ -1,5 +1,10 @@
 /* stylelint-disable no-descending-specificity */
 
+.flex-table {
+  display: flex;
+  flex-direction: column;
+}
+
 .flex-table p,
 .flex-table li,
 .flex-table ul,


### PR DESCRIPTION
This PR uses `display: flex` for the journal table. It should not cause any visual difference, but it can make sorting the journal table significantly faster at least on Firefox. (In a test Beancount file with 10k transactions, sort by date back and forth takes 927ms in handling the click event in total with this PR, vs. 1,428ms without.) 

I profiled sorting, and it seems that Firefox spends a significant amount of time trying to resolve lines in the block when removing the element from their original position. Using flex box for the container removes the need to handle the complexity of doing line layout which only exists in `block` container.

It doesn't seem to make any difference on Chrome, though.