### PR TITLE
store: listen to storage events; improve test coverage

### DIFF
--- a/frontend/src/lib/store.ts
+++ b/frontend/src/lib/store.ts
@@ -31,13 +31,18 @@ export function derived_array<S, T extends StrictEquality>(
 
 /** A store that has its value synced to localStorage. */
 export type LocalStoreSyncedStore<T> = Writable<T> & {
+  /** The key that this is stored under in localStorage. */
+  key: string;
   /** List all the values that this store can take. */
   values: () => [T, string][];
 };
 
+/** Keep track of all created stores. */
+const local_storage_synced_stores = new Set();
+
 /**
  * Create a store that syncs its value to localStorage.
- * @param key - The key to save this with in localStorage.
+ * @param key - The key to save this with in localStorage (will be prefixed with `fava-`).
  * @param validator - A Validator to check the loaded value.
  * @param init - A default to initialise the store with if localStorage is empty.
  * @param values - An optional enumerator of all possible values and descriptions.
@@ -48,25 +53,60 @@ export function localStorageSyncedStore<T>(
   init: () => T,
   values: () => [T, string][] = () => [],
 ): LocalStoreSyncedStore<T> {
-  const fullKey = `fava-${key}`;
+  if (key.startsWith("fava")) {
+    throw new Error("INTERNAL: should be called without 'fava-' prefix.");
+  }
+  const full_key = `fava-${key}`;
+  if (local_storage_synced_stores.has(full_key)) {
+    throw new Error(`INTERNAL: duplicate store with key '${key}'.`);
+  }
+  local_storage_synced_stores.add(full_key);
 
   // Create a store which is empty first but reads the value from
   // localStorage on the first subscription.
-  const store = writable<T>(undefined, (set) => {
-    const stored_val = localStorage.getItem(fullKey);
-    let initial: T | null = null;
-    if (stored_val != null) {
-      const val = parseJSON(stored_val).and_then(validator).unwrap_or(null);
-      if (val !== null) {
-        initial = val;
+  const {
+    set: store_set,
+    update: store_update,
+    subscribe,
+  } = writable<T>(undefined, (set) => {
+    const set_from_stored_value = (stored: string | null) => {
+      let initial: T | null = null;
+      if (stored != null) {
+        const res = parseJSON(stored).and_then(validator);
+        if (res.is_ok) {
+          initial = res.value;
+        }
       }
-    }
-    set(initial ?? init());
+      set(initial ?? init());
+    };
+    set_from_stored_value(localStorage.getItem(full_key));
 
-    store.subscribe((val) => {
-      localStorage.setItem(fullKey, JSON.stringify(val));
-    });
+    const listener = (event: StorageEvent) => {
+      if (event.storageArea === localStorage && event.key === full_key) {
+        set_from_stored_value(event.newValue);
+      }
+    };
+
+    window.addEventListener("storage", listener);
+    return () => {
+      window.removeEventListener("storage", listener);
+    };
   });
 
-  return { ...store, values };
+  return {
+    set: (val: T) => {
+      localStorage.setItem(full_key, JSON.stringify(val));
+      store_set(val);
+    },
+    update: (updater) => {
+      store_update((old_val) => {
+        const val = updater(old_val);
+        localStorage.setItem(full_key, JSON.stringify(val));
+        return val;
+      });
+    },
+    subscribe,
+    key: full_key,
+    values,
+  };
 }

--- a/frontend/test/store.test.ts
+++ b/frontend/test/store.test.ts
@@ -1,8 +1,12 @@
-import { writable } from "svelte/store";
+import { get as store_get, writable } from "svelte/store";
 import { test } from "uvu";
 import * as assert from "uvu/assert";
 
-import { derived_array } from "../src/lib/store";
+import { derived_array, localStorageSyncedStore } from "../src/lib/store";
+import { string } from "../src/lib/validation";
+import { setup_jsdom } from "./dom";
+
+test.before.each(setup_jsdom);
 
 test("derived store", () => {
   const source = writable<string[]>([]);
@@ -22,6 +26,67 @@ test("derived store", () => {
   source.set(["a", "b"]);
   assert.is(source_count, 6);
   assert.is(derived_count, 2);
+});
+
+test("localStorage-synced stores", () => {
+  const a = localStorageSyncedStore("test-store", string, () => "default");
+  assert.equal(a.key, "fava-test-store");
+  assert.equal(a.values(), []);
+
+  // Getting the value will temporarily attach a subscriber (and unsubscribe as well).
+  localStorage.removeItem(a.key);
+  assert.equal(store_get(a), "default");
+
+  localStorage.setItem(a.key, "invalid-non-json-stringified");
+  assert.equal(store_get(a), "default");
+
+  localStorage.setItem(a.key, JSON.stringify("value"));
+  assert.equal(store_get(a), "value");
+
+  a.set("another-value");
+  assert.equal(store_get(a), "another-value");
+  assert.equal(localStorage.getItem(a.key), JSON.stringify("another-value"));
+
+  a.update(() => "a-value");
+  assert.equal(store_get(a), "a-value");
+  assert.equal(localStorage.getItem(a.key), JSON.stringify("a-value"));
+
+  const seen_values: string[] = [];
+  const unsubscribe = a.subscribe((v) => {
+    seen_values.push(v);
+  });
+  window.dispatchEvent(
+    new StorageEvent("storage", {
+      key: a.key,
+      newValue: JSON.stringify("event-value-different-storage-area"),
+      storageArea: sessionStorage,
+    }),
+  );
+  window.dispatchEvent(
+    new StorageEvent("storage", {
+      key: "fava-wrong-key",
+      newValue: JSON.stringify("event-value-wrong-key"),
+      storageArea: localStorage,
+    }),
+  );
+  window.dispatchEvent(
+    new StorageEvent("storage", {
+      key: a.key,
+      newValue: JSON.stringify("event-value"),
+      storageArea: localStorage,
+    }),
+  );
+  unsubscribe();
+  assert.equal(seen_values, ["a-value", "event-value"]);
+
+  assert.throws(() => {
+    // The prefix is added automatically.
+    localStorageSyncedStore("fava-test-store", string, () => "value");
+  });
+  assert.throws(() => {
+    // No duplicate stores
+    localStorageSyncedStore("test-store", string, () => "value");
+  });
 });
 
 test.run();


### PR DESCRIPTION
This syncs store changes between tabs (instead of loading the updated
value on page reload).

<!--
Hi, thank you for opening a PR!

Please ensure that your change passes tests and the various linters by running
`make test` and `make lint`. If testable, your changes should be covered by
unit tests.

Explain your changes below and link to related issues.
-->
