### PR TITLE
Allow account completion to be case insensitive

### DIFF
--- a/frontend/src/codemirror/beancount-autocomplete.ts
+++ b/frontend/src/codemirror/beancount-autocomplete.ts
@@ -54,7 +54,7 @@ export const beancountCompletion: CompletionSource = (context) => {
     };
   }
 
-  const indented = context.matchBefore(/^\s+[A-Z]\S*/);
+  const indented = context.matchBefore(/^\s+[A-Z]\S*/i);
   if (indented) {
     const indentation = indented.text.length - indented.text.trimStart().length;
     return {


### PR DESCRIPTION
<!--
Hi, thank you for opening a PR!

Please ensure that your change passes tests and the various linters by running
`make test` and `make lint`. If testable, your changes should be covered by
unit tests.

Explain your changes below and link to related issues.
-->

In the Fava editor, if an intended line starts with a lowercase letter, there will be no completion

```beancount
2020-01-01 *
  account-name
  ;          ^ no completion here
```

This PR fixes this and provides a better edit experience.