### PR TITLE
fix: prevent double negative sign display on balance sheet tree-table

### DIFF
--- a/frontend/src/tree-table/Diff.svelte
+++ b/frontend/src/tree-table/Diff.svelte
@@ -16,7 +16,7 @@
 
 <br />
 <span class:positive title={$ctx.amount(num, currency)}>
-  ({positive ? "+" : "-"}{$ctx.num(diff, currency)})
+  ({positive ? "+" : "-"}{$ctx.num(Math.abs(diff), currency)})
 </span>
 
 <style>


### PR DESCRIPTION
### What is the problem?

When `diff` is negative, the component displays a double negative sign like `--10823.44`. This happens because the numeric formatting already includes the negative sign, and the template adds an additional `-` prefix.

> <img width="714" height="233" alt="prevent-double-negative-sign-display-bug" src="https://github.com/user-attachments/assets/435b7b86-4177-4a5b-ba5e-43efa9da7649" />

### What changes were made?

- Use `Math.abs(diff)` to show the absolute value without the sign.
- Add a manual `+` or `-` prefix based on the sign of `diff`.
