### PR TITLE
fix context overflow on long file names

### DIFF
--- a/frontend/src/modals/EntryContext.svelte
+++ b/frontend/src/modals/EntryContext.svelte
@@ -71,3 +71,12 @@
     </div>
   </details>
 {/if}
+
+<style>
+  code {
+    display: inline-block;
+    max-width: 80%;
+    overflow: clip;
+    text-overflow: ellipsis;
+  }
+</style>


### PR DESCRIPTION
Fixes an overflow in the UI if the ledger path is really long. 
Before / After:

---------

<img width="1090" height="129" alt="Screenshot 2025-07-19 at 1 57 57 PM" src="https://github.com/user-attachments/assets/ea2550c2-36d3-48d3-bd68-b1de95acba4e" />

--------


<img width="847" height="98" alt="Screenshot 2025-07-19 at 1 51 30 PM" src="https://github.com/user-attachments/assets/d644e5de-ddf3-40c1-9de9-43ce29f95fd2" />

