### PR TITLE
Exclude modal dialogs from browser history

### DIFF
--- a/frontend/src/router.ts
+++ b/frontend/src/router.ts
@@ -303,6 +303,7 @@ export class Router extends Events<"page-loaded"> {
         return;
       }
       if (link.getAttribute("href")?.charAt(0) === "#") {
+        window.history.replaceState(null, "", link.getAttribute("href"));
         return;
       }
       if (is_external_link(link)) {

--- a/frontend/src/stores/url.ts
+++ b/frontend/src/stores/url.ts
@@ -43,7 +43,7 @@ export const syncedSearchParams: Readable<URLSearchParams> = derived(
 
 export function closeOverlay(): void {
   if (window.location.hash) {
-    window.history.back();
+    window.history.replaceState(null, "", "#");
   }
   urlHash.set("");
 }


### PR DESCRIPTION
Currently, when I close a modal dialog (e.g. the beancount file context in the journal view when pressing on the transaction date) and then press the back button in my browser, the modal dialog opens again. If I open a few modal dialogs after another, all of them open again when I click the back button a few times.

With this change, `history.back()` is called upon closing the modal dialog, therefore removing the modal URL from the browser history. Now, pressing the back button brings me to the previous page, and not the previous modal dialog.