### PR TITLE
autocomplete: use index as key for fuzzy wrapped text for unique keys

### DIFF
--- a/frontend/src/AutocompleteInput.svelte
+++ b/frontend/src/AutocompleteInput.svelte
@@ -199,7 +199,7 @@
             mousedown(ev, suggestion);
           }}
         >
-          {#each fuzzywrapped as [type, text] (`${type}-${text}`)}
+          {#each fuzzywrapped as [type, text], i (i)}
             {#if type === "text"}
               {text}
             {:else}


### PR DESCRIPTION
<!--
Hi, thank you for opening a PR!

Please ensure that your change passes tests and the various linters by running
`make test` and `make lint`. If testable, your changes should be covered by
unit tests.

Explain your changes below and link to related issues.
-->
