### PR TITLE
Add ctrl-p and ctrl-n for up/down navigation in drop-downs

### DIFF
--- a/frontend/src/AutocompleteInput.svelte
+++ b/frontend/src/AutocompleteInput.svelte
@@ -138,10 +138,16 @@
       } else {
         value = "";
       }
-    } else if (event.key === "ArrowUp") {
+    } else if (
+      event.key === "ArrowUp" ||
+      (event.ctrlKey && event.key.toLowerCase() === "p")
+    ) {
       event.preventDefault();
       index = index === 0 ? filteredSuggestions.length - 1 : index - 1;
-    } else if (event.key === "ArrowDown") {
+    } else if (
+      event.key === "ArrowDown" ||
+      (event.ctrlKey && event.key.toLowerCase() === "n")
+    ) {
       event.preventDefault();
       index = index === filteredSuggestions.length - 1 ? 0 : index + 1;
     }

--- a/frontend/src/codemirror/setup.ts
+++ b/frontend/src/codemirror/setup.ts
@@ -3,6 +3,7 @@ import {
   closeBrackets,
   closeBracketsKeymap,
   completionKeymap,
+  moveCompletionSelection,
 } from "@codemirror/autocomplete";
 import {
   defaultKeymap,
@@ -64,6 +65,8 @@ const baseExtensions = [
   highlightSelectionMatches(),
   lintGutter(),
   keymap.of([
+    { key: "Control-n", run: moveCompletionSelection(true) },
+    { key: "Control-p", run: moveCompletionSelection(false) },
     ...closeBracketsKeymap,
     ...defaultKeymap,
     ...searchKeymap,


### PR DESCRIPTION
Hi! I added ctrl+p and ctrl+n shortcuts to move the selection up & down in dropdown menus, e.g. in the slice editor auto-complete, or in the account quick-open. These are common shortcuts that I use everywhere else. I find it quite useful since they let me keep my hands on the home row (and avoid the horrible macbook arrow keys!).