### PR TITLE
router: refactor to reduce URL-related stores

### DIFF
--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -6,7 +6,7 @@ import { fetchJSON } from "../lib/fetch";
 import type { ValidationT } from "../lib/validation";
 import { string } from "../lib/validation";
 import { notify, notify_err } from "../notifications";
-import router from "../router";
+import { router } from "../router";
 import type { Filters, FiltersConversionInterval } from "../stores/filters";
 import type { GetAPIValidators, SourceFile } from "./validators";
 import { getAPIValidators } from "./validators";

--- a/frontend/src/charts/Chart.svelte
+++ b/frontend/src/charts/Chart.svelte
@@ -1,13 +1,14 @@
 <script lang="ts">
   import type { Snippet } from "svelte";
 
+  import { router } from "../router";
   import {
     barChartMode,
     chartToggledCurrencies,
     hierarchyChartMode,
     lineChartMode,
-    showCharts,
   } from "../stores/chart";
+  import { show_charts } from "../stores/url";
   import type { FavaChart } from ".";
   import BarChart from "./BarChart.svelte";
   import ChartLegend from "./ChartLegend.svelte";
@@ -30,7 +31,7 @@
 </script>
 
 <div class="flex-row">
-  {#if $showCharts}
+  {#if $show_charts}
     {#if chart.type === "barchart"}
       <ChartLegend
         legend={chart.currencies}
@@ -66,13 +67,13 @@
     type="button"
     class="show-charts"
     onclick={() => {
-      showCharts.update((v) => !v);
+      router.set_search_param("charts", $show_charts ? "false" : "");
     }}
   >
-    {$showCharts ? "▼" : "◀"}
+    {$show_charts ? "▼" : "◀"}
   </button>
 </div>
-<div hidden={!$showCharts} bind:clientWidth={width}>
+<div hidden={!$show_charts} bind:clientWidth={width}>
   {#if width}
     {#if chart.type === "barchart"}
       <BarChart {chart} {width} />

--- a/frontend/src/charts/ChartSwitcher.svelte
+++ b/frontend/src/charts/ChartSwitcher.svelte
@@ -2,7 +2,8 @@
   import { _ } from "../i18n";
   import type { KeySpec } from "../keyboard-shortcuts";
   import { keyboardShortcut } from "../keyboard-shortcuts";
-  import { lastActiveChartName, showCharts } from "../stores/chart";
+  import { lastActiveChartName } from "../stores/chart";
+  import { show_charts } from "../stores/url";
   import type { FavaChart } from ".";
   import Chart from "./Chart.svelte";
   import ConversionAndInterval from "./ConversionAndInterval.svelte";
@@ -37,7 +38,7 @@
   <Chart chart={active_chart}>
     <ConversionAndInterval />
   </Chart>
-  <div hidden={!$showCharts}>
+  <div hidden={!$show_charts}>
     {#each charts as chart, index (chart.name)}
       <button
         type="button"

--- a/frontend/src/charts/ConversionAndInterval.svelte
+++ b/frontend/src/charts/ConversionAndInterval.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
   import { _, format } from "../i18n";
   import { getInterval, intervalLabel, INTERVALS } from "../lib/interval";
-  import { conversion, interval } from "../stores";
+  import { router } from "../router";
   import { conversions } from "../stores/chart";
+  import { conversion, interval } from "../stores/url";
   import SelectCombobox from "./SelectCombobox.svelte";
 
   const conversion_description = (option: string) => {
@@ -23,14 +24,24 @@
 </script>
 
 <SelectCombobox
-  bind:value={$conversion}
+  bind:value={
+    () => $conversion,
+    (value: string) => {
+      router.set_search_param("conversion", value);
+    }
+  }
   options={$conversions}
   description={conversion_description}
   multiple_select={is_currency_conversion}
 />
 
 <SelectCombobox
-  bind:value={$interval}
+  bind:value={
+    () => $interval,
+    (value: string) => {
+      router.set_search_param("interval", value);
+    }
+  }
   options={INTERVALS}
   description={(o: string) => intervalLabel(getInterval(o))}
 />

--- a/frontend/src/charts/context.ts
+++ b/frontend/src/charts/context.ts
@@ -1,8 +1,9 @@
 import { derived } from "svelte/store";
 
-import { conversion, currencies } from "../stores";
+import { currencies } from "../stores";
 import { currentDateFormat } from "../stores/format";
 import { operating_currency } from "../stores/options";
+import { conversion } from "../stores/url";
 
 /** Context data for parsing and rendering of the charts. */
 export interface ChartContext {

--- a/frontend/src/document-upload.ts
+++ b/frontend/src/document-upload.ts
@@ -18,10 +18,7 @@ import { notify, notify_err } from "./notifications";
  * We want to allow a drop if the dragged thing is either a file that could be
  * dragged from a file manager or a URL (as dragged from a document link in Fava).
  */
-function dragover(event: Event, closestTarget: Element): void {
-  if (!(event instanceof DragEvent)) {
-    return;
-  }
+function dragover(event: DragEvent, closestTarget: Element): void {
   const types = event.dataTransfer?.types ?? [];
   if (types.includes("Files") || types.includes("text/uri-list")) {
     closestTarget.classList.add("dragover");
@@ -31,10 +28,7 @@ function dragover(event: Event, closestTarget: Element): void {
 delegate(document, "dragenter", ".droptarget", dragover);
 delegate(document, "dragover", ".droptarget", dragover);
 
-function dragleave(event: Event, closestTarget: Element): void {
-  if (!(event instanceof DragEvent)) {
-    return;
-  }
+function dragleave(event: DragEvent, closestTarget: Element): void {
   closestTarget.classList.remove("dragover");
   event.preventDefault();
 }
@@ -50,10 +44,7 @@ interface DroppedFile {
 }
 export const files: Writable<DroppedFile[]> = writable([]);
 
-function drop(event: Event, target: Element): void {
-  if (!(event instanceof DragEvent)) {
-    return;
-  }
+function drop(event: DragEvent, target: Element): void {
   target.classList.remove("dragover");
   event.preventDefault();
   event.stopPropagation();

--- a/frontend/src/editor/SliceEditor.svelte
+++ b/frontend/src/editor/SliceEditor.svelte
@@ -5,9 +5,8 @@
   import { initBeancountEditor } from "../codemirror/setup";
   import { _ } from "../i18n";
   import { notify_err } from "../notifications";
-  import router from "../router";
+  import { router } from "../router";
   import { reloadAfterSavingEntrySlice } from "../stores/editor";
-  import { closeOverlay } from "../stores/url";
   import DeleteButton from "./DeleteButton.svelte";
   import SaveButton from "./SaveButton.svelte";
 
@@ -43,7 +42,7 @@
       if ($reloadAfterSavingEntrySlice) {
         router.reload();
       }
-      closeOverlay();
+      router.close_overlay();
     } catch (error) {
       notify_err(error, (err) => `Saving failed: ${err.message}`);
     } finally {
@@ -59,7 +58,7 @@
       if ($reloadAfterSavingEntrySlice) {
         router.reload();
       }
-      closeOverlay();
+      router.close_overlay();
     } catch (error) {
       notify_err(error, (err) => `Deleting failed: ${err.message}`);
     } finally {

--- a/frontend/src/extensions.ts
+++ b/frontend/src/extensions.ts
@@ -149,7 +149,7 @@ export function handleExtensionPageLoad(): void {
       })
       .catch(log_error);
   }
-  const path = getUrlPath(window.location) ?? "";
+  const path = getUrlPath(window.location).unwrap_or("");
   if (path.startsWith("extension/")) {
     for (const { name } of exts) {
       if (path.startsWith(`extension/${name}`)) {

--- a/frontend/src/helpers.ts
+++ b/frontend/src/helpers.ts
@@ -1,5 +1,7 @@
 import { derived, get as store_get } from "svelte/store";
 
+import type { Result } from "./lib/result";
+import { err, ok } from "./lib/result";
 import { base_url } from "./stores";
 import { use_external_editor } from "./stores/fava_options";
 import { syncedSearchParams } from "./stores/url";
@@ -9,11 +11,12 @@ import { syncedSearchParams } from "./stores/url";
  */
 export function getUrlPath(
   url: Pick<URL | Location, "pathname">,
-): string | null {
+): Result<string, string> {
+  const { pathname } = url;
   const $base_url = store_get(base_url);
-  return $base_url && url.pathname.startsWith($base_url)
-    ? decodeURI(url.pathname.slice($base_url.length))
-    : null;
+  return $base_url && pathname.startsWith($base_url)
+    ? ok(decodeURI(pathname.slice($base_url.length)))
+    : err(`Path '${pathname}' not relative to base url '${$base_url}'.`);
 }
 
 /**

--- a/frontend/src/journal/index.ts
+++ b/frontend/src/journal/index.ts
@@ -1,7 +1,9 @@
 import { mount, unmount } from "svelte";
+import { get as store_get } from "svelte/store";
 
 import { delegate } from "../lib/events";
 import { notify_err } from "../notifications";
+import { router } from "../router";
 import { type SortableJournal, sortableJournal } from "../sort";
 import { fql_filter } from "../stores/filters";
 import { journalShow } from "../stores/journal";
@@ -19,8 +21,10 @@ export function escape_for_regex(value: string): string {
  * as a regex must be escaped.
  */
 function addFilter(value: string): void {
-  fql_filter.update((fql_filter_val) =>
-    fql_filter_val ? `${fql_filter_val} ${value}` : value,
+  const $fql_filter = store_get(fql_filter);
+  router.set_search_param(
+    "filter",
+    $fql_filter ? `${$fql_filter} ${value}` : value,
   );
 }
 

--- a/frontend/src/lib/errors.ts
+++ b/frontend/src/lib/errors.ts
@@ -1,7 +1,23 @@
+import { log_error } from "../log";
+
 /** Render the message of an error, with causes if set. */
 export function errorWithCauses(error: Error): string {
   const msg = error.message;
   return error.cause instanceof Error
     ? `${msg}\n  Caused by: ${errorWithCauses(error.cause)}`
     : error.message;
+}
+
+class InvalidErrorType extends Error {
+  constructor() {
+    super("INTERNAL ERROR: error of invalid type.");
+  }
+}
+
+export function assert_is_error(error: unknown): asserts error is Error {
+  if (error instanceof Error) {
+    return;
+  }
+  log_error(error);
+  throw new InvalidErrorType();
 }

--- a/frontend/src/lib/events.ts
+++ b/frontend/src/lib/events.ts
@@ -67,6 +67,18 @@ export class Events<T = string> {
  * @param selector - The DOM selector to match.
  * @param callback - The event listener to execute on a match.
  */
+export function delegate<K extends keyof HTMLElementEventMap>(
+  element: HTMLElement,
+  type: K,
+  selector: string,
+  callback: (e: HTMLElementEventMap[K], c: Element) => void,
+): void;
+export function delegate<K extends keyof DocumentEventMap>(
+  element: Document,
+  type: K,
+  selector: string,
+  callback: (e: DocumentEventMap[K], c: Element) => void,
+): void;
 export function delegate(
   element: HTMLElement | Document,
   type: string,

--- a/frontend/src/lib/fetch.ts
+++ b/frontend/src/lib/fetch.ts
@@ -12,7 +12,7 @@ class FetchError extends Error {}
 
 /** Wrapper around fetch with some default options */
 export async function fetch(
-  input: string,
+  input: string | URL,
   init: RequestInit = {},
 ): Promise<Response> {
   return window.fetch(input, { credentials: "same-origin", ...init });

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -36,9 +36,9 @@ import { getScriptTagValue } from "./lib/dom";
 import { log_error } from "./log";
 import { notify, notify_err } from "./notifications";
 import { frontend_routes } from "./reports/routes";
-import router, { setStoreValuesFromURL, syncStoreValuesToURL } from "./router";
+import { router } from "./router";
 import { initSidebar } from "./sidebar";
-import { has_changes, updatePageTitle } from "./sidebar/page-title";
+import { has_changes } from "./sidebar/page-title";
 import { SortableTable } from "./sort/sortable-table";
 import { errors, ledgerData } from "./stores";
 import { init_color_scheme } from "./stores/color_scheme";
@@ -65,7 +65,6 @@ function defineCustomElements() {
 
 router.on("page-loaded", () => {
   read_mtime();
-  updatePageTitle();
   has_changes.set(false);
   handleExtensionPageLoad();
 });
@@ -81,7 +80,7 @@ function onChanges() {
     .catch((e: unknown) => {
       notify_err(e, (err) => `Error fetching ledger data: ${err.message}`);
     });
-  if (store_get(auto_reload) && !router.hasInteruptHandler) {
+  if (store_get(auto_reload) && !router.has_interrupt_handler) {
     router.reload();
   } else {
     get("errors").then((v) => {
@@ -125,8 +124,6 @@ function init(): void {
   });
 
   router.init(frontend_routes);
-  setStoreValuesFromURL();
-  syncStoreValuesToURL();
   initSidebar();
   initGlobalKeyboardShortcuts();
   defineCustomElements();

--- a/frontend/src/modals/AddEntry.svelte
+++ b/frontend/src/modals/AddEntry.svelte
@@ -4,8 +4,9 @@
   import Entry from "../entry-forms/Entry.svelte";
   import { todayAsString } from "../format";
   import { _ } from "../i18n";
+  import { router } from "../router";
   import { addEntryContinue } from "../stores/editor";
-  import { closeOverlay, urlHash } from "../stores/url";
+  import { hash } from "../stores/url";
   import ModalBase from "./ModalBase.svelte";
 
   /** The entry types which have support adding in the modal. */
@@ -29,11 +30,11 @@
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
     entry = entry.constructor.empty(added_entry_date);
     if (!$addEntryContinue) {
-      closeOverlay();
+      router.close_overlay();
     }
   }
 
-  let shown = $derived($urlHash === "add-transaction");
+  let shown = $derived($hash === "add-transaction");
 </script>
 
 <ModalBase {shown} focus=".payee input">

--- a/frontend/src/modals/Context.svelte
+++ b/frontend/src/modals/Context.svelte
@@ -4,12 +4,12 @@
   import SliceEditor from "../editor/SliceEditor.svelte";
   import { _ } from "../i18n";
   import ReportLoadError from "../reports/ReportLoadError.svelte";
-  import { urlHash } from "../stores/url";
+  import { hash } from "../stores/url";
   import EntryContext from "./EntryContext.svelte";
   import ModalBase from "./ModalBase.svelte";
 
-  let shown = $derived($urlHash.startsWith("context"));
-  let entry_hash = $derived(shown ? $urlHash.slice(8) : "");
+  let shown = $derived($hash.startsWith("context"));
+  let entry_hash = $derived(shown ? $hash.slice(8) : "");
   let content = $derived(shown ? get("context", { entry_hash }) : null);
 </script>
 

--- a/frontend/src/modals/DocumentUpload.svelte
+++ b/frontend/src/modals/DocumentUpload.svelte
@@ -10,7 +10,7 @@
   import AccountInput from "../entry-forms/AccountInput.svelte";
   import { _ } from "../i18n";
   import { notify, notify_err } from "../notifications";
-  import router from "../router";
+  import { router } from "../router";
   import { documents } from "../stores/options";
   import ModalBase from "./ModalBase.svelte";
 

--- a/frontend/src/modals/Export.svelte
+++ b/frontend/src/modals/Export.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
   import { urlFor } from "../helpers";
   import { _ } from "../i18n";
-  import { urlHash } from "../stores/url";
+  import { hash } from "../stores/url";
   import ModalBase from "./ModalBase.svelte";
 
-  let shown = $derived($urlHash === "export");
+  let shown = $derived($hash === "export");
 </script>
 
 <ModalBase {shown}>

--- a/frontend/src/modals/ModalBase.svelte
+++ b/frontend/src/modals/ModalBase.svelte
@@ -9,7 +9,7 @@
   import type { Action } from "svelte/action";
 
   import { attemptFocus, getFocusableElements } from "../lib/focus";
-  import { closeOverlay } from "../stores/url";
+  import { router } from "../router";
 
   interface Props {
     shown: boolean;
@@ -18,7 +18,12 @@
     children: Snippet;
   }
 
-  let { shown, focus, closeHandler = closeOverlay, children }: Props = $props();
+  let {
+    shown,
+    focus,
+    closeHandler = router.close_overlay,
+    children,
+  }: Props = $props();
 
   /**
    * A Svelte action to handle focus within a modal.

--- a/frontend/src/reports/accounts/AccountReport.svelte
+++ b/frontend/src/reports/accounts/AccountReport.svelte
@@ -6,7 +6,7 @@
   import { _ } from "../../i18n";
   import { is_non_empty } from "../../lib/array";
   import { intervalLabel } from "../../lib/interval";
-  import { interval } from "../../stores";
+  import { interval } from "../../stores/url";
   import IntervalTreeTable from "../../tree-table/IntervalTreeTable.svelte";
   import type { AccountReportProps } from ".";
 

--- a/frontend/src/reports/accounts/index.ts
+++ b/frontend/src/reports/accounts/index.ts
@@ -25,7 +25,7 @@ export const account_report = new Route<AccountReportProps>(
   "account",
   AccountReport,
   async (url) => {
-    const [, account = ""] = getUrlPath(url)?.split("/") ?? [];
+    const [, account = ""] = getUrlPath(url).unwrap().split("/");
     const report_type = to_report_type(url.searchParams.get("r"));
     const res = await get("account_report", {
       ...getURLFilters(url),
@@ -34,11 +34,8 @@ export const account_report = new Route<AccountReportProps>(
     });
     return { ...res, account, report_type };
   },
-  (route) => {
-    if (route.url) {
-      const [, account] = getUrlPath(route.url)?.split("/") ?? [];
-      return `account:${account ?? "ERROR"}`;
-    }
-    throw new Error("Internal error: Expected route to have URL.");
+  (url) => {
+    const [, account] = getUrlPath(url).unwrap().split("/");
+    return `account:${account ?? "ERROR"}`;
   },
 );

--- a/frontend/src/reports/documents/Documents.svelte
+++ b/frontend/src/reports/documents/Documents.svelte
@@ -8,7 +8,7 @@
   import { basename } from "../../lib/paths";
   import { stratify } from "../../lib/tree";
   import ModalBase from "../../modals/ModalBase.svelte";
-  import router from "../../router";
+  import { router } from "../../router";
   import type { DocumentsReportProps } from ".";
   import Accounts from "./Accounts.svelte";
   import DocumentPreview from "./DocumentPreview.svelte";

--- a/frontend/src/reports/editor/Editor.svelte
+++ b/frontend/src/reports/editor/Editor.svelte
@@ -12,7 +12,7 @@
   import SaveButton from "../../editor/SaveButton.svelte";
   import { log_error } from "../../log";
   import { notify_err } from "../../notifications";
-  import router from "../../router";
+  import { router } from "../../router";
   import { errors } from "../../stores";
   import { insert_entry } from "../../stores/fava_options";
   import type { EditorReportProps } from ".";
@@ -116,7 +116,7 @@
       ? "There are unsaved changes. Are you sure you want to leave?"
       : null;
 
-  onMount(() => router.addInteruptHandler(checkEditorChanges));
+  onMount(() => router.add_interrupt_handler(checkEditorChanges));
 </script>
 
 <form

--- a/frontend/src/reports/editor/EditorMenu.svelte
+++ b/frontend/src/reports/editor/EditorMenu.svelte
@@ -9,7 +9,7 @@
   import { urlFor } from "../../helpers";
   import { _ } from "../../i18n";
   import { modKey } from "../../keyboard-shortcuts";
-  import router from "../../router";
+  import { router } from "../../router";
   import { insert_entry } from "../../stores/fava_options";
   import { sources } from "../../stores/options";
   import AppMenu from "./AppMenu.svelte";

--- a/frontend/src/reports/holdings/index.ts
+++ b/frontend/src/reports/holdings/index.ts
@@ -77,7 +77,7 @@ export const holdings = new Route<HoldingsReportProps>(
   "holdings",
   Holdings,
   async (url) => {
-    const [, key = ""] = getUrlPath(url)?.split("/") ?? [];
+    const [, key = ""] = getUrlPath(url).unwrap().split("/");
     const aggregation_key = to_report_type(key);
     const query_string = QUERIES[aggregation_key];
     const query_result_table = await get("query", {

--- a/frontend/src/reports/import/Import.svelte
+++ b/frontend/src/reports/import/Import.svelte
@@ -7,7 +7,7 @@
   import { urlFor } from "../../helpers";
   import { _ } from "../../i18n";
   import { notify, notify_err } from "../../notifications";
-  import router from "../../router";
+  import { router } from "../../router";
   import { import_config } from "../../stores/fava_options";
   import DocumentPreview from "../documents/DocumentPreview.svelte";
   import type { ImportReportProps } from ".";
@@ -50,7 +50,7 @@
       ? "There are unfinished imports, are you sure you want to continue?"
       : null;
 
-  onMount(() => router.addInteruptHandler(preventNavigation));
+  onMount(() => router.add_interrupt_handler(preventNavigation));
 
   /**
    * Move the given file to the new file name (and remove from the list).

--- a/frontend/src/reports/import/ImportFileUpload.svelte
+++ b/frontend/src/reports/import/ImportFileUpload.svelte
@@ -2,7 +2,7 @@
   import { put } from "../../api";
   import { _ } from "../../i18n";
   import { notify, notify_err } from "../../notifications";
-  import router from "../../router";
+  import { router } from "../../router";
 
   let input: HTMLInputElement | undefined = $state.raw();
 

--- a/frontend/src/reports/query/Query.svelte
+++ b/frontend/src/reports/query/Query.svelte
@@ -4,7 +4,7 @@
   import { get } from "../../api";
   import { err, ok, type Result } from "../../lib/result";
   import { log_error } from "../../log";
-  import router from "../../router";
+  import { router } from "../../router";
   import { filter_params } from "../../stores/filters";
   import { query_shell_history } from "../../stores/query";
   import { searchParams } from "../../stores/url";

--- a/frontend/src/router.ts
+++ b/frontend/src/router.ts
@@ -5,33 +5,59 @@
  * load the content of the page and replace the <article> contents with them.
  */
 
-import type { Readable, Writable } from "svelte/store";
+import type { Readable } from "svelte/store";
 import { writable } from "svelte/store";
 
 import { getUrlPath } from "./helpers";
+import { assert_is_error } from "./lib/errors";
 import { delegate, Events } from "./lib/events";
-import { fetch, handleText } from "./lib/fetch";
-import { DEFAULT_INTERVAL, getInterval } from "./lib/interval";
 import { log_error } from "./log";
-import { notify_err } from "./notifications";
-import type { FrontendRoute } from "./reports/route";
+import {
+  backend_route,
+  type BaseRoute,
+  ErrorRoute,
+  type FrontendRoute,
+} from "./reports/route";
 import { raw_page_title } from "./sidebar/page-title";
-import { conversion, interval } from "./stores";
-import { showCharts } from "./stores/chart";
-import { account_filter, fql_filter, time_filter } from "./stores/filters";
-import { pathname, search, urlHash } from "./stores/url";
+import { current_url } from "./stores/url";
+
+/** Whether this is a left-button click without any modifier keys pressed. */
+const is_normal_click = (event: MouseEvent) =>
+  event.button === 0 &&
+  !event.altKey &&
+  !event.ctrlKey &&
+  !event.metaKey &&
+  !event.shiftKey;
+
+/** Whether this is an external link or has the `data-remote` attribute */
+const is_external_link = (link: HTMLAnchorElement | SVGAElement) =>
+  link.hasAttribute("data-remote") ||
+  (link instanceof HTMLAnchorElement &&
+    (link.host !== window.location.host || !link.protocol.startsWith("http")));
 
 /**
- * Set a store's inital value from the URL.
+ * The various query parameters used in Fava.
  */
-export function setStoreValuesFromURL(): void {
-  const params = new URL(window.location.href).searchParams;
-  account_filter.set(params.get("account") ?? "");
-  fql_filter.set(params.get("filter") ?? "");
-  time_filter.set(params.get("time") ?? "");
-  interval.set(getInterval(params.get("interval")));
-  conversion.set(params.get("conversion") ?? "at_cost");
-  showCharts.set(params.get("charts") !== "false");
+type FavaQueryParameters =
+  | "account"
+  | "charts"
+  | "conversion"
+  | "filter"
+  | "interval"
+  | "query_string"
+  | "time";
+
+/** Set a query parameter, mutating the URL in place. */
+export function set_query_param(
+  url: URL,
+  key: FavaQueryParameters,
+  value: string,
+): void {
+  if (value) {
+    url.searchParams.set(key, value);
+  } else {
+    url.searchParams.delete(key);
+  }
 }
 
 const is_loading_internal = writable(false);
@@ -39,23 +65,17 @@ const is_loading_internal = writable(false);
 export const is_loading: Readable<boolean> = is_loading_internal;
 
 export class Router extends Events<"page-loaded"> {
-  /** The URL hash. */
-  private hash: string;
-
-  /** The URL pathname. */
-  private pathname: string;
-
-  /** The URL search string. */
-  private search: string;
+  /** The current URL - internal, should always be accessed by getter/setter. */
+  #current: URL;
 
   /** The <article> element. */
-  private article: HTMLElement;
+  #article: HTMLElement;
 
   /** The frontend rendered routes. */
-  private frontend_routes?: FrontendRoute[];
+  #frontend_routes: FrontendRoute[] = [];
 
-  /** A possibly frontend rendered component. */
-  private frontend_route?: FrontendRoute | undefined;
+  /** The currently rendered route. */
+  #current_route?: BaseRoute | undefined;
 
   /**
    * Function to intercept navigation, e.g., when there are unsaved changes.
@@ -63,7 +83,7 @@ export class Router extends Events<"page-loaded"> {
    * If they return a string, that is displayed to the user in an alert to
    * confirm navigation.
    */
-  private interruptHandlers: Set<() => string | null>;
+  #interrupt_handlers = new Set<() => string | null>();
 
   constructor() {
     super();
@@ -72,32 +92,42 @@ export class Router extends Events<"page-loaded"> {
     if (!article) {
       throw new Error("<article> element is missing from markup");
     }
-    this.article = article;
+    this.#article = article;
 
-    this.hash = window.location.hash;
-    this.pathname = window.location.pathname;
-    this.search = window.location.search;
+    this.#current = new URL(window.location.href);
+    current_url.set(this.#current);
+  }
 
-    this.interruptHandlers = new Set();
+  /** The current URL. */
+  get current(): URL {
+    return this.#current;
+  }
+
+  /** Set the current URL. */
+  private set current(url: URL) {
+    if (this.#current.href !== url.href) {
+      this.#current = url;
+      current_url.set(url);
+    }
   }
 
   /**
    * Whether an interrupt handler is active like on the editor or import report.
    * Avoid auto-reloading in that case.
    */
-  get hasInteruptHandler(): boolean {
-    return this.interruptHandlers.size > 0;
+  get has_interrupt_handler(): boolean {
+    return this.#interrupt_handlers.size > 0;
   }
 
   /**
    * Add an interrupt handler. Returns a function that removes it.
-   * This can be used directly in a svelte onMount hook.
+   * This can be used directly in a Svelte onMount hook.
    */
-  addInteruptHandler(handler: () => string | null): () => void {
-    this.interruptHandlers.add(handler);
+  add_interrupt_handler(handler: () => string | null): () => void {
+    this.#interrupt_handlers.add(handler);
 
     return () => {
-      this.interruptHandlers.delete(handler);
+      this.#interrupt_handlers.delete(handler);
     };
   }
 
@@ -105,166 +135,59 @@ export class Router extends Events<"page-loaded"> {
    * Check whether any of the registered interruptHandlers wants to stop
    * navigation.
    */
-  private shouldInterrupt(): string | null {
-    for (const handler of this.interruptHandlers) {
-      const ret = handler();
-      if (ret != null) {
-        return ret;
+  #should_interrupt(): string | null {
+    for (const handler of this.#interrupt_handlers) {
+      const leave_message = handler();
+      if (leave_message != null) {
+        return leave_message;
       }
     }
     return null;
   }
 
-  private async frontendRender(url: URL): Promise<void> {
-    const report = getUrlPath(url);
-    const route = this.frontend_routes?.find(
-      (r) => report?.startsWith(`${r.report}/`) === true,
-    );
-    if (route) {
-      is_loading_internal.set(true);
-      try {
-        await route.render(this.article, url, this.frontend_route);
-      } finally {
-        is_loading_internal.set(false);
-      }
-      raw_page_title.set(route.title);
-    } else {
-      this.frontend_route?.destroy();
-    }
-    this.frontend_route = route;
-  }
-
   /**
-   * This should be called once when the page has been loaded. Initializes the
-   * router and takes over clicking on links.
+   * Render the route for the given URL.
    */
-  init(frontend_routes: FrontendRoute[]): void {
-    this.frontend_routes = frontend_routes;
-    urlHash.set(window.location.hash.slice(1));
-    this.updateState();
+  async #render_route(url: URL, before_render?: () => void): Promise<void> {
+    const previous = this.#current_route;
+    const relative_path = getUrlPath(url).unwrap();
+    const report = relative_path.slice(0, relative_path.indexOf("/"));
+    const route =
+      this.#frontend_routes.find((r) => r.report === report) ?? backend_route;
 
-    this.frontendRender(new URL(window.location.href)).catch(log_error);
-
-    window.addEventListener("beforeunload", (event) => {
-      const leaveMessage = this.shouldInterrupt();
-      if (leaveMessage != null) {
-        event.preventDefault();
-      }
-    });
-
-    window.addEventListener("popstate", () => {
-      urlHash.set(window.location.hash.slice(1));
-      if (
-        window.location.hash !== this.hash &&
-        window.location.pathname === this.pathname &&
-        window.location.search === this.search
-      ) {
-        this.updateState();
-      } else if (
-        window.location.pathname !== this.pathname ||
-        window.location.search !== this.search
-      ) {
-        this.loadURL(window.location.href, false).catch(log_error);
-        setStoreValuesFromURL();
-      }
-    });
-
-    this.takeOverLinks();
-  }
-
-  /**
-   * Go to URL. If load is `true`, load the page at URL, otherwise only update
-   * the current state.
-   */
-  navigate(url: string, load = true): void {
-    if (load) {
-      this.loadURL(url).catch(log_error);
-    } else {
-      window.history.pushState(null, "", url);
-      this.updateState();
-    }
-  }
-
-  /**
-   * Set the URL parameter and push a history state for it if changed.
-   */
-  set_search_param(key: string, value: string): void {
-    const url = new URL(window.location.href);
-    const current_value = url.searchParams.get(key) ?? "";
-    if (value !== current_value) {
-      if (value) {
-        url.searchParams.set(key, value);
-      } else {
-        url.searchParams.delete(key);
-      }
-      window.history.pushState(null, "", url);
-      this.updateState();
-    }
-  }
-
-  /*
-   * Replace <article> contents with the page at `url`.
-   *
-   * If `historyState` is false, do not create a history state and do not
-   * scroll to top.
-   */
-  private async loadURL(url: string, historyState = true): Promise<void> {
-    const leaveMessage = this.shouldInterrupt();
-    if (leaveMessage != null) {
-      if (!window.confirm(leaveMessage)) {
-        return;
-      }
-    }
-
-    const getUrl = new URL(url, window.location.href);
-
-    await this.frontendRender(getUrl);
-
+    is_loading_internal.set(true);
     try {
-      if (!this.frontend_route) {
-        getUrl.searchParams.set("partial", "true");
-        is_loading_internal.set(true);
-        const content = await fetch(getUrl.toString()).then(handleText);
-        if (historyState) {
-          window.history.pushState(null, "", url);
-          window.scroll(0, 0);
-        }
-        this.updateState();
-        this.article.innerHTML = content;
-      } else {
-        if (historyState) {
-          window.history.pushState(null, "", url);
-          window.scroll(0, 0);
-        }
-        this.updateState();
-      }
-      this.trigger("page-loaded");
-      setStoreValuesFromURL();
-      const hash = window.location.hash.slice(1);
-      urlHash.set(hash);
-      if (hash) {
-        document.getElementById(hash)?.scrollIntoView();
-      }
-    } catch (error) {
-      notify_err(error, (e) => `Loading ${url} failed: ${e.message}`);
-    } finally {
-      is_loading_internal.set(false);
+      await route.render(this.#article, url, previous, before_render);
+      this.#current_route = route;
+    } catch (error: unknown) {
+      assert_is_error(error);
+      const error_route = new ErrorRoute(error);
+      error_route.render(this.#article, url, previous, before_render);
+      this.#current_route = error_route;
     }
+    raw_page_title.set(this.#current_route.get_title(url));
+    is_loading_internal.set(false);
   }
 
-  /*
-   * Update the routers state.
-   *
-   * The routers state is used to distinguish between the user navigating the
-   * browser history or the hash changing.
-   */
-  private updateState(): void {
-    this.hash = window.location.hash;
-    this.pathname = window.location.pathname;
-    this.search = window.location.search;
-    pathname.set(this.pathname);
-    search.set(this.search);
-  }
+  #beforeunload = () => (event: BeforeUnloadEvent) => {
+    const leave_message = this.#should_interrupt();
+    if (leave_message != null) {
+      event.preventDefault();
+    }
+  };
+
+  #popstate = (): void => {
+    const target = new URL(window.location.href);
+    const { current } = this;
+    if (
+      target.pathname !== current.pathname ||
+      target.search !== current.search
+    ) {
+      this.#load_url(target).catch(log_error);
+    } else {
+      this.current = target;
+    }
+  };
 
   /*
    * Intercept all clicks on links (<a>) and .navigate() to the link instead.
@@ -275,90 +198,134 @@ export class Router extends Events<"page-loaded"> {
    *  - the link starts with a hash '#', or
    *  - the link has a `data-remote` attribute.
    */
-  private takeOverLinks(): void {
-    const is_normal_click = (event: MouseEvent) =>
-      event.button === 0 &&
-      !event.altKey &&
-      !event.ctrlKey &&
-      !event.metaKey &&
-      !event.shiftKey;
+  #intercept_link_click = (event: PointerEvent, link: Element): void => {
+    if (!(link instanceof HTMLAnchorElement || link instanceof SVGAElement)) {
+      return;
+    }
+    if (!is_normal_click(event)) {
+      return;
+    }
+    if (event.defaultPrevented) {
+      return;
+    }
+    if (link.getAttribute("href")?.charAt(0) === "#") {
+      return;
+    }
+    if (is_external_link(link)) {
+      return;
+    }
 
-    const is_external_link = (link: HTMLAnchorElement | SVGAElement) =>
-      link.hasAttribute("data-remote") ||
-      (link instanceof HTMLAnchorElement &&
-        (link.host !== window.location.host ||
-          !link.protocol.startsWith("http")));
+    event.preventDefault();
+    const href =
+      link instanceof HTMLAnchorElement ? link.href : link.href.baseVal;
 
-    delegate(document, "click", "a", (event, link) => {
-      if (
-        !(event instanceof MouseEvent) ||
-        !(link instanceof HTMLAnchorElement || link instanceof SVGAElement)
-      ) {
-        return;
-      }
-      if (!is_normal_click(event)) {
-        return;
-      }
-      if (event.defaultPrevented) {
-        return;
-      }
-      if (link.getAttribute("href")?.charAt(0) === "#") {
-        return;
-      }
-      if (is_external_link(link)) {
-        return;
-      }
+    this.navigate(href);
+  };
 
-      event.preventDefault();
-      const href =
-        link instanceof HTMLAnchorElement ? link.href : link.href.baseVal;
+  /**
+   * This should be called once when the page has been loaded. Initializes the
+   * router and takes over clicking on links.
+   */
+  init(frontend_routes: FrontendRoute[]): void {
+    this.#frontend_routes = frontend_routes;
+    this.#render_route(this.current).catch(log_error);
 
-      this.navigate(href);
-    });
+    window.addEventListener("beforeunload", this.#beforeunload);
+    window.addEventListener("popstate", this.#popstate);
+    delegate(document, "click", "a", this.#intercept_link_click);
   }
+
+  /**
+   * Go to URL.
+   *
+   * If load is `true`, load the page at URL, otherwise only push
+   * a new history item update and update the current url.
+   */
+  navigate(url: string | URL, load = true): void {
+    const target =
+      url instanceof URL ? url : new URL(url, window.location.href);
+    if (load) {
+      this.#load_url(target).catch(log_error);
+    } else {
+      window.history.pushState(null, "", target);
+      this.current = target;
+    }
+  }
+
+  /**
+   * Replace `<article>` contents with the page at `url`.
+   *
+   * Might render in the frontend or load the whole page contents.
+   */
+  async #load_url(url: URL): Promise<void> {
+    const leave_message = this.#should_interrupt();
+    if (leave_message != null && !window.confirm(leave_message)) {
+      return;
+    }
+
+    const is_reload = url.href === this.current.href;
+    const before_render = is_reload
+      ? undefined
+      : () => {
+          // Push state and set current URL after loading the data but before rendering.
+          this.#article.scroll(0, 0);
+          if (url.href !== window.location.href) {
+            window.history.pushState(null, "", url);
+          }
+          this.current = url;
+        };
+    await this.#render_route(url, before_render);
+
+    this.trigger("page-loaded");
+    const hash = this.current.hash.slice(1);
+    if (hash) {
+      document.getElementById(hash)?.scrollIntoView();
+    }
+  }
+
+  /**
+   * Set the URL parameter and push a history state for it if changed.
+   *
+   * For `charts` and `query_string`, this will not load the target URL.
+   */
+  set_search_param(key: "charts", value: "false" | ""): void;
+  set_search_param(
+    key:
+      | "account"
+      | "conversion"
+      | "filter"
+      | "interval"
+      | "query_string"
+      | "time",
+    value: string,
+  ): void;
+  set_search_param(key: FavaQueryParameters, value: string): void {
+    const target = new URL(this.current);
+    set_query_param(target, key, value);
+    if (target.href !== this.current.href) {
+      const load = !(key === "charts" || key === "query_string");
+      this.navigate(target, load);
+    }
+  }
+
+  /**
+   * Close the modal overlay.
+   */
+  close_overlay = (): void => {
+    if (this.current.hash) {
+      const target = new URL(this.current);
+      target.hash = "";
+      this.navigate(target, false);
+    }
+  };
 
   /*
    * Reload the page.
    */
-  reload(): void {
-    this.loadURL(window.location.href, false).catch(log_error);
-  }
+  reload = (): void => {
+    this.#load_url(this.current).catch(log_error);
+  };
 }
 
-const router = new Router();
-export default router;
-
-/**
- * Sync a store value to the URL.
- *
- * Update and navigate to the URL on store changes.
- */
-function syncToURL<T extends boolean | string>(
-  store: Writable<T>,
-  name: string,
-  defaultValue: T,
-  shouldLoad = true,
-): void {
-  store.subscribe((val: T) => {
-    const newURL = new URL(window.location.href);
-    newURL.searchParams.set(name, val.toString());
-    if (val === "" || val === defaultValue) {
-      newURL.searchParams.delete(name);
-    }
-    if (newURL.href !== window.location.href) {
-      router.navigate(newURL.href, shouldLoad);
-    }
-  });
-}
-
-/**
- * Update URL on store changes.
- */
-export function syncStoreValuesToURL(): void {
-  syncToURL(account_filter, "account", "");
-  syncToURL(fql_filter, "filter", "");
-  syncToURL(time_filter, "time", "");
-  syncToURL(interval, "interval", DEFAULT_INTERVAL);
-  syncToURL(conversion, "conversion", "at_cost");
-  syncToURL(showCharts, "charts", true, false);
-}
+/** The Fava router. */
+export const router = new Router();

--- a/frontend/src/sidebar/AccountSelector.svelte
+++ b/frontend/src/sidebar/AccountSelector.svelte
@@ -2,7 +2,7 @@
   import AutocompleteInput from "../AutocompleteInput.svelte";
   import { urlForAccount } from "../helpers";
   import { _ } from "../i18n";
-  import router from "../router";
+  import { router } from "../router";
   import { accounts } from "../stores";
 
   let value = $state("");

--- a/frontend/src/sidebar/FilterForm.svelte
+++ b/frontend/src/sidebar/FilterForm.svelte
@@ -2,6 +2,7 @@
   import AutocompleteInput from "../AutocompleteInput.svelte";
   import { _ } from "../i18n";
   import { escape_for_regex } from "../journal";
+  import { router, set_query_param } from "../router";
   import { accounts, links, payees, tags, years } from "../stores";
   import { account_filter, fql_filter, time_filter } from "../stores/filters";
 
@@ -42,6 +43,9 @@
     time_filter_value = v;
   });
 
+  /** Set the target we want to navigate to to avoid duplicate navigation. */
+  let target: URL | null = null;
+
   /**
    * Submit the filter form.
    *
@@ -51,9 +55,19 @@
    * it seems to work around a Safari bug, see #809 and #1528.
    */
   function submit() {
-    account_filter.set(account_filter_value);
-    fql_filter.set(fql_filter_value);
-    time_filter.set(time_filter_value);
+    const url = new URL(router.current);
+    set_query_param(url, "account", account_filter_value);
+    set_query_param(url, "filter", fql_filter_value);
+    set_query_param(url, "time", time_filter_value);
+    if (url.href !== router.current.href) {
+      target = url;
+      setTimeout(() => {
+        if (target) {
+          router.navigate(target);
+          target = null;
+        }
+      });
+    }
   }
 </script>
 

--- a/frontend/src/sidebar/Header.svelte
+++ b/frontend/src/sidebar/Header.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { keyboardShortcut } from "../keyboard-shortcuts";
-  import router from "../router";
+  import { router } from "../router";
   import { ledgerData } from "../stores";
   import { ledger_title } from "../stores/options";
   import FilterForm from "./FilterForm.svelte";
@@ -33,7 +33,7 @@
     hidden={!$has_changes}
     class="reload-page"
     use:keyboardShortcut={"r"}
-    onclick={router.reload.bind(router)}
+    onclick={router.reload}
   >
     &#8635;
   </button>

--- a/frontend/src/sidebar/page-title.ts
+++ b/frontend/src/sidebar/page-title.ts
@@ -4,9 +4,6 @@
 
 import { derived, writable } from "svelte/store";
 
-import { getScriptTagValue } from "../lib/dom";
-import { string } from "../lib/validation";
-
 /** The page title, can either be the title itself or `account:{name}` */
 export const raw_page_title = writable("");
 
@@ -30,13 +27,3 @@ export const page_title = derived(
     return { title: $raw_page_title, type: "plain" };
   },
 );
-
-/**
- * Update page (next to our icon) and the html document `<title>`.
- */
-export function updatePageTitle(): void {
-  const v = getScriptTagValue("#page-title", string);
-  if (v.is_ok) {
-    raw_page_title.set(v.value);
-  }
-}

--- a/frontend/src/stores/chart.ts
+++ b/frontend/src/stores/chart.ts
@@ -9,9 +9,6 @@ import { currencies_sorted } from ".";
 import { conversion_currencies } from "./fava_options";
 import { operating_currency } from "./options";
 
-/** Whether the charts should be shown - this applies globally to all charts. */
-export const showCharts = writable(true);
-
 /** This store is used to switch to the same chart (as identified by name) on navigation. */
 export const lastActiveChartName = writable<string | null>(null);
 

--- a/frontend/src/stores/filters.ts
+++ b/frontend/src/stores/filters.ts
@@ -1,11 +1,22 @@
-import { derived, writable } from "svelte/store";
+import { derived } from "svelte/store";
+
+import { searchParams } from "./url";
 
 /** The time filter. */
-export const time_filter = writable("");
+export const time_filter = derived(
+  searchParams,
+  ($searchParams) => $searchParams.get("time") ?? "",
+);
 /** The account filter. */
-export const account_filter = writable("");
+export const account_filter = derived(
+  searchParams,
+  ($searchParams) => $searchParams.get("account") ?? "",
+);
 /** The filter with our custom query syntax. */
-export const fql_filter = writable("");
+export const fql_filter = derived(
+  searchParams,
+  ($searchParams) => $searchParams.get("filter") ?? "",
+);
 
 /** The three entry filters that Fava supports. */
 export interface Filters extends Record<string, string | undefined> {

--- a/frontend/src/stores/format.ts
+++ b/frontend/src/stores/format.ts
@@ -10,8 +10,9 @@ import {
   replaceNumbers,
   timeFilterDateFormat,
 } from "../format";
-import { incognito, interval, precisions } from ".";
+import { incognito, precisions } from ".";
 import { locale } from "./fava_options";
+import { interval } from "./url";
 
 const short_format = format(".3s");
 

--- a/frontend/src/stores/index.ts
+++ b/frontend/src/stores/index.ts
@@ -2,13 +2,7 @@ import { derived, type Readable, writable } from "svelte/store";
 
 import type { BeancountError, LedgerData } from "../api/validators";
 import { get_internal_accounts } from "../lib/account";
-import { DEFAULT_INTERVAL } from "../lib/interval";
 import { derived_array } from "../lib/store";
-
-/** The current conversion used for reports. */
-export const conversion = writable("");
-/** The current interval used for reports. */
-export const interval = writable(DEFAULT_INTERVAL);
 
 /** The Beancount errors. */
 export const errors = writable<readonly BeancountError[]>([]);

--- a/frontend/src/tree-table/tree-table-custom-element.ts
+++ b/frontend/src/tree-table/tree-table-custom-element.ts
@@ -20,9 +20,6 @@ export class TreeTableCustomElement extends HTMLElement {
     });
 
     delegate(this, "click", "span.has-children", (event) => {
-      if (!(event instanceof MouseEvent)) {
-        return;
-      }
       const { target } = event;
       if (
         !(target instanceof HTMLElement) ||

--- a/frontend/test/helpers.ts
+++ b/frontend/test/helpers.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from "node:url";
 import { ledgerDataValidator } from "../src/api/validators";
 import { parseJSON } from "../src/lib/json";
 import { ledgerData } from "../src/stores/index";
+import { current_url } from "../src/stores/url";
 
 /** Load the Python test snapshot output with the given name and parse as JSON. */
 export async function loadJSONSnapshot(
@@ -35,6 +36,9 @@ export async function initialiseLedgerData(): Promise<void> {
     );
     const res = ledgerDataValidator(data).unwrap();
     ledgerData.set(res);
+    current_url.set(
+      new URL("http://localhost:5000/example-beancount-file/income_statement/"),
+    );
     loaded = true;
   } catch (error: unknown) {
     console.error(error);

--- a/frontend/test/urls.test.ts
+++ b/frontend/test/urls.test.ts
@@ -3,6 +3,7 @@ import { test } from "uvu";
 import * as assert from "uvu/assert";
 
 import { getUrlPath, urlForAccount, urlForInternal } from "../src/helpers";
+import { ok } from "../src/lib/result";
 import { base_url } from "../src/stores/index";
 import { initialiseLedgerData } from "./helpers";
 
@@ -28,12 +29,12 @@ test("get path for account", () => {
 test("extract relative path from URL", () => {
   const $base_url = store_get(base_url);
   assert.equal($base_url, "/long-example/");
-  assert.equal(getUrlPath({ pathname: "/example/asdf" }), null);
-  assert.equal(getUrlPath({ pathname: "/long-example/asdf" }), "asdf");
+  assert.ok(getUrlPath({ pathname: "/example/asdf" }).is_err);
+  assert.equal(getUrlPath({ pathname: "/long-example/asdf" }), ok("asdf"));
   assert.equal(encodeURI("Ä€/asdf"), "%C3%84%E2%82%AC/asdf");
   assert.equal(
     getUrlPath({ pathname: "/long-example/%C3%84%E2%82%AC/asdf" }),
-    "Ä€/asdf",
+    ok("Ä€/asdf"),
   );
 });
 


### PR DESCRIPTION
This reduces the amount of syncing between different stores.

Also, move unmounting of previous page and updating of URL store to
after loading the next page to minimise the time a blank page might be
shown.

Also improve error handling, e.g. in case of network error.

<!--
Hi, thank you for opening a PR!

Please ensure that your change passes tests and the various linters by running
`make test` and `make lint`. If testable, your changes should be covered by
unit tests.

Explain your changes below and link to related issues.
-->
