### PR TITLE
frontend: refactor api to use individual functions

### DIFF
--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -1,15 +1,34 @@
 import { get as store_get } from "svelte/store";
 
-import type { Entry } from "../entries/index.ts";
+import {
+  Document,
+  type Entry,
+  entryValidator,
+  Event,
+  Transaction,
+} from "../entries/index.ts";
 import { urlForRaw } from "../helpers.ts";
+import type { NonEmptyArray } from "../lib/array.ts";
 import { fetchJSON } from "../lib/fetch.ts";
-import type { ValidationT } from "../lib/validation.ts";
-import { string } from "../lib/validation.ts";
+import type { Validator } from "../lib/validation.ts";
+import { array, boolean, string } from "../lib/validation.ts";
 import { notify, notify_err } from "../notifications.ts";
+import { query_validator } from "../reports/query/query_table.ts";
 import { router } from "../router.ts";
 import type { Filters, FiltersConversionInterval } from "../stores/filters.ts";
-import type { GetAPIValidators, SourceFile } from "./validators.ts";
-import { getAPIValidators } from "./validators.ts";
+import {
+  account_report_validator,
+  commodities_validator,
+  context_validator,
+  error_validator,
+  importable_files_validator,
+  ledgerDataValidator,
+  options_validator,
+  source_validator,
+  type SourceFile,
+  statistics_validator,
+  tree_report_validator,
+} from "./validators.ts";
 
 class InvalidResponseDataError extends Error {
   constructor(cause: Error) {
@@ -18,116 +37,244 @@ class InvalidResponseDataError extends Error {
   }
 }
 
-/** Required arguments for the various PUT API endpoints. */
-interface PutAPIInputs {
-  add_document: FormData;
-  upload_import_file: FormData;
-  add_entries: { entries: Entry[] };
-  attach_document: { filename: string; entry_hash: string };
-  format_source: { source: string };
-  source: SourceFile;
-  source_slice: { entry_hash: string; source: string; sha256sum: string };
+// This module contains wrapper functions (get_*, delete_*, put_* functions
+// below) to call the API endpoints defined in json_api.py.
+//
+// For each HTTP endpoint, a function with types for the parameters and
+// a validator for the response should be added to this module.
+type DeleteEndpoint = "document" | "source_slice";
+type GetEndpoint =
+  | "balance_sheet"
+  | "account_report"
+  | "changed"
+  | "commodities"
+  | "context"
+  | "documents"
+  | "errors"
+  | "events"
+  | "extract"
+  | "imports"
+  | "income_statement"
+  | "trial_balance"
+  | "ledger_data"
+  | "options"
+  | "payee_accounts"
+  | "payee_transaction"
+  | "narration_transaction"
+  | "narrations"
+  | "query"
+  | "source"
+  | "statistics";
+type PutEndpoint =
+  | "add_document"
+  | "add_entries"
+  | "attach_document"
+  | "format_source"
+  | "move"
+  | "source"
+  | "source_slice"
+  | "upload_import_file";
+
+type ApiEndpoint = DeleteEndpoint | GetEndpoint | PutEndpoint;
+
+/**
+ * Define a function to call the endpoint with the required parameters.
+ */
+// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters
+function define_endpoint<T extends Record<string, string>, R>(
+  endpoint: ApiEndpoint,
+  validator: Validator<R>,
+  method: "DELETE" | "GET" | "PUT" = "GET",
+): (params: T) => Promise<R> {
+  return async (params) => {
+    const $urlForRaw = store_get(urlForRaw);
+    const url = $urlForRaw(`api/${endpoint}`, params);
+    const json = await fetchJSON(url, { method });
+    const res = validator(json);
+    if (res.is_ok) {
+      return res.value;
+    }
+    throw new InvalidResponseDataError(res.error);
+  };
 }
 
 /**
- * PUT to an API endpoint and convert the returned JSON data to an object.
- * @param endpoint - the endpoint to fetch
- * @param body - either a FormData instance or an object that will be converted
- *               to JSON.
- * @returns the response message string
+ * Define a function to call an endpoint without parameters.
  */
-export async function put<T extends keyof PutAPIInputs>(
-  endpoint: T,
-  body: PutAPIInputs[T],
-): Promise<string> {
-  const opts =
-    body instanceof FormData
-      ? { body }
-      : {
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(body),
-        };
-  const $urlForRaw = store_get(urlForRaw);
-  const url = $urlForRaw(`api/${endpoint}`);
-  const json = await fetchJSON(url, { method: "PUT", ...opts });
-  const res = string(json);
-  if (res.is_ok) {
-    return res.value;
-  }
-  throw new InvalidResponseDataError(res.error);
-}
-
-interface GetAPIParams {
-  balance_sheet: FiltersConversionInterval;
-  account_report: FiltersConversionInterval & { a: string; r: string };
-  changed: undefined;
-  commodities: Filters;
-  context: { entry_hash: string };
-  documents: Filters;
-  errors: undefined;
-  events: Filters;
-  extract: { filename: string; importer: string };
-  imports: undefined;
-  income_statement: FiltersConversionInterval;
-  trial_balance: FiltersConversionInterval;
-  ledger_data: undefined;
-  move: { filename: string; account: string; new_name: string };
-  options: undefined;
-  payee_accounts: { payee: string };
-  payee_transaction: { payee: string };
-  narration_transaction: { narration: string };
-  narrations: undefined;
-  query: Filters & { query_string: string };
-  source: { filename: string };
-  statistics: Filters;
+function define_paramless_endpoint<R>(
+  endpoint: ApiEndpoint,
+  validator: Validator<R>,
+): () => Promise<R> {
+  return async () => {
+    const $urlForRaw = store_get(urlForRaw);
+    const url = $urlForRaw(`api/${endpoint}`);
+    const json = await fetchJSON(url, { method: "GET" });
+    const res = validator(json);
+    if (res.is_ok) {
+      return res.value;
+    }
+    throw new InvalidResponseDataError(res.error);
+  };
 }
 
 /**
- * Fetch an API endpoint and convert the JSON data to an object.
- * @param endpoint - the endpoint to fetch
- * @param params - a string to append as params or an object.
- * @returns the validated response returned by the endpoint.
+ * Define a function to call the PUT endpoint with the required typed parameters.
  */
-export async function get<T extends keyof GetAPIParams>(
-  endpoint: T,
-  ...[params]: GetAPIParams[T] extends undefined
-    ? [undefined?, number?]
-    : [GetAPIParams[T], number?]
-): Promise<ValidationT<GetAPIValidators[T]>> {
-  const $urlForRaw = store_get(urlForRaw);
-  const url = $urlForRaw(`api/${endpoint}`, params);
-  const json = await fetchJSON(url);
-  const res = getAPIValidators[endpoint](json);
-  if (res.is_ok) {
-    return res.value as ValidationT<GetAPIValidators[T]>;
-  }
-  throw new InvalidResponseDataError(res.error);
+// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters
+function define_put<T>(endpoint: PutEndpoint): (body: T) => Promise<string> {
+  return async (body) => {
+    const opts: RequestInit =
+      body instanceof FormData
+        ? { body }
+        : {
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(body),
+          };
+    const $urlForRaw = store_get(urlForRaw);
+    const url = $urlForRaw(`api/${endpoint}`);
+    const json = await fetchJSON(url, { method: "PUT", ...opts });
+    const res = string(json);
+    if (res.is_ok) {
+      return res.value;
+    }
+    throw new InvalidResponseDataError(res.error);
+  };
 }
 
-interface DeleteAPIParams {
-  document: { filename: string };
-  source_slice: { entry_hash: string; sha256sum: string };
-}
+// With the use of satisfies and this helper type we can achieve partial type inference
+// on the endpoint definitions below.
+type Api<T> = (params: T) => unknown;
 
-/**
- * Delete an API endpoint and convert the JSON data to an object.
- * @param endpoint - the endpoint to fetch
- * @param params - a string to append as params or an object.
- * @returns the response returned by the endpoint.
- */
-export async function doDelete<T extends keyof DeleteAPIParams>(
-  endpoint: T,
-  params: DeleteAPIParams[T],
-): Promise<string> {
-  const $urlForRaw = store_get(urlForRaw);
-  const url = $urlForRaw(`api/${endpoint}`, params);
-  const json = await fetchJSON(url, { method: "DELETE" });
-  const res = string(json);
-  if (res.is_ok) {
-    return res.value;
-  }
-  throw new InvalidResponseDataError(res.error);
-}
+// DELETE endpoints
+
+const delete_document_raw = define_endpoint(
+  "document",
+  string,
+  "DELETE",
+) satisfies Api<{
+  filename: string;
+}>;
+export const delete_source_slice = define_endpoint(
+  "source_slice",
+  string,
+  "DELETE",
+) satisfies Api<{
+  entry_hash: string;
+  sha256sum: string;
+}>;
+
+// GET endpoints
+
+export const get_account_report = define_endpoint(
+  "account_report",
+  account_report_validator,
+) satisfies Api<FiltersConversionInterval & { a: string; r: string }>;
+export const get_balance_sheet = define_endpoint(
+  "balance_sheet",
+  tree_report_validator,
+) satisfies Api<FiltersConversionInterval>;
+export const get_changed = define_paramless_endpoint("changed", boolean);
+export const get_commodities = define_endpoint(
+  "commodities",
+  commodities_validator,
+) satisfies Api<Filters>;
+export const get_context = define_endpoint(
+  "context",
+  context_validator,
+) satisfies Api<{
+  entry_hash: string;
+}>;
+export const get_documents = define_endpoint(
+  "documents",
+  array(Document.validator),
+) satisfies Api<Filters>;
+export const get_errors = define_paramless_endpoint(
+  "errors",
+  array(error_validator),
+);
+export const get_events = define_endpoint(
+  "events",
+  array(Event.validator),
+) satisfies Api<Filters>;
+export const get_extract = define_endpoint(
+  "extract",
+  array(entryValidator),
+) satisfies Api<{ filename: string; importer: string }>;
+export const get_imports = define_paramless_endpoint(
+  "imports",
+  importable_files_validator,
+);
+export const get_income_statement = define_endpoint(
+  "income_statement",
+  tree_report_validator,
+) satisfies Api<FiltersConversionInterval>;
+export const get_ledger_data = define_paramless_endpoint(
+  "ledger_data",
+  ledgerDataValidator,
+);
+export const get_narration_transaction = define_endpoint(
+  "narration_transaction",
+  Transaction.validator,
+) satisfies Api<{ narration: string }>;
+export const get_narrations = define_paramless_endpoint(
+  "narrations",
+  array(string),
+);
+export const get_options = define_paramless_endpoint(
+  "options",
+  options_validator,
+);
+export const get_payee_accounts = define_endpoint(
+  "payee_accounts",
+  array(string),
+) satisfies Api<{ payee: string }>;
+export const get_payee_transaction = define_endpoint(
+  "payee_transaction",
+  Transaction.validator,
+) satisfies Api<{ payee: string }>;
+export const get_query = define_endpoint(
+  "query",
+  query_validator,
+) satisfies Api<Filters & { query_string: string }>;
+export const get_source = define_endpoint(
+  "source",
+  source_validator,
+) satisfies Api<{ filename: string }>;
+export const get_statistics = define_endpoint(
+  "statistics",
+  statistics_validator,
+) satisfies Api<Filters>;
+export const get_trial_balance = define_endpoint(
+  "trial_balance",
+  tree_report_validator,
+) satisfies Api<FiltersConversionInterval>;
+
+// PUT endpoints
+
+export const put_add_document = define_put<FormData>("add_document");
+const put_add_entries = define_put<{ entries: NonEmptyArray<Entry> }>(
+  "add_entries",
+);
+export const put_attach_document = define_put<{
+  filename: string;
+  entry_hash: string;
+}>("attach_document");
+export const put_format_source = define_put<{ source: string }>(
+  "format_source",
+);
+const put_move = define_put<{
+  filename: string;
+  account: string;
+  new_name: string;
+}>("move");
+export const put_source = define_put<SourceFile>("source");
+export const put_source_slice = define_put<{
+  entry_hash: string;
+  source: string;
+  sha256sum: string;
+}>("source_slice");
+export const put_upload_import_file =
+  define_put<FormData>("upload_import_file");
 
 /**
  * Move a file, either in an import directory or a document.
@@ -136,13 +283,13 @@ export async function doDelete<T extends keyof DeleteAPIParams>(
  * @param new_name - the new filename.
  * @returns whether the file was moved successfully.
  */
-export async function moveDocument(
+export async function move_document(
   filename: string,
   account: string,
   new_name: string,
 ): Promise<boolean> {
   try {
-    const msg = await get("move", { filename, account, new_name });
+    const msg = await put_move({ filename, account, new_name });
     notify(msg);
     return true;
   } catch (error) {
@@ -156,9 +303,9 @@ export async function moveDocument(
  * @param filename - the filename of the file to delete.
  * @returns whether the file was deleted successfully.
  */
-export async function deleteDocument(filename: string): Promise<boolean> {
+export async function delete_document(filename: string): Promise<boolean> {
   try {
-    const msg = await doDelete("document", { filename });
+    const msg = await delete_document_raw({ filename });
     notify(msg);
     return true;
   } catch (error) {
@@ -171,14 +318,13 @@ export async function deleteDocument(filename: string): Promise<boolean> {
  * Save an array of entries.
  * @param entries - an array of entries to save to the Beancount file.
  */
-export async function saveEntries(entries: Entry[]): Promise<void> {
-  if (!entries.length) {
-    return;
-  }
+export async function save_entries(
+  entries: NonEmptyArray<Entry>,
+): Promise<void> {
   try {
-    const data = await put("add_entries", { entries });
+    const msg = await put_add_entries({ entries });
     router.reload();
-    notify(data);
+    notify(msg);
   } catch (error) {
     notify_err(error, (e) => `Saving failed: ${e.message}`);
     throw error;

--- a/frontend/src/api/validators.ts
+++ b/frontend/src/api/validators.ts
@@ -1,11 +1,5 @@
 import { account_hierarchy_validator } from "../charts/hierarchy.ts";
-import {
-  Document,
-  entryBaseValidator,
-  entryValidator,
-  Event,
-  Transaction,
-} from "../entries/index.ts";
+import { entryBaseValidator } from "../entries/index.ts";
 import type { ValidationT } from "../lib/validation.ts";
 import {
   array,
@@ -20,7 +14,7 @@ import {
   tuple,
   unknown,
 } from "../lib/validation.ts";
-import { Inventory, query_validator } from "../reports/query/query_table.ts";
+import { Inventory } from "../reports/query/query_table.ts";
 
 /** A Beancount error that should be shown to the user in the list of errors. */
 export interface BeancountError {
@@ -33,7 +27,7 @@ export interface BeancountError {
 }
 
 /** Validator for a BeancountError. */
-const error_validator = object<BeancountError>({
+export const error_validator = object<BeancountError>({
   type: string,
   message: string,
   source: optional(object({ filename: string, lineno: number })),
@@ -118,7 +112,7 @@ export const ledgerDataValidator = object({
 
 export type LedgerData = ValidationT<typeof ledgerDataValidator>;
 
-const importable_files_validator = array(
+export const importable_files_validator = array(
   object({
     name: string,
     basename: string,
@@ -135,13 +129,13 @@ const importable_files_validator = array(
 
 const date_range = object({ begin: date, end: date });
 
-const commodities = array(
+export const commodities_validator = array(
   object({ base: string, quote: string, prices: array(tuple(date, number)) }),
 );
 
-export type Commodities = ValidationT<typeof commodities>;
+export type Commodities = ValidationT<typeof commodities_validator>;
 
-const context = object({
+export const context_validator = object({
   entry: entryBaseValidator,
   balances_before: optional(record(array(string))),
   balances_after: optional(record(array(string))),
@@ -161,55 +155,33 @@ export interface SourceFile {
   readonly sha256sum: string;
   readonly source: string;
 }
-const source = object<SourceFile>({
+export const source_validator = object<SourceFile>({
   file_path: string,
   sha256sum: string,
   source: string,
 });
 
-const tree_report = object({
+export const tree_report_validator = object({
   charts: unknown,
   trees: array(account_hierarchy_validator),
   date_range: optional(date_range),
 });
 
-export const getAPIValidators = {
-  balance_sheet: tree_report,
-  account_report: object({
-    charts: unknown,
-    journal: optional(string),
-    dates: optional(array(date_range)),
-    interval_balances: optional(array(account_hierarchy_validator)),
-    budgets: optional(record(array(account_budget))),
-  }),
-  changed: boolean,
-  commodities,
-  context,
-  documents: array(Document.validator),
-  errors: array(error_validator),
-  events: array(Event.validator),
-  extract: array(entryValidator),
-  imports: importable_files_validator,
-  income_statement: tree_report,
-  journal: array(entryValidator),
-  ledger_data: ledgerDataValidator,
-  move: string,
-  options: object({
-    fava_options: record(string),
-    beancount_options: record(string),
-  }),
-  payee_accounts: array(string),
-  payee_transaction: Transaction.validator,
-  narration_transaction: Transaction.validator,
-  narrations: array(string),
-  query: query_validator,
-  source,
-  statistics: object({
-    all_balance_directives: string,
-    entries_by_type: record(number),
-    balances: record(Inventory.validator),
-  }),
-  trial_balance: tree_report,
-};
+export const account_report_validator = object({
+  charts: unknown,
+  journal: optional(string),
+  dates: optional(array(date_range)),
+  interval_balances: optional(array(account_hierarchy_validator)),
+  budgets: optional(record(array(account_budget))),
+});
 
-export type GetAPIValidators = typeof getAPIValidators;
+export const statistics_validator = object({
+  all_balance_directives: string,
+  entries_by_type: record(number),
+  balances: record(Inventory.validator),
+});
+
+export const options_validator = object({
+  fava_options: record(string),
+  beancount_options: record(string),
+});

--- a/frontend/src/codemirror/beancount-format.ts
+++ b/frontend/src/codemirror/beancount-format.ts
@@ -1,11 +1,11 @@
 import type { Command } from "@codemirror/view";
 
-import { put } from "../api/index.ts";
+import { put_format_source } from "../api/index.ts";
 import { notify_err } from "../notifications.ts";
 import { replaceContents } from "./editor-transactions.ts";
 
 export const beancountFormat: Command = (cm) => {
-  put("format_source", { source: cm.state.sliceDoc() }).then(
+  put_format_source({ source: cm.state.sliceDoc() }).then(
     (data) => {
       cm.dispatch(replaceContents(cm.state, data));
     },

--- a/frontend/src/document-upload.ts
+++ b/frontend/src/document-upload.ts
@@ -6,7 +6,7 @@
 import type { Writable } from "svelte/store";
 import { writable } from "svelte/store";
 
-import { put } from "./api/index.ts";
+import { put_attach_document } from "./api/index.ts";
 import { todayAsString } from "./format.ts";
 import { delegate } from "./lib/events.ts";
 import { basename, documentHasAccount } from "./lib/paths.ts";
@@ -83,7 +83,7 @@ function drop(event: DragEvent, target: Element): void {
       ) {
         filename = basename(filename);
       }
-      put("attach_document", { filename, entry_hash: targetEntry }).then(
+      put_attach_document({ filename, entry_hash: targetEntry }).then(
         notify,
         (error: unknown) => {
           notify_err(

--- a/frontend/src/editor/SliceEditor.svelte
+++ b/frontend/src/editor/SliceEditor.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import type { LanguageSupport } from "@codemirror/language";
 
-  import { doDelete, put } from "../api/index.ts";
+  import { delete_source_slice, put_source_slice } from "../api/index.ts";
   import { initBeancountEditor } from "../codemirror/setup.ts";
   import { _ } from "../i18n.ts";
   import { notify_err } from "../notifications.ts";
@@ -34,7 +34,7 @@
     event?.preventDefault();
     saving = true;
     try {
-      sha256sum = await put("source_slice", {
+      sha256sum = await put_source_slice({
         entry_hash,
         source: currentSlice,
         sha256sum,
@@ -53,7 +53,7 @@
   async function deleteSlice() {
     deleting = true;
     try {
-      await doDelete("source_slice", { entry_hash, sha256sum });
+      await delete_source_slice({ entry_hash, sha256sum });
       entry_hash = "";
       if ($reloadAfterSavingEntrySlice) {
         router.reload();

--- a/frontend/src/entry-forms/Transaction.svelte
+++ b/frontend/src/entry-forms/Transaction.svelte
@@ -1,5 +1,10 @@
 <script lang="ts">
-  import { get } from "../api/index.ts";
+  import {
+    get_narration_transaction,
+    get_narrations,
+    get_payee_accounts,
+    get_payee_transaction,
+  } from "../api/index.ts";
   import AutocompleteInput from "../AutocompleteInput.svelte";
   import type { EntryMetadata, Transaction } from "../entries/index.ts";
   import { Posting } from "../entries/index.ts";
@@ -23,7 +28,7 @@
     if (payee) {
       suggestions = undefined;
       if ($payees.includes(payee)) {
-        get("payee_accounts", { payee })
+        get_payee_accounts({ payee })
           .then((s) => {
             suggestions = s;
           })
@@ -41,7 +46,7 @@
   let narration = $derived(entry.get_narration_tags_links());
   let narration_suggestions: string[] = $state.raw([]);
   $effect(() => {
-    get("narrations")
+    get_narrations()
       .then((s) => {
         narration_suggestions = s;
       })
@@ -58,7 +63,7 @@
     if (entry.narration || entry.postings.some((p) => !p.is_empty())) {
       return;
     }
-    const payee_transaction = await get("payee_transaction", {
+    const payee_transaction = await get_payee_transaction({
       payee: entry.payee,
     });
     entry = payee_transaction.set("date", entry.date);
@@ -67,7 +72,7 @@
     if (entry.payee || entry.postings.some((p) => !p.is_empty())) {
       return;
     }
-    const data = await get("narration_transaction", { narration });
+    const data = await get_narration_transaction({ narration });
     data.set("date", entry.date);
     entry = data;
     narration = entry.get_narration_tags_links();

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -24,7 +24,7 @@ import "@ungap/custom-elements";
 
 import { get as store_get } from "svelte/store";
 
-import { get } from "./api/index.ts";
+import { get_changed, get_errors, get_ledger_data } from "./api/index.ts";
 import { ledgerDataValidator } from "./api/validators.ts";
 import { CopyableText } from "./clipboard.ts";
 import { BeancountTextarea } from "./codemirror/setup.ts";
@@ -70,7 +70,7 @@ function defineCustomElements() {
  * Update the ledger data and errors; Reload if automatic reloading is configured.
  */
 function onChanges() {
-  get("ledger_data")
+  get_ledger_data()
     .then((v) => {
       ledgerData.set(v);
     })
@@ -80,7 +80,7 @@ function onChanges() {
   if (store_get(auto_reload) && !router.has_interrupt_handler) {
     router.reload();
   } else {
-    get("errors").then((v) => {
+    get_errors().then((v) => {
       errors.set(v);
     }, log_error);
     notify(_("File change detected. Click to reload."), "warning", () => {
@@ -98,7 +98,7 @@ function onChanges() {
  * This will be scheduled every 5 seconds.
  */
 function pollForChanges(): void {
-  get("changed").catch(log_error);
+  get_changed().catch(log_error);
 }
 
 function init(): void {

--- a/frontend/src/modals/AddEntry.svelte
+++ b/frontend/src/modals/AddEntry.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { saveEntries } from "../api/index.ts";
+  import { save_entries } from "../api/index.ts";
   import { Balance, Note, Transaction } from "../entries/index.ts";
   import Entry from "../entry-forms/Entry.svelte";
   import { todayAsString } from "../format.ts";
@@ -23,7 +23,7 @@
 
   async function submit(event: SubmitEvent) {
     event.preventDefault();
-    await saveEntries([entry]);
+    await save_entries([entry]);
     const added_entry_date = entry.date;
     // Reuse the date of the entry that was just added.
     // @ts-expect-error all these entries have that static method, but TS is not able to determine that

--- a/frontend/src/modals/Context.svelte
+++ b/frontend/src/modals/Context.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { get } from "../api/index.ts";
+  import { get_context } from "../api/index.ts";
   import { getBeancountLanguageSupport } from "../codemirror/beancount.ts";
   import SliceEditor from "../editor/SliceEditor.svelte";
   import { _ } from "../i18n.ts";
@@ -10,7 +10,7 @@
 
   let shown = $derived($hash.startsWith("context"));
   let entry_hash = $derived(shown ? $hash.slice(8) : "");
-  let content = $derived(shown ? get("context", { entry_hash }) : null);
+  let content = $derived(shown ? get_context({ entry_hash }) : null);
 </script>
 
 <ModalBase {shown}>

--- a/frontend/src/modals/DocumentUpload.svelte
+++ b/frontend/src/modals/DocumentUpload.svelte
@@ -5,7 +5,7 @@
   the file name.
 -->
 <script lang="ts">
-  import { put } from "../api/index.ts";
+  import { put_add_document } from "../api/index.ts";
   import { account, files, hash } from "../document-upload.ts";
   import AccountInput from "../entry-forms/AccountInput.svelte";
   import { _ } from "../i18n.ts";
@@ -33,7 +33,7 @@
         formData.append("hash", $hash);
         formData.append("folder", documents_folder);
         formData.append("file", dataTransferFile, name);
-        return put("add_document", formData).then(notify, (error: unknown) => {
+        return put_add_document(formData).then(notify, (error: unknown) => {
           notify_err(error, (err) => `Upload error: ${err.message}`);
         });
       }),

--- a/frontend/src/reports/accounts/index.ts
+++ b/frontend/src/reports/accounts/index.ts
@@ -1,4 +1,4 @@
-import { get } from "../../api/index.ts";
+import { get_account_report } from "../../api/index.ts";
 import type { AccountBudget } from "../../api/validators.ts";
 import type { AccountTreeNode } from "../../charts/hierarchy.ts";
 import { getUrlPath } from "../../helpers.ts";
@@ -27,7 +27,7 @@ export const account_report = new Route<AccountReportProps>(
   async (url) => {
     const [, account = ""] = getUrlPath(url).unwrap().split("/");
     const report_type = to_report_type(url.searchParams.get("r"));
-    const res = await get("account_report", {
+    const res = await get_account_report({
       ...getURLFilters(url),
       a: account,
       r: report_type,

--- a/frontend/src/reports/commodities/index.ts
+++ b/frontend/src/reports/commodities/index.ts
@@ -1,4 +1,4 @@
-import { get } from "../../api/index.ts";
+import { get_commodities } from "../../api/index.ts";
 import type { Commodities } from "../../api/validators.ts";
 import type { FavaChart } from "../../charts/index.ts";
 import { LineChart } from "../../charts/line.ts";
@@ -18,7 +18,7 @@ export const commodities = new Route<CommoditiesReportProps>(
   "commodities",
   CommoditiesSvelte,
   async (url) =>
-    get("commodities", getURLFilters(url)).then((cs) => {
+    get_commodities(getURLFilters(url)).then((cs) => {
       const charts = cs.map(({ base, quote, prices }) => {
         const name = `${base} / ${quote}`;
         const values = prices.map((d) => ({ name, date: d[0], value: d[1] }));

--- a/frontend/src/reports/documents/Documents.svelte
+++ b/frontend/src/reports/documents/Documents.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { group } from "d3-array";
 
-  import { moveDocument } from "../../api/index.ts";
+  import { move_document } from "../../api/index.ts";
   import type { Document } from "../../entries/index.ts";
   import AccountInput from "../../entry-forms/AccountInput.svelte";
   import { _ } from "../../i18n.ts";
@@ -50,7 +50,7 @@
   async function move(event: SubmitEvent) {
     event.preventDefault();
     if (moving) {
-      const moved = await moveDocument(
+      const moved = await move_document(
         moving.filename,
         moving.account,
         moving.newName,

--- a/frontend/src/reports/documents/index.ts
+++ b/frontend/src/reports/documents/index.ts
@@ -1,4 +1,4 @@
-import { get } from "../../api/index.ts";
+import { get_documents } from "../../api/index.ts";
 import type { Document } from "../../entries/index.ts";
 import { _ } from "../../i18n.ts";
 import { getURLFilters } from "../../stores/filters.ts";
@@ -13,7 +13,7 @@ export const documents = new Route(
   "documents",
   Documents,
   async (url: URL) =>
-    get("documents", getURLFilters(url)).then((data) => ({
+    get_documents(getURLFilters(url)).then((data) => ({
       documents: data,
     })),
   () => _("Documents"),

--- a/frontend/src/reports/editor/Editor.svelte
+++ b/frontend/src/reports/editor/Editor.svelte
@@ -2,7 +2,7 @@
   import type { EditorView } from "@codemirror/view";
   import { onMount, untrack } from "svelte";
 
-  import { get, put } from "../../api/index.ts";
+  import { get_errors, put_source } from "../../api/index.ts";
   import {
     replaceContents,
     scrollToLine,
@@ -40,14 +40,14 @@
   async function save(cm: EditorView) {
     saving = true;
     try {
-      sha256sum = await put("source", {
+      sha256sum = await put_source({
         file_path,
         source: cm.state.sliceDoc(),
         sha256sum,
       });
       changed = false;
       cm.focus();
-      get("errors").then((v) => {
+      get_errors().then((v) => {
         errors.set(v);
       }, log_error);
     } catch (error) {

--- a/frontend/src/reports/editor/index.ts
+++ b/frontend/src/reports/editor/index.ts
@@ -1,6 +1,6 @@
 import type { LanguageSupport } from "@codemirror/language";
 
-import { get } from "../../api/index.ts";
+import { get_source } from "../../api/index.ts";
 import type { SourceFile } from "../../api/validators.ts";
 import { getBeancountLanguageSupport } from "../../codemirror/beancount.ts";
 import { _ } from "../../i18n.ts";
@@ -20,7 +20,7 @@ export const editor = new Route<EditorReportProps>(
     const line = url.searchParams.get("line");
     const line_search_param = line != null ? Number.parseInt(line, 10) : null;
     return Promise.all([
-      get("source", {
+      get_source({
         filename: url.searchParams.get("file_path") ?? "",
       }),
       getBeancountLanguageSupport(),

--- a/frontend/src/reports/events/index.ts
+++ b/frontend/src/reports/events/index.ts
@@ -1,4 +1,4 @@
-import { get } from "../../api/index.ts";
+import { get_events } from "../../api/index.ts";
 import type { Event } from "../../entries/index.ts";
 import { _ } from "../../i18n.ts";
 import { getURLFilters } from "../../stores/filters.ts";
@@ -13,6 +13,6 @@ export const events = new Route<EventsReportProps>(
   "events",
   Events,
   async (url: URL) =>
-    get("events", getURLFilters(url)).then((data) => ({ events: data })),
+    get_events(getURLFilters(url)).then((data) => ({ events: data })),
   () => _("Events"),
 );

--- a/frontend/src/reports/holdings/index.ts
+++ b/frontend/src/reports/holdings/index.ts
@@ -1,4 +1,4 @@
-import { get } from "../../api/index.ts";
+import { get_query } from "../../api/index.ts";
 import { getUrlPath } from "../../helpers.ts";
 import { _ } from "../../i18n.ts";
 import { getURLFilters } from "../../stores/filters.ts";
@@ -80,7 +80,7 @@ export const holdings = new Route<HoldingsReportProps>(
     const [, key = ""] = getUrlPath(url).unwrap().split("/");
     const aggregation_key = to_report_type(key);
     const query_string = QUERIES[aggregation_key];
-    const query_result_table = await get("query", {
+    const query_result_table = await get_query({
       query_string,
       ...getURLFilters(url),
     });

--- a/frontend/src/reports/import/Import.svelte
+++ b/frontend/src/reports/import/Import.svelte
@@ -3,14 +3,15 @@
   import { SvelteMap } from "svelte/reactivity";
 
   import {
-    deleteDocument,
-    get,
-    moveDocument,
-    saveEntries,
+    delete_document,
+    get_extract,
+    move_document,
+    save_entries,
   } from "../../api/index.ts";
   import type { Entry } from "../../entries/index.ts";
   import { urlFor } from "../../helpers.ts";
   import { _ } from "../../i18n.ts";
+  import { is_non_empty } from "../../lib/array.ts";
   import { notify, notify_err } from "../../notifications.ts";
   import { router } from "../../router.ts";
   import { import_config } from "../../stores/fava_options.ts";
@@ -61,7 +62,7 @@
    * Move the given file to the new file name (and remove from the list).
    */
   async function move(filename: string, account: string, newName: string) {
-    const moved = await moveDocument(filename, account, newName);
+    const moved = await move_document(filename, account, newName);
     if (moved) {
       router.reload();
     }
@@ -74,7 +75,7 @@
     if (!window.confirm(_("Delete this file?"))) {
       return;
     }
-    const removed = await deleteDocument(filename);
+    const removed = await delete_document(filename);
     if (removed) {
       if (selected === filename) {
         selected = null;
@@ -94,7 +95,7 @@
       return;
     }
     try {
-      entries = await get("extract", { filename, importer });
+      entries = await get_extract({ filename, importer });
       if (entries.length) {
         extract_cache.set(file_importer_key, entries);
       } else {
@@ -115,7 +116,9 @@
       extract_cache.delete(key);
     }
     entries = [];
-    await saveEntries(without_duplicates);
+    if (is_non_empty(without_duplicates)) {
+      await save_entries(without_duplicates);
+    }
   }
 </script>
 

--- a/frontend/src/reports/import/ImportFileUpload.svelte
+++ b/frontend/src/reports/import/ImportFileUpload.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { put } from "../../api/index.ts";
+  import { put_upload_import_file } from "../../api/index.ts";
   import { _ } from "../../i18n.ts";
   import { notify, notify_err } from "../../notifications.ts";
   import { router } from "../../router.ts";
@@ -16,7 +16,7 @@
       Array.from(input.files).map(async (file) => {
         const formData = new FormData();
         formData.append("file", file, file.name);
-        return put("upload_import_file", formData).then(
+        return put_upload_import_file(formData).then(
           notify,
           (error: unknown) => {
             notify_err(error, (err) => `Upload error: ${err.message}`);

--- a/frontend/src/reports/import/index.ts
+++ b/frontend/src/reports/import/index.ts
@@ -1,4 +1,4 @@
-import { get } from "../../api/index.ts";
+import { get_imports } from "../../api/index.ts";
 import { todayAsString } from "../../format.ts";
 import { _ } from "../../i18n.ts";
 import { Route } from "../route.ts";
@@ -35,7 +35,7 @@ export const import_report = new Route<ImportReportProps>(
   "import",
   ImportSvelte,
   async () =>
-    get("imports", undefined)
+    get_imports()
       .then((files) => {
         // Initially set the file names for all importable files.
         const today = todayAsString();

--- a/frontend/src/reports/options/index.ts
+++ b/frontend/src/reports/options/index.ts
@@ -1,4 +1,4 @@
-import { get } from "../../api/index.ts";
+import { get_options } from "../../api/index.ts";
 import { _ } from "../../i18n.ts";
 import { Route } from "../route.ts";
 import OptionsSvelte from "./Options.svelte";
@@ -11,6 +11,6 @@ export interface OptionsReportProps {
 export const options = new Route<OptionsReportProps>(
   "options",
   OptionsSvelte,
-  async () => get("options"),
+  async () => get_options(),
   () => _("Options"),
 );

--- a/frontend/src/reports/query/Query.svelte
+++ b/frontend/src/reports/query/Query.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { onMount } from "svelte";
 
-  import { get } from "../../api/index.ts";
+  import { get_query } from "../../api/index.ts";
   import { err, ok, type Result } from "../../lib/result.ts";
   import { log_error } from "../../log.ts";
   import { router } from "../../router.ts";
@@ -50,7 +50,7 @@
     }
     query_shell_history.add(query);
     router.set_search_param("query_string", query);
-    get("query", { query_string: query, ...$filter_params })
+    get_query({ query_string: query, ...$filter_params })
       .then(
         (res) => ok(res),
         (error: unknown) =>
@@ -71,7 +71,7 @@
       .map(([query]) => query);
     results = {};
     for (const query of to_rerun) {
-      get("query", { query_string: query, ...$filter_params })
+      get_query({ query_string: query, ...$filter_params })
         .then(
           (res) => ok(res),
           (error: unknown) =>

--- a/frontend/src/reports/statistics/index.ts
+++ b/frontend/src/reports/statistics/index.ts
@@ -1,4 +1,4 @@
-import { get } from "../../api/index.ts";
+import { get_query, get_statistics } from "../../api/index.ts";
 import { _ } from "../../i18n.ts";
 import { getURLFilters } from "../../stores/filters.ts";
 import type { Inventory, QueryResultTable } from "../query/query_table.ts";
@@ -18,14 +18,12 @@ export const statistics = new Route<StatisticsReportProps>(
   "statistics",
   Statistics,
   async (url) => {
-    const postings_per_account = await get("query", {
+    const postings_per_account = await get_query({
       query_string: postings_per_account_query,
       ...getURLFilters(url),
     });
-    const { all_balance_directives, balances, entries_by_type } = await get(
-      "statistics",
-      getURLFilters(url),
-    );
+    const { all_balance_directives, balances, entries_by_type } =
+      await get_statistics(getURLFilters(url));
     if (postings_per_account.t !== "table") {
       throw new Error("Internal error: expected a query result table");
     }

--- a/frontend/src/reports/tree_reports/index.ts
+++ b/frontend/src/reports/tree_reports/index.ts
@@ -1,4 +1,8 @@
-import { get } from "../../api/index.ts";
+import {
+  get_balance_sheet,
+  get_income_statement,
+  get_trial_balance,
+} from "../../api/index.ts";
 import type { AccountTreeNode } from "../../charts/hierarchy.ts";
 import { _ } from "../../i18n.ts";
 import { getURLFilters } from "../../stores/filters.ts";
@@ -16,20 +20,20 @@ export interface TreeReportProps {
 export const income_statement = new Route(
   "income_statement",
   IncomeStatement,
-  async (url) => get("income_statement", getURLFilters(url)),
+  async (url) => get_income_statement(getURLFilters(url)),
   () => _("Income Statement"),
 );
 
 export const balance_sheet = new Route(
   "balance_sheet",
   BalanceSheet,
-  async (url) => get("balance_sheet", getURLFilters(url)),
+  async (url) => get_balance_sheet(getURLFilters(url)),
   () => _("Balance Sheet"),
 );
 
 export const trial_balance = new Route(
   "trial_balance",
   TrialBalance,
-  async (url) => get("trial_balance", getURLFilters(url)),
+  async (url) => get_trial_balance(getURLFilters(url)),
   () => _("Trial Balance"),
 );

--- a/frontend/src/stores/filters.ts
+++ b/frontend/src/stores/filters.ts
@@ -19,7 +19,7 @@ export const fql_filter = derived(
 );
 
 /** The three entry filters that Fava supports. */
-export interface Filters extends Record<string, string | undefined> {
+export interface Filters extends Record<string, string> {
   account: string;
   filter: string;
   time: string;

--- a/frontend/test/end-to-end-validation.test.ts
+++ b/frontend/test/end-to-end-validation.test.ts
@@ -3,13 +3,14 @@ import { before, test } from "node:test";
 
 import { get as store_get } from "svelte/store";
 
-import { getAPIValidators } from "../src/api/validators.ts";
 import { chartContext } from "../src/charts/context.ts";
 import {
   currenciesScale,
   sunburstScale,
   treemapScale,
 } from "../src/charts/helpers.ts";
+import { entryValidator, Event } from "../src/entries/index.ts";
+import { array } from "../src/lib/validation.ts";
 import { conversions } from "../src/stores/chart.ts";
 import { currencies, ledgerData } from "../src/stores/index.ts";
 import { initialiseLedgerData, loadJSONSnapshot } from "./helpers.ts";
@@ -57,13 +58,13 @@ test("validate ledger data", () => {
 
 test("validate events", async () => {
   const data = await loadJSONSnapshot("test_json_api-test_api-events.json");
-  const res = getAPIValidators.events(data);
+  const res = array(Event.validator)(data);
   equal(res.unwrap()[0]?.type, "employer");
 });
 
 test("validate journal", async () => {
   const data = await loadJSONSnapshot("test_json_api-test_api-journal.json");
-  const res = getAPIValidators.journal(data);
+  const res = array(entryValidator)(data);
   ok(res.is_ok);
   const entries = res.unwrap();
   equal(entries.length, 25);

--- a/src/fava/json_api.py
+++ b/src/fava/json_api.py
@@ -87,6 +87,13 @@ class IncorrectTypeValidationError(ValidationError):
         )
 
 
+class InvalidJsonRequestError(ValidationError):
+    """Validation failed due to invalid JSON in body."""
+
+    def __init__(self) -> None:
+        super().__init__("Invalid JSON body.")
+
+
 def json_err(msg: str, status: HTTPStatus) -> Response:
     """Jsonify the error message."""
     res = jsonify({"error": msg})
@@ -261,8 +268,7 @@ def api_endpoint(func: Callable[..., Any]) -> Callable[[], Response]:
             if method == "put":
                 request_json = request.get_json(silent=True)
                 if request_json is None:
-                    msg = "Invalid JSON request."
-                    raise FavaAPIError(msg)
+                    raise InvalidJsonRequestError
                 data = request_json
             else:
                 data = request.args
@@ -324,8 +330,8 @@ def get_context(entry_hash: str) -> Context:
 
 
 @api_endpoint
-def get_move(account: str, new_name: str, filename: str) -> str:
-    """Move a file."""
+def put_move(account: str, new_name: str, filename: str) -> str:
+    """Move a document."""
     if not g.ledger.options["documents"]:
         raise DocumentDirectoryMissingError
 

--- a/tests/test_json_api.py
+++ b/tests/test_json_api.py
@@ -154,9 +154,9 @@ def test_api_add_document_and_move_and_delete(
         )
 
         # move to same path should fail
-        response = test_client.get(
+        response = test_client.put(
             move_url,
-            query_string={
+            json={
                 "account": account,
                 "filename": str(filename),
                 "new_name": "2015-12-12 test",
@@ -166,9 +166,9 @@ def test_api_add_document_and_move_and_delete(
             response, f"{filename} already exists.", HTTPStatus.CONFLICT
         )
 
-        response = test_client.get(
+        response = test_client.put(
             move_url,
-            query_string={
+            json={
                 "account": account,
                 "filename": str(filename),
                 "new_name": "2015-12-12 test_moved",
@@ -386,27 +386,27 @@ def test_api_imports(
 
 
 def test_api_move(test_client: FlaskClient) -> None:
-    response = test_client.get("/long-example/api/move")
+    response = test_client.put("/long-example/api/move")
     assert_api_error(
         response,
-        "Invalid API request: Parameter `account` is missing.",
+        "Invalid API request: Invalid JSON body.",
         HTTPStatus.BAD_REQUEST,
     )
 
     invalid = {"account": "Assets", "new_name": "new", "filename": "old"}
-    response = test_client.get("/long-example/api/move", query_string=invalid)
+    response = test_client.put("/long-example/api/move", json=invalid)
     assert_api_error(
         response,
         "You need to set a documents folder.",
         HTTPStatus.UNPROCESSABLE_ENTITY,
     )
 
-    response = test_client.get("/import/api/move", query_string=invalid)
+    response = test_client.put("/import/api/move", json=invalid)
     assert_api_error(response, "Not a valid account: 'Assets'")
 
-    response = test_client.get(
+    response = test_client.put(
         "/import/api/move",
-        query_string={
+        json={
             **invalid,
             "account": "Assets:Checking",
         },
@@ -436,7 +436,11 @@ def test_api_get_source_unknown_file(test_client: FlaskClient) -> None:
 
 def test_api_put_source_bad_request(test_client: FlaskClient) -> None:
     response = test_client.put("/example/api/source")
-    assert_api_error(response, "Invalid JSON request.")
+    assert_api_error(
+        response,
+        "Invalid API request: Invalid JSON body.",
+        HTTPStatus.BAD_REQUEST,
+    )
 
 
 def test_api_source(app_in_tmp_dir: Flask) -> None:


### PR DESCRIPTION
This simplifies the Typescript logic in the definitions in these
functions and makes it more explicit via the individual imports which
API functions are used

Also fix the "move" endpoint to be a PUT endpoint since it mutates.

<!--
Hi, thank you for opening a PR!

Please ensure that your change passes tests and the various linters by running
`make test` and `make lint`. If testable, your changes should be covered by
unit tests.

Explain your changes below and link to related issues.
-->
