### PR TITLE
charts: parse first and provide context later

### DIFF
--- a/frontend/src/api/validators.ts
+++ b/frontend/src/api/validators.ts
@@ -1,4 +1,5 @@
 import { account_hierarchy_validator } from "../charts/hierarchy.ts";
+import { chart_validator } from "../charts/index.ts";
 import { entryBaseValidator } from "../entries/index.ts";
 import type { ValidationT } from "../lib/validation.ts";
 import {
@@ -12,7 +13,6 @@ import {
   record,
   string,
   tuple,
-  unknown,
 } from "../lib/validation.ts";
 import { Inventory } from "../reports/query/query_table.ts";
 
@@ -162,13 +162,13 @@ export const source_validator = object<SourceFile>({
 });
 
 export const tree_report_validator = object({
-  charts: unknown,
+  charts: chart_validator,
   trees: array(account_hierarchy_validator),
   date_range: optional(date_range),
 });
 
 export const account_report_validator = object({
-  charts: unknown,
+  charts: chart_validator,
   journal: optional(string),
   dates: optional(array(date_range)),
   interval_balances: optional(array(account_hierarchy_validator)),

--- a/frontend/src/charts/ChartSwitcher.svelte
+++ b/frontend/src/charts/ChartSwitcher.svelte
@@ -5,17 +5,18 @@
   import { lastActiveChartName } from "../stores/chart.ts";
   import { show_charts } from "../stores/url.ts";
   import Chart from "./Chart.svelte";
+  import { chartContext } from "./context.ts";
   import ConversionAndInterval from "./ConversionAndInterval.svelte";
-  import type { FavaChart } from "./index.ts";
+  import type { ParsedFavaChart } from "./index.ts";
 
   interface Props {
-    charts: readonly FavaChart[];
+    charts: readonly ParsedFavaChart[];
   }
 
   let { charts }: Props = $props();
 
   let active_chart = $derived(
-    charts.find((c) => c.name === $lastActiveChartName) ?? charts[0],
+    charts.find((c) => c.label === $lastActiveChartName) ?? charts[0],
   );
 
   // Get the shortcut key for jumping to the previous chart.
@@ -35,22 +36,22 @@
 </script>
 
 {#if active_chart}
-  <Chart chart={active_chart}>
+  <Chart chart={active_chart.with_context($chartContext)}>
     <ConversionAndInterval />
   </Chart>
   <div hidden={!$show_charts}>
-    {#each charts as chart, index (chart.name)}
+    {#each charts as chart, index (chart.label)}
       <button
         type="button"
         class="unset"
         class:selected={chart === active_chart}
         onclick={() => {
-          $lastActiveChartName = chart.name;
+          $lastActiveChartName = chart.label;
         }}
         {@attach keyboardShortcut(shortcutPrevious(index))}
         {@attach keyboardShortcut(shortcutNext(index))}
       >
-        {chart.name}
+        {chart.label}
       </button>
     {/each}
   </div>

--- a/frontend/src/charts/bar.ts
+++ b/frontend/src/charts/bar.ts
@@ -3,10 +3,17 @@ import type { Series } from "d3-shape";
 import { stack, stackOffsetDiverging } from "d3-shape";
 
 import type { FormatterContext } from "../format.ts";
-import type { Result } from "../lib/result.ts";
-import type { ValidationError, ValidationT } from "../lib/validation.ts";
-import { array, date, number, object, record } from "../lib/validation.ts";
+import type { ValidationT, Validator } from "../lib/validation.ts";
+import {
+  array,
+  date,
+  number,
+  object,
+  record,
+  string,
+} from "../lib/validation.ts";
 import type { ChartContext } from "./context.ts";
+import type { ParsedFavaChart } from "./index.ts";
 import type { TooltipContent } from "./tooltip.ts";
 import { domHelpers } from "./tooltip.ts";
 
@@ -28,17 +35,6 @@ export interface BarChartDatum {
   account_balances: Record<string, Record<string, number>>;
 }
 
-const bar_validator = array(
-  object({
-    date,
-    budgets: record(number),
-    balance: record(number),
-    account_balances: record(record(number)),
-  }),
-);
-
-type ParsedBarChartData = ValidationT<typeof bar_validator>;
-
 export class BarChart {
   readonly type = "barchart";
   /** The accounts that occur in some bar.  */
@@ -48,18 +44,18 @@ export class BarChart {
     currency: string,
     stacks: Series<BarChartDatum, string>[],
   ][];
-  readonly name: string | null;
+  readonly label: string | null;
   /** The currencies that are shown in this bar chart. */
   readonly currencies: readonly string[];
   /** The data for the (single) bars for all the intervals in this chart. */
   private readonly bar_groups: BarChartDatum[];
 
   constructor(
-    name: string | null,
+    label: string | null,
     currencies: readonly string[],
     bar_groups: BarChartDatum[],
   ) {
-    this.name = name;
+    this.label = label;
     this.currencies = currencies;
     this.bar_groups = bar_groups;
     this.accounts = Array.from(
@@ -168,18 +164,37 @@ function currencies_to_show(
   return to_show;
 }
 
-/**
- * Try to parse a bar chart.
- */
-export function bar(
-  label: string | null,
-  json: unknown,
-  $chartContext: ChartContext,
-): Result<BarChart, ValidationError> {
-  return bar_validator(json).map((parsedData) => {
-    const currencies = currencies_to_show(parsedData, $chartContext);
+const bar_validator = array(
+  object({
+    date,
+    budgets: record(number),
+    balance: record(number),
+    account_balances: record(record(number)),
+  }),
+);
 
-    const bar_groups = parsedData.map((interval) => ({
+type ParsedBarChartData = ValidationT<typeof bar_validator>;
+
+const bar_chart_validator = object({ label: string, data: bar_validator });
+
+export class ParsedBarChart implements ParsedFavaChart {
+  readonly label: string | null;
+  readonly data: ParsedBarChartData;
+
+  constructor(label: string | null, data: ParsedBarChartData) {
+    this.label = label;
+    this.data = data;
+  }
+
+  static validator: Validator<ParsedBarChart> = (json) =>
+    bar_chart_validator(json).map(
+      ({ label, data }) => new ParsedBarChart(label, data),
+    );
+
+  with_context($chartContext: ChartContext): BarChart {
+    const currencies = currencies_to_show(this.data, $chartContext);
+
+    const bar_groups = this.data.map((interval) => ({
       values: currencies.map((currency) => ({
         currency,
         value: interval.balance[currency] ?? 0,
@@ -190,6 +205,6 @@ export function bar(
       account_balances: interval.account_balances,
     }));
 
-    return new BarChart(label, currencies, bar_groups);
-  });
+    return new BarChart(this.label, currencies, bar_groups);
+  }
 }

--- a/frontend/src/charts/hierarchy.ts
+++ b/frontend/src/charts/hierarchy.ts
@@ -4,9 +4,8 @@ import { hierarchy as d3Hierarchy } from "d3-hierarchy";
 import type { Writable } from "svelte/store";
 import { writable } from "svelte/store";
 
-import type { Result } from "../lib/result.ts";
 import type { TreeNode } from "../lib/tree.ts";
-import type { ValidationError, Validator } from "../lib/validation.ts";
+import type { Validator } from "../lib/validation.ts";
 import {
   array,
   boolean,
@@ -17,13 +16,16 @@ import {
   optional,
   record,
   string,
-  unknown,
 } from "../lib/validation.ts";
-import { notify_warn } from "../notifications.ts";
 import { sort_by_strings } from "../sort/index.ts";
 import type { ChartContext } from "./context.ts";
+import type { ParsedFavaChart } from "./index.ts";
 
-/** The data provided with a fava.core.tree.SerialisedTreeNode. */
+/**
+ * An account tree - data provided with a fava.core.tree.SerialisedTreeNode.
+ *
+ * Used in the hierarchy charts but also in e.g. the tree-tables.
+ * */
 export type AccountTreeNode = TreeNode<{
   readonly account: string;
   readonly balance: Record<string, number>;
@@ -32,62 +34,6 @@ export type AccountTreeNode = TreeNode<{
   readonly cost_children: Record<string, number> | null;
   readonly has_txns: boolean;
 }>;
-
-/** The data for a single account in a d3-hierarchy. */
-export type AccountHierarchyDatum = TreeNode<{
-  readonly account: string;
-  readonly balance: Record<string, number>;
-  readonly dummy: boolean;
-}>;
-
-export type AccountHierarchyInputDatum = TreeNode<{
-  readonly account: string;
-  readonly balance: Record<string, number>;
-}>;
-
-/** A d3-hierarchy node for an account. */
-export type AccountHierarchyNode = HierarchyNode<AccountHierarchyDatum>;
-
-/**
- * Add internal nodes as dummy leaf nodes to their own children.
- *
- * In the treemap, we only render leaf nodes, so for accounts that have both
- * children and a balance, we want to duplicate them as leaf nodes.
- */
-export function addInternalNodesAsLeaves({
-  account,
-  balance,
-  children,
-}: AccountHierarchyInputDatum): AccountHierarchyDatum {
-  if (children.length) {
-    const c = children.map(addInternalNodesAsLeaves);
-    c.push({ account, balance, children: [], dummy: true });
-    return { account, balance: {}, children: c, dummy: false };
-  }
-  return { account, balance, children: [], dummy: false };
-}
-
-export class HierarchyChart {
-  readonly type = "hierarchy";
-  /** All currencies for which we have an hierarchy. */
-  readonly currencies: readonly string[];
-  /** The currency to show the treemap of. */
-  readonly treemap_currency: Writable<string> | null;
-  readonly name: string | null;
-  readonly data: ReadonlyMap<string, AccountHierarchyNode>;
-
-  constructor(
-    name: string | null,
-    data: ReadonlyMap<string, AccountHierarchyNode>,
-  ) {
-    this.name = name;
-    this.data = data;
-    this.currencies = [...this.data.keys()];
-    const first_currency = this.currencies[0];
-    this.treemap_currency =
-      first_currency != null ? writable<string>(first_currency) : null;
-  }
-}
 
 const sort_children = (values: AccountTreeNode[]) =>
   sort_by_strings(values, (v) => v.account);
@@ -106,54 +52,103 @@ export const account_hierarchy_validator: Validator<AccountTreeNode> = object({
   has_txns: defaultValue(boolean, () => false),
 });
 
-export function hierarchy_from_parsed_data(
-  label: string | null,
-  data: AccountHierarchyInputDatum,
-  { currencies }: ChartContext,
-): HierarchyChart {
-  const root = addInternalNodesAsLeaves(data);
-  return new HierarchyChart(
-    label,
-    new Map(
-      currencies
-        .map((currency) => {
-          const r = d3Hierarchy<AccountHierarchyDatum>(root);
-          const root_balance = sum(
-            r.descendants(),
-            (n) => n.data.balance[currency] ?? 0,
-          );
-          // depending on the balance for this currency in the root,
-          // build the tree either for all positive values or all negative values
-          const sign = root_balance ? Math.sign(root_balance) : 1;
-          r.sum(
-            (d) => sign * Math.max(sign * (d.balance[currency] ?? 0), 0),
-          ).sort((a, b) => sign * ((b.value ?? 0) - (a.value ?? 0)));
-          return [currency, r] as const;
-        })
-        .filter(([, h]) => h.value != null && h.value !== 0),
-    ),
-  );
+/** The data for a single account in a d3-hierarchy. */
+export type AccountHierarchyDatum = TreeNode<{
+  readonly account: string;
+  readonly balance: Record<string, number>;
+  readonly dummy: boolean;
+}>;
+
+type AccountHierarchyInputDatum = TreeNode<{
+  readonly account: string;
+  readonly balance: Record<string, number>;
+}>;
+
+/** A d3-hierarchy node for an account. */
+export type AccountHierarchyNode = HierarchyNode<AccountHierarchyDatum>;
+
+/**
+ * Add internal nodes as dummy leaf nodes to their own children.
+ *
+ * In the treemap, we only render leaf nodes, so for accounts that have both
+ * children and a balance, we want to duplicate them as leaf nodes.
+ */
+function add_internal_nodes_as_leaves({
+  account,
+  balance,
+  children,
+}: AccountHierarchyInputDatum): AccountHierarchyDatum {
+  if (children.length) {
+    const c = children.map(add_internal_nodes_as_leaves);
+    c.push({ account, balance, children: [], dummy: true });
+    return { account, balance: {}, children: c, dummy: false };
+  }
+  return { account, balance, children: [], dummy: false };
 }
 
-const hierarchy_data_with_modifier = object({
-  modifier: number,
-  root: unknown,
+export class HierarchyChart {
+  readonly type = "hierarchy";
+  /** All currencies for which we have an hierarchy. */
+  readonly currencies: readonly string[];
+  /** The currency to show the treemap of. */
+  readonly treemap_currency: Writable<string> | null;
+  readonly label: string | null;
+  readonly data: ReadonlyMap<string, AccountHierarchyNode>;
+
+  constructor(
+    label: string | null,
+    data: ReadonlyMap<string, AccountHierarchyNode>,
+  ) {
+    this.label = label;
+    this.data = data;
+    this.currencies = [...this.data.keys()];
+    const first_currency = this.currencies[0];
+    this.treemap_currency =
+      first_currency != null ? writable<string>(first_currency) : null;
+  }
+}
+
+const hierarchy_validator = object({
+  label: string,
+  data: account_hierarchy_validator,
 });
 
-export function hierarchy(
-  label: string | null,
-  json: unknown,
-  $chartContext: ChartContext,
-): Result<HierarchyChart, ValidationError> {
-  const with_modifier = hierarchy_data_with_modifier(json);
-  if (with_modifier.is_ok) {
-    notify_warn(
-      "Tree for the hierarchy chart should now be specified at the top-level directly.\n" +
-        "{ modifier: 1, root: { ...children } } -> { ...children }",
+export class ParsedHierarchyChart implements ParsedFavaChart {
+  readonly label: string | null;
+  readonly data: AccountHierarchyInputDatum;
+
+  constructor(label: string | null, data: AccountHierarchyInputDatum) {
+    this.label = label;
+    this.data = data;
+  }
+
+  static validator: Validator<ParsedHierarchyChart> = (json) =>
+    hierarchy_validator(json).map(
+      ({ label, data }) => new ParsedHierarchyChart(label, data),
+    );
+
+  with_context({ currencies }: ChartContext): HierarchyChart {
+    const root = add_internal_nodes_as_leaves(this.data);
+    return new HierarchyChart(
+      this.label,
+      new Map(
+        currencies
+          .map((currency) => {
+            const r = d3Hierarchy<AccountHierarchyDatum>(root);
+            const root_balance = sum(
+              r.descendants(),
+              (n) => n.data.balance[currency] ?? 0,
+            );
+            // depending on the balance for this currency in the root,
+            // build the tree either for all positive values or all negative values
+            const sign = root_balance ? Math.sign(root_balance) : 1;
+            r.sum(
+              (d) => sign * Math.max(sign * (d.balance[currency] ?? 0), 0),
+            ).sort((a, b) => sign * ((b.value ?? 0) - (a.value ?? 0)));
+            return [currency, r] as const;
+          })
+          .filter(([, h]) => h.value != null && h.value !== 0),
+      ),
     );
   }
-  const root = with_modifier.is_ok ? with_modifier.value.root : json;
-  return account_hierarchy_validator(root).map((r) =>
-    hierarchy_from_parsed_data(label, r, $chartContext),
-  );
 }

--- a/frontend/src/charts/index.ts
+++ b/frontend/src/charts/index.ts
@@ -4,65 +4,32 @@
  * The charts heavily use d3 libraries.
  */
 
-import { collect, err, type Result } from "../lib/result.ts";
-import type { ValidationError } from "../lib/validation.ts";
-import { array, object, string, unknown } from "../lib/validation.ts";
+import type { Validator } from "../lib/validation.ts";
+import { array, tagged_union } from "../lib/validation.ts";
 import type { BarChart } from "./bar.ts";
-import { bar } from "./bar.ts";
+import { ParsedBarChart } from "./bar.ts";
 import type { ChartContext } from "./context.ts";
-import type { HierarchyChart } from "./hierarchy.ts";
-import { hierarchy } from "./hierarchy.ts";
+import { type HierarchyChart, ParsedHierarchyChart } from "./hierarchy.ts";
 import type { LineChart } from "./line.ts";
-import { balances } from "./line.ts";
-import type { ScatterPlot } from "./scatterplot.ts";
-import { scatterplot } from "./scatterplot.ts";
-
-const parsers: Record<
-  string,
-  (
-    label: string,
-    json: unknown,
-    $chartContext: ChartContext,
-  ) => Result<FavaChart, ValidationError>
-> = {
-  balances,
-  bar,
-  hierarchy,
-  scatterplot,
-};
+import { ParsedLineChart } from "./line.ts";
+import { ScatterPlot } from "./scatterplot.ts";
 
 export type FavaChart = HierarchyChart | BarChart | ScatterPlot | LineChart;
 
-const chart_data_validator = array(
-  object({ label: string, type: string, data: unknown }),
+/*
+ * The charts are parsed / loaded from the raw JSON into classed implementing
+ * this interface and can be provided the context before rendering.
+ */
+export interface ParsedFavaChart {
+  readonly label: string | null;
+  with_context($chartContext: ChartContext): FavaChart;
+}
+
+export const chart_validator: Validator<ParsedFavaChart[]> = array(
+  tagged_union("type", {
+    balances: ParsedLineChart.validator,
+    bar: ParsedBarChart.validator,
+    hierarchy: ParsedHierarchyChart.validator,
+    scatterplot: ScatterPlot.validator,
+  }),
 );
-
-class ChartValidationError extends Error {
-  constructor(type: string, cause: ValidationError) {
-    super(`Parsing of data for ${type} chart failed.`, { cause });
-  }
-}
-
-class UnknownChartTypeError extends Error {
-  constructor(type: string) {
-    super(`Unknown chart type ${type}`);
-  }
-}
-
-export function parseChartData(
-  data: unknown,
-  $chartContext: ChartContext,
-): Result<FavaChart[], ChartValidationError | UnknownChartTypeError> {
-  return chart_data_validator(data).and_then((chartData) =>
-    collect(
-      chartData.map(({ type, label, data }) => {
-        const parser = parsers[type];
-        return parser
-          ? parser(label, data, $chartContext).map_err(
-              (error) => new ChartValidationError(type, error),
-            )
-          : err(new UnknownChartTypeError(type));
-      }),
-    ),
-  );
-}

--- a/frontend/src/charts/line.ts
+++ b/frontend/src/charts/line.ts
@@ -2,9 +2,16 @@ import { sort } from "d3-array";
 
 import type { FormatterContext } from "../format.ts";
 import { day } from "../format.ts";
-import type { Result } from "../lib/result.ts";
-import type { ValidationError } from "../lib/validation.ts";
-import { array, date, number, object, record } from "../lib/validation.ts";
+import type { Validator } from "../lib/validation.ts";
+import {
+  array,
+  date,
+  number,
+  object,
+  record,
+  string,
+} from "../lib/validation.ts";
+import type { ParsedFavaChart } from "./index.ts";
 import type { TooltipContent } from "./tooltip.ts";
 import { domHelpers } from "./tooltip.ts";
 
@@ -34,7 +41,7 @@ interface LineChartSeries {
 export class LineChart {
   readonly type = "linechart";
   readonly series_names: readonly string[];
-  readonly name: string | null;
+  readonly label: string | null;
   private readonly data: readonly LineChartSeries[];
   readonly tooltipText: (
     c: FormatterContext,
@@ -42,11 +49,11 @@ export class LineChart {
   ) => TooltipContent;
 
   constructor(
-    name: string | null,
+    label: string | null,
     data: readonly LineChartSeries[],
     tooltipText: (c: FormatterContext, d: LineChartDatum) => TooltipContent,
   ) {
-    this.name = name;
+    this.label = label;
     this.data = sort(data, (d) => -d.values.length);
     this.tooltipText = tooltipText;
     this.series_names = this.data.map((series) => series.name);
@@ -57,42 +64,54 @@ export class LineChart {
     const hidden_names_set = new Set(hidden_names);
     return this.data.filter((series) => !hidden_names_set.has(series.name));
   }
-}
 
-const balances_validator = array(object({ date, balance: record(number) }));
-
-export function balances_from_parsed_data(
-  label: string | null,
-  parsed_data: { date: Date; balance: Record<string, number> }[],
-): LineChart {
-  const groups = new Map<string, LineChartDatum[]>();
-  for (const { date: date_val, balance } of parsed_data) {
-    Object.entries(balance).forEach(([currency, value]) => {
-      const group = groups.get(currency);
-      const datum = { date: date_val, value, name: currency };
-      if (group) {
-        group.push(datum);
-      } else {
-        groups.set(currency, [datum]);
-      }
-    });
+  with_context(): this {
+    return this;
   }
-  const data = [...groups.entries()].map(([name, values]) => ({
-    name,
-    values,
-  }));
-
-  return new LineChart(label, data, (c, d) => [
-    domHelpers.t(c.amount(d.value, d.name)),
-    domHelpers.em(day(d.date)),
-  ]);
 }
 
-export function balances(
-  label: string | null,
-  json: unknown,
-): Result<LineChart, ValidationError> {
-  return balances_validator(json).map((parsedData) =>
-    balances_from_parsed_data(label, parsedData),
-  );
+const balances_validator = object({
+  label: string,
+  data: array(object({ date, balance: record(number) })),
+});
+
+type ParsedLineChartData = { date: Date; balance: Record<string, number> }[];
+
+export class ParsedLineChart implements ParsedFavaChart {
+  readonly label: string | null;
+  readonly data: ParsedLineChartData;
+
+  constructor(label: string | null, data: ParsedLineChartData) {
+    this.label = label;
+    this.data = data;
+  }
+
+  static validator: Validator<ParsedLineChart> = (json) =>
+    balances_validator(json).map(
+      ({ label, data }) => new ParsedLineChart(label, data),
+    );
+
+  with_context(): LineChart {
+    const groups = new Map<string, LineChartDatum[]>();
+    for (const { date: date_val, balance } of this.data) {
+      Object.entries(balance).forEach(([currency, value]) => {
+        const group = groups.get(currency);
+        const datum = { date: date_val, value, name: currency };
+        if (group) {
+          group.push(datum);
+        } else {
+          groups.set(currency, [datum]);
+        }
+      });
+    }
+    const data = [...groups.entries()].map(([name, values]) => ({
+      name,
+      values,
+    }));
+
+    return new LineChart(this.label, data, (c, d) => [
+      domHelpers.t(c.amount(d.value, d.name)),
+      domHelpers.em(day(d.date)),
+    ]);
+  }
 }

--- a/frontend/src/charts/query-charts.ts
+++ b/frontend/src/charts/query-charts.ts
@@ -5,9 +5,9 @@ import type {
 } from "../reports/query/query_table.ts";
 import type { ChartContext } from "./context.ts";
 import type { HierarchyChart } from "./hierarchy.ts";
-import { hierarchy_from_parsed_data } from "./hierarchy.ts";
+import { ParsedHierarchyChart } from "./hierarchy.ts";
 import type { LineChart } from "./line.ts";
-import { balances_from_parsed_data } from "./line.ts";
+import { ParsedLineChart } from "./line.ts";
 
 /** Get the query chart, if possible, from a query result */
 export function getQueryChart(
@@ -29,14 +29,14 @@ export function getQueryChart(
       (account, d) => ({ account, balance: d?.balance ?? {} }),
     );
     root.account = "(root)";
-    return hierarchy_from_parsed_data(null, root, $chartContext);
+    return new ParsedHierarchyChart(null, root).with_context($chartContext);
   }
   if (first.dtype === "date" && second.dtype === "Inventory") {
     const bals = (table.rows as [Date, Inventory][]).map(([date, inv]) => ({
       date,
       balance: inv.value,
     }));
-    return balances_from_parsed_data(null, bals);
+    return new ParsedLineChart(null, bals).with_context();
   }
   return null;
 }

--- a/frontend/src/charts/scatterplot.ts
+++ b/frontend/src/charts/scatterplot.ts
@@ -1,6 +1,6 @@
-import type { Result } from "../lib/result.ts";
-import type { ValidationError } from "../lib/validation.ts";
+import type { Validator } from "../lib/validation.ts";
 import { array, date, object, string } from "../lib/validation.ts";
+import type { ParsedFavaChart } from "./index.ts";
 
 /** Data point for the scatterplot (events). */
 export interface ScatterPlotDatum {
@@ -9,26 +9,29 @@ export interface ScatterPlotDatum {
   readonly description: string;
 }
 
-export class ScatterPlot {
+const scatterplot_validator = object({
+  label: string,
+  data: array<ScatterPlotDatum>(
+    object({ type: string, date, description: string }),
+  ),
+});
+
+export class ScatterPlot implements ParsedFavaChart {
   readonly type = "scatterplot";
-  readonly name: string | null;
+  readonly label: string | null;
   readonly data: readonly ScatterPlotDatum[];
 
-  constructor(name: string | null, data: readonly ScatterPlotDatum[]) {
-    this.name = name;
+  constructor(label: string | null, data: readonly ScatterPlotDatum[]) {
+    this.label = label;
     this.data = data;
   }
-}
 
-const scatterplot_validator = array<ScatterPlotDatum>(
-  object({ type: string, date, description: string }),
-);
+  static validator: Validator<ScatterPlot> = (json) =>
+    scatterplot_validator(json).map(
+      ({ label, data }) => new ScatterPlot(label, data),
+    );
 
-export function scatterplot(
-  label: string | null,
-  json: unknown,
-): Result<ScatterPlot, ValidationError> {
-  return scatterplot_validator(json).map(
-    (value) => new ScatterPlot(label, value),
-  );
+  with_context(): this {
+    return this;
+  }
 }

--- a/frontend/src/lib/validation.ts
+++ b/frontend/src/lib/validation.ts
@@ -35,8 +35,8 @@ class TaggedUnionObjectValidationError extends ValidationError {
   }
 }
 class TaggedUnionInvalidTagValidationError extends ValidationError {
-  constructor() {
-    super("Validation of tagged union failed: invalid tag.");
+  constructor(tag: string) {
+    super(`Validation of tagged union failed: invalid tag ${tag}.`);
   }
 }
 class TaggedUnionValidationError extends ValidationError {
@@ -196,11 +196,11 @@ export function tagged_union<T>(
       return err(new TaggedUnionObjectValidationError());
     }
     const tag_value = json[tag];
-    if (
-      typeof tag_value !== "string" ||
-      !Object.hasOwn(validators, tag_value)
-    ) {
-      return err(new TaggedUnionInvalidTagValidationError());
+    if (typeof tag_value !== "string") {
+      return err(new TaggedUnionInvalidTagValidationError("- not a string"));
+    }
+    if (!Object.hasOwn(validators, tag_value)) {
+      return err(new TaggedUnionInvalidTagValidationError(tag_value));
     }
     const res = validators[tag_value as keyof T](json);
     return res.is_ok

--- a/frontend/src/reports/accounts/AccountReport.svelte
+++ b/frontend/src/reports/accounts/AccountReport.svelte
@@ -1,7 +1,5 @@
 <script lang="ts">
   import ChartSwitcher from "../../charts/ChartSwitcher.svelte";
-  import { chartContext } from "../../charts/context.ts";
-  import { parseChartData } from "../../charts/index.ts";
   import { urlForAccount } from "../../helpers.ts";
   import { _ } from "../../i18n.ts";
   import { is_non_empty } from "../../lib/array.ts";
@@ -21,16 +19,10 @@
   }: AccountReportProps = $props();
 
   let accumulate = $derived(report_type === "balances");
-
-  let chartData = $derived(
-    parseChartData(charts, $chartContext).unwrap_or(null),
-  );
   let interval_label = $derived(intervalLabel($interval).toLowerCase());
 </script>
 
-{#if chartData}
-  <ChartSwitcher charts={chartData} />
-{/if}
+<ChartSwitcher {charts} />
 
 <div class="droptarget" data-account-name={account}>
   <div class="headerline">

--- a/frontend/src/reports/accounts/index.ts
+++ b/frontend/src/reports/accounts/index.ts
@@ -1,6 +1,7 @@
 import { get_account_report } from "../../api/index.ts";
 import type { AccountBudget } from "../../api/validators.ts";
 import type { AccountTreeNode } from "../../charts/hierarchy.ts";
+import type { ParsedFavaChart } from "../../charts/index.ts";
 import { getUrlPath } from "../../helpers.ts";
 import { getURLFilters } from "../../stores/filters.ts";
 import { Route } from "../route.ts";
@@ -14,7 +15,7 @@ const to_report_type = (s: string | null): AccountReportType =>
 export interface AccountReportProps {
   account: string;
   report_type: AccountReportType;
-  charts: unknown;
+  charts: ParsedFavaChart[];
   journal: string | null;
   interval_balances: AccountTreeNode[] | null;
   dates: { begin: Date; end: Date }[] | null;

--- a/frontend/src/reports/commodities/index.ts
+++ b/frontend/src/reports/commodities/index.ts
@@ -1,6 +1,5 @@
 import { get_commodities } from "../../api/index.ts";
 import type { Commodities } from "../../api/validators.ts";
-import type { FavaChart } from "../../charts/index.ts";
 import { LineChart } from "../../charts/line.ts";
 import { domHelpers } from "../../charts/tooltip.ts";
 import { day } from "../../format.ts";
@@ -10,7 +9,7 @@ import { Route } from "../route.ts";
 import CommoditiesSvelte from "./Commodities.svelte";
 
 export interface CommoditiesReportProps {
-  charts: FavaChart[];
+  charts: LineChart[];
   commodities: Commodities;
 }
 

--- a/frontend/src/reports/tree_reports/BalanceSheet.svelte
+++ b/frontend/src/reports/tree_reports/BalanceSheet.svelte
@@ -1,21 +1,13 @@
 <script lang="ts">
   import ChartSwitcher from "../../charts/ChartSwitcher.svelte";
-  import { chartContext } from "../../charts/context.ts";
-  import { parseChartData } from "../../charts/index.ts";
   import TreeTable from "../../tree-table/TreeTable.svelte";
   import type { TreeReportProps } from "./index.ts";
 
   let { charts, trees, date_range }: TreeReportProps = $props();
   let end = $derived(date_range?.end ?? null);
-
-  let chartData = $derived(
-    parseChartData(charts, $chartContext).unwrap_or(null),
-  );
 </script>
 
-{#if chartData}
-  <ChartSwitcher charts={chartData} />
-{/if}
+<ChartSwitcher {charts} />
 
 <div class="row">
   <div class="column">

--- a/frontend/src/reports/tree_reports/IncomeStatement.svelte
+++ b/frontend/src/reports/tree_reports/IncomeStatement.svelte
@@ -1,21 +1,13 @@
 <script lang="ts">
   import ChartSwitcher from "../../charts/ChartSwitcher.svelte";
-  import { chartContext } from "../../charts/context.ts";
-  import { parseChartData } from "../../charts/index.ts";
   import TreeTable from "../../tree-table/TreeTable.svelte";
   import type { TreeReportProps } from "./index.ts";
 
   let { charts, trees, date_range }: TreeReportProps = $props();
   let end = $derived(date_range?.end ?? null);
-
-  let chartData = $derived(
-    parseChartData(charts, $chartContext).unwrap_or(null),
-  );
 </script>
 
-{#if chartData}
-  <ChartSwitcher charts={chartData} />
-{/if}
+<ChartSwitcher {charts} />
 
 <div class="row">
   <div class="column">

--- a/frontend/src/reports/tree_reports/TrialBalance.svelte
+++ b/frontend/src/reports/tree_reports/TrialBalance.svelte
@@ -1,21 +1,13 @@
 <script lang="ts">
   import ChartSwitcher from "../../charts/ChartSwitcher.svelte";
-  import { chartContext } from "../../charts/context.ts";
-  import { parseChartData } from "../../charts/index.ts";
   import TreeTable from "../../tree-table/TreeTable.svelte";
   import type { TreeReportProps } from "./index.ts";
 
   let { charts, trees, date_range }: TreeReportProps = $props();
   let end = $derived(date_range?.end ?? null);
-
-  let chartData = $derived(
-    parseChartData(charts, $chartContext).unwrap_or(null),
-  );
 </script>
 
-{#if chartData}
-  <ChartSwitcher charts={chartData} />
-{/if}
+<ChartSwitcher {charts} />
 
 <div class="row">
   {#each trees as tree (tree.account)}

--- a/frontend/src/reports/tree_reports/index.ts
+++ b/frontend/src/reports/tree_reports/index.ts
@@ -4,6 +4,7 @@ import {
   get_trial_balance,
 } from "../../api/index.ts";
 import type { AccountTreeNode } from "../../charts/hierarchy.ts";
+import type { ParsedFavaChart } from "../../charts/index.ts";
 import { _ } from "../../i18n.ts";
 import { getURLFilters } from "../../stores/filters.ts";
 import { Route } from "../route.ts";
@@ -12,7 +13,7 @@ import IncomeStatement from "./IncomeStatement.svelte";
 import TrialBalance from "./TrialBalance.svelte";
 
 export interface TreeReportProps {
-  charts: unknown;
+  charts: ParsedFavaChart[];
   trees: AccountTreeNode[];
   date_range: { begin: Date; end: Date } | null;
 }

--- a/frontend/src/svelte-custom-elements.ts
+++ b/frontend/src/svelte-custom-elements.ts
@@ -3,16 +3,14 @@
  */
 
 import { type Component, mount, unmount } from "svelte";
-import { get as store_get } from "svelte/store";
 
 import ChartSwitcher from "./charts/ChartSwitcher.svelte";
-import { chartContext } from "./charts/context.ts";
 import {
   account_hierarchy_validator,
   type AccountTreeNode,
 } from "./charts/hierarchy.ts";
-import type { FavaChart } from "./charts/index.ts";
-import { parseChartData } from "./charts/index.ts";
+import type { ParsedFavaChart } from "./charts/index.ts";
+import { chart_validator } from "./charts/index.ts";
 import { domHelpers } from "./charts/tooltip.ts";
 import type { Result } from "./lib/result.ts";
 import { log_error } from "./log.ts";
@@ -58,13 +56,10 @@ class SvelteCustomElementComponent<T extends Record<string, unknown>> {
 }
 
 const components = [
-  new SvelteCustomElementComponent<{ charts: readonly FavaChart[] }>(
+  new SvelteCustomElementComponent<{ charts: readonly ParsedFavaChart[] }>(
     "charts",
     ChartSwitcher,
-    (data) =>
-      parseChartData(data, store_get(chartContext)).map((charts) => ({
-        charts,
-      })),
+    (data) => chart_validator(data).map((charts) => ({ charts })),
   ),
   new SvelteCustomElementComponent<{ table: QueryResultTable }>(
     "query-table",

--- a/src/fava/application.py
+++ b/src/fava/application.py
@@ -49,7 +49,6 @@ from fava import template_filters
 from fava._ctx_globals_class import Context
 from fava.beans import funcs
 from fava.context import g
-from fava.core import conversion
 from fava.core import FavaLedger
 from fava.core.charts import FavaJSONProvider
 from fava.core.documents import is_document_or_import_file
@@ -232,7 +231,6 @@ def _setup_template_config(fava_app: Flask, *, incognito: bool) -> None:
     }
 
     # Add template filters
-    fava_app.add_template_filter(conversion.units)
     fava_app.add_template_filter(funcs.hash_entry)
     fava_app.add_template_filter(template_filters.basename)
     fava_app.add_template_filter(template_filters.flag_to_type)

--- a/src/fava/core/__init__.py
+++ b/src/fava/core/__init__.py
@@ -31,7 +31,7 @@ from fava.core.attributes import AttributesModule
 from fava.core.budgets import BudgetModule
 from fava.core.charts import ChartModule
 from fava.core.commodities import CommoditiesModule
-from fava.core.conversion import cost_or_value
+from fava.core.conversion import conversion_from_str
 from fava.core.extensions import ExtensionModule
 from fava.core.fava_options import parse_options
 from fava.core.file import _incomplete_sortkey
@@ -511,8 +511,9 @@ class FavaLedger:
                            the account.
 
         Yields:
-            Tuples of ``(entry, change, balance)``.
+            Tuples of ``(index, entry, change, balance)``.
         """
+        conv = conversion_from_str(conversion)
         relevant_account = account_tester(
             account_name, with_children=with_children
         )
@@ -536,8 +537,8 @@ class FavaLedger:
                 yield (
                     index,
                     entry,
-                    cost_or_value(change, conversion, prices, entry.date),
-                    cost_or_value(balance, conversion, prices, entry.date),
+                    conv.apply(change, prices, entry.date),
+                    conv.apply(balance, prices, entry.date),
                 )
 
     def get_entry(self, entry_hash: str) -> Directive:

--- a/src/fava/core/accounts.py
+++ b/src/fava/core/accounts.py
@@ -10,7 +10,7 @@ from fava.beans.abc import Balance
 from fava.beans.abc import Close
 from fava.beans.flags import FLAG_UNREALIZED
 from fava.beans.funcs import hash_entry
-from fava.core.conversion import units
+from fava.core.conversion import UNITS
 from fava.core.group_entries import group_entries_by_account
 from fava.core.group_entries import TransactionPosting
 from fava.core.module_base import FavaModule
@@ -72,7 +72,7 @@ def balance_string(tree_node: TreeNode) -> str:
     account = tree_node.name
     today = str(local_today())
     res = ""
-    for currency, number in units(tree_node.balance).items():
+    for currency, number in UNITS.apply(tree_node.balance).items():
         res += f"{today} balance {account:<28} {number:>15} {currency}\n"
     return res
 

--- a/src/fava/core/query.py
+++ b/src/fava/core/query.py
@@ -11,7 +11,7 @@ from beancount.core.amount import Amount
 from beancount.core.inventory import Inventory
 from beancount.core.position import Position
 
-from fava.core.conversion import simple_units
+from fava.core.conversion import UNITS
 
 if TYPE_CHECKING:  # pragma: no cover
     from typing import Any
@@ -155,7 +155,7 @@ class InventoryColumn(BaseColumn):
         val: Inventory | None,
     ) -> SimpleCounterInventory | None:
         """Serialise an inventory."""
-        return simple_units(val) if val is not None else None
+        return UNITS.apply_inventory(val) if val is not None else None
 
 
 COLUMNS = {

--- a/src/fava/ext/fava_ext_test/__init__.py
+++ b/src/fava/ext/fava_ext_test/__init__.py
@@ -17,7 +17,6 @@ from flask import jsonify
 
 from fava.context import g
 from fava.core.charts import DateAndBalance
-from fava.core.conversion import cost_or_value
 from fava.core.inventory import SimpleCounterInventory
 from fava.core.query import DecimalColumn
 from fava.core.query import QueryResultTable
@@ -59,7 +58,7 @@ def _portfolio_data(nodes: list[TreeNode]) -> QueryResultTable:
     account_balances: list[tuple[str, Decimal | None]] = []
     total = Decimal()
     for node in nodes:
-        balance = cost_or_value(node.balance, g.conv, g.ledger.prices)
+        balance = g.conv.apply(node.balance, g.ledger.prices)
         if currency in balance:
             balance_dec = balance[currency]
             total += balance_dec

--- a/src/fava/internal_api.py
+++ b/src/fava/internal_api.py
@@ -19,7 +19,6 @@ from fava.util.excel import HAVE_EXCEL
 
 if TYPE_CHECKING:  # pragma: no cover
     from collections.abc import Sequence
-    from datetime import date
     from typing import Literal
 
     from fava.beans.abc import Meta
@@ -31,6 +30,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from fava.core.fava_options import FavaOptions
     from fava.core.tree import SerialisedTreeNode
     from fava.helpers import BeancountError
+    from fava.util.date import DateRange
     from fava.util.date import Interval
 
 
@@ -180,8 +180,8 @@ class ChartApi:
     @staticmethod
     def hierarchy(
         account_name: str,
-        begin_date: date | None = None,
-        end_date: date | None = None,
+        *,
+        date_range: DateRange | None = None,
         label: str | None = None,
     ) -> ChartData:
         """Generate data for an account hierarchy chart."""
@@ -191,8 +191,7 @@ class ChartApi:
                 g.filtered,
                 account_name,
                 g.conv,
-                begin_date,
-                end_date or g.filtered.end_date,
+                date_range,
             ),
         )
 

--- a/src/fava/json_api.py
+++ b/src/fava/json_api.py
@@ -30,7 +30,7 @@ from fava.beans.abc import Document
 from fava.beans.abc import Event
 from fava.context import g
 from fava.core import EntryNotFoundForHashError
-from fava.core.conversion import units
+from fava.core.conversion import UNITS
 from fava.core.documents import filepath_in_document_folder
 from fava.core.documents import is_document_or_import_file
 from fava.core.filters import FilterError
@@ -745,8 +745,7 @@ def get_account_report() -> AccountReportJournal | AccountReportTree:
         charts.extend(
             ChartApi.hierarchy(
                 account_name,
-                date_range.begin,
-                date_range.end,
+                date_range=date_range,
                 label=g.interval.format_date(date_range.begin),
             )
             for date_range in dates[:3]
@@ -783,7 +782,7 @@ def get_account_report() -> AccountReportJournal | AccountReportTree:
             charts,
             interval_balances=[
                 tree.get(account_name).serialise(
-                    g.conversion,
+                    g.conv,
                     g.ledger.prices,
                     date_range.end_inclusive,
                     with_cost=False,
@@ -801,7 +800,7 @@ def get_account_report() -> AccountReportJournal | AccountReportTree:
         g.ledger.account_journal(
             g.filtered,
             account_name,
-            g.conversion,
+            g.conv,
             with_children=g.ledger.fava_options.account_journal_include_children,
         )
     )
@@ -833,7 +832,7 @@ def get_statistics() -> Statistics:
     }
 
     balances = {
-        account_name: units(node.balance)
+        account_name: UNITS.apply(node.balance)
         for account_name, node in g.filtered.root_tree.items()
     }
 

--- a/tests/test_core_charts.py
+++ b/tests/test_core_charts.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from decimal import Decimal
 from typing import TYPE_CHECKING
 
+from fava.core.conversion import AT_COST
 from fava.util.date import Day
 from fava.util.date import Month
 
@@ -91,7 +92,7 @@ def test_net_worth_off_by_one(
 
 def test_hierarchy(example_ledger: FavaLedger) -> None:
     filtered = example_ledger.get_filtered()
-    data = example_ledger.charts.hierarchy(filtered, "Assets", "at_cost")
+    data = example_ledger.charts.hierarchy(filtered, "Assets", AT_COST)
     assert data.balance_children == {
         "IRAUSD": Decimal("7200.00"),
         "USD": Decimal("94320.27840"),

--- a/tests/test_core_conversion.py
+++ b/tests/test_core_conversion.py
@@ -15,9 +15,10 @@ from fava.core.conversion import _CurrencyConversion
 from fava.core.conversion import Conversion
 from fava.core.conversion import conversion_from_str
 from fava.core.conversion import convert_position
+from fava.core.conversion import cost_or_value
 from fava.core.conversion import get_cost
 from fava.core.conversion import get_market_value
-from fava.core.conversion import get_units
+from fava.core.conversion import UNITS
 from fava.core.inventory import _Amount
 from fava.core.inventory import _Cost
 from fava.core.inventory import _Position
@@ -95,7 +96,9 @@ def test_conversion_from_string(
     ],
 )
 def test_get_units(position: str, expected: str) -> None:
-    assert get_units(_pos(position)) == _amt(expected)
+    inv = _inv(position)
+    res = _simple_inv(expected)
+    assert UNITS.apply(inv) == res
 
 
 @pytest.mark.parametrize(
@@ -221,8 +224,6 @@ def test_conversion(
     )
     inv = _inv(inventory)
     conv = conversion_from_str(conversion)
-    assert conv.apply(
-        inv,
-        prices=prices,
-        date=conversion_date,
-    ) == _simple_inv(expected)
+    res = _simple_inv(expected)
+    assert conv.apply(inv, prices=prices, date=conversion_date) == res
+    assert cost_or_value(inv, conv, prices=prices, date=conversion_date) == res


### PR DESCRIPTION
This centralises adding the context in the components rendering the
charts and simplifies the reports using charts.

Also optimise some of the conversion logic and fix an off-by-one bug
with the hierarchy charts.

<!--
Hi, thank you for opening a PR!

Please ensure that your change passes tests and the various linters by running
`make test` and `make lint`. If testable, your changes should be covered by
unit tests.

Explain your changes below and link to related issues.
-->
