### PR TITLE
api: simplify; add tests for fetch logic

### DIFF
--- a/frontend/src/charts/ConversionAndInterval.svelte
+++ b/frontend/src/charts/ConversionAndInterval.svelte
@@ -1,6 +1,11 @@
 <script lang="ts">
   import { _, format } from "../i18n.ts";
-  import { getInterval, intervalLabel, INTERVALS } from "../lib/interval.ts";
+  import {
+    DEFAULT_INTERVAL,
+    getInterval,
+    intervalLabel,
+    INTERVALS,
+  } from "../lib/interval.ts";
   import { router } from "../router.ts";
   import { conversions } from "../stores/chart.ts";
   import { conversion, interval } from "../stores/url.ts";
@@ -27,7 +32,7 @@
   bind:value={
     () => $conversion,
     (value: string) => {
-      router.set_search_param("conversion", value);
+      router.set_search_param("conversion", value === "at_cost" ? "" : value);
     }
   }
   options={$conversions}
@@ -39,7 +44,10 @@
   bind:value={
     () => $interval,
     (value: string) => {
-      router.set_search_param("interval", value);
+      router.set_search_param(
+        "interval",
+        value === DEFAULT_INTERVAL ? "" : value,
+      );
     }
   }
   options={INTERVALS}

--- a/frontend/src/editor/DocumentPreviewEditor.svelte
+++ b/frontend/src/editor/DocumentPreviewEditor.svelte
@@ -6,7 +6,7 @@
 <script lang="ts">
   import { replaceContents } from "../codemirror/editor-transactions.ts";
   import { initDocumentPreviewEditor } from "../codemirror/setup.ts";
-  import { fetch, handleText } from "../lib/fetch.ts";
+  import { fetch_text } from "../lib/fetch.ts";
 
   interface Props {
     /** The URL to load the editor contents from. */
@@ -24,11 +24,9 @@
   };
 
   $effect(() => {
-    fetch(url)
-      .then(handleText)
-      .then(set_editor_content, () => {
-        set_editor_content(`Loading ${url} failed...`);
-      });
+    fetch_text(url).then(set_editor_content, () => {
+      set_editor_content(`Loading ${url} failed...`);
+    });
   });
 </script>
 

--- a/frontend/src/extensions.ts
+++ b/frontend/src/extensions.ts
@@ -6,7 +6,6 @@
 import { get as store_get } from "svelte/store";
 
 import { getUrlPath, urlForRaw } from "./helpers.ts";
-import { fetch } from "./lib/fetch.ts";
 import { log_error } from "./log.ts";
 import { extensions } from "./stores/index.ts";
 

--- a/frontend/src/helpers.ts
+++ b/frontend/src/helpers.ts
@@ -6,17 +6,23 @@ import { use_external_editor } from "./stores/fava_options.ts";
 import { base_url } from "./stores/index.ts";
 import { syncedSearchParams } from "./stores/url.ts";
 
+class NonRelativeUrlPathError extends Error {
+  constructor(pathname: string, $base_url: string) {
+    super(`Path '${pathname}' not relative to base url '${$base_url}'.`);
+  }
+}
+
 /**
  * Get the URL path relative to the base url of the current ledger.
  */
 export function getUrlPath(
   url: Pick<URL | Location, "pathname">,
-): Result<string, string> {
+): Result<string, NonRelativeUrlPathError> {
   const { pathname } = url;
   const $base_url = store_get(base_url);
   return $base_url && pathname.startsWith($base_url)
     ? ok(decodeURI(pathname.slice($base_url.length)))
-    : err(`Path '${pathname}' not relative to base url '${$base_url}'.`);
+    : err(new NonRelativeUrlPathError(pathname, $base_url));
 }
 
 /**

--- a/frontend/src/journal/index.ts
+++ b/frontend/src/journal/index.ts
@@ -3,7 +3,7 @@ import { mount, unmount } from "svelte";
 import { get as store_get } from "svelte/store";
 
 import { delegate } from "../lib/events.ts";
-import { fetch, handleText } from "../lib/fetch.ts";
+import { fetch_text } from "../lib/fetch.ts";
 import { log_error } from "../log.ts";
 import { notify_err } from "../notifications.ts";
 import { router } from "../router.ts";
@@ -131,22 +131,20 @@ export class FavaJournal extends HTMLElement {
     let errorShown = false;
 
     const promises = pages_and_urls.map(async ([page, page_url]) => {
-      return fetch(page_url)
-        .then(handleText)
-        .then(
-          (html) => {
-            const doc = parser.parseFromString(html, "text/html");
-            return doc.querySelectorAll("ol.journal > li:not(.head)");
-          },
-          (error: unknown) => {
-            log_error(`Failed to fetch page ${page.toString()}`, error);
-            if (!errorShown) {
-              notify_err(new Error("Failed to fetch some journal pages"));
-              errorShown = true;
-            }
-            return [];
-          },
-        );
+      return fetch_text(page_url).then(
+        (html) => {
+          const doc = parser.parseFromString(html, "text/html");
+          return doc.querySelectorAll("ol.journal > li:not(.head)");
+        },
+        (error: unknown) => {
+          log_error(`Failed to fetch page ${page.toString()}`, error);
+          if (!errorShown) {
+            notify_err(new Error("Failed to fetch some journal pages"));
+            errorShown = true;
+          }
+          return [];
+        },
+      );
     });
 
     let sorting = false;

--- a/frontend/src/lib/fetch.ts
+++ b/frontend/src/lib/fetch.ts
@@ -1,73 +1,65 @@
-import { log_error } from "../log.ts";
-import { set_mtime } from "../stores/mtime.ts";
-import {
-  defaultValue,
-  isJsonObject,
-  object,
-  string,
-  unknown,
-} from "./validation.ts";
+import { isJsonObject, object, string } from "./validation.ts";
 
-class FetchError extends Error {}
+export class FetchError extends Error {}
 
-/** Wrapper around fetch with some default options */
-export async function fetch(
-  input: string | URL,
-  init: RequestInit = {},
-): Promise<Response> {
-  return window.fetch(input, { credentials: "same-origin", ...init });
+export class FetchHTTPError extends FetchError {
+  readonly status: number;
+
+  constructor(message: string | null, status: number) {
+    super(
+      message != null
+        ? `HTTP ${status.toString()} - ${message}`
+        : `HTTP ${status.toString()}`,
+    );
+    this.status = status;
+  }
 }
 
+export class FetchInvalidResponseError extends FetchError {
+  constructor(msg: string) {
+    super(`Invalid response: ${msg}`);
+  }
+}
+
+const error_response_validator = object({ error: string });
+
 /**
- * Handles JSON content for a Promise returned by fetch, also handling an HTTP
- * error status.
+ * Fetch JSON content, also handling an HTTP error status.
+ *
+ * Checks for an object at the top JSON level. For errors, looks
+ * for an error message like `{ "error": "error message" }
  */
-async function handleJSON(
-  response: Response,
+export async function fetch_json(
+  input: URL,
+  init?: RequestInit,
 ): Promise<Record<string, unknown>> {
-  const data: unknown = await response.json().catch(() => null);
+  const response = await fetch(input, init);
+  const json: unknown = await response.json().catch(() => null);
   if (!response.ok) {
-    throw new FetchError(
-      isJsonObject(data) && typeof data.error === "string"
-        ? data.error
-        : response.statusText,
+    throw new FetchHTTPError(
+      error_response_validator(json)
+        .map((d) => d.error)
+        .unwrap_or(null),
+      response.status,
     );
   }
-  if (!isJsonObject(data)) {
-    throw new FetchError("Invalid response: not a valid JSON object");
+  if (!isJsonObject(json)) {
+    throw new FetchInvalidResponseError("Not a valid JSON object");
   }
-  return data;
-}
-
-const response_validator = object({
-  data: unknown,
-  mtime: defaultValue(string, () => null),
-});
-
-export async function fetchJSON(
-  input: string,
-  init?: RequestInit,
-): Promise<unknown> {
-  const res = await fetch(input, init).then(handleJSON);
-  const validated = response_validator(res).unwrap_or(null);
-  if (validated) {
-    if (typeof validated.mtime === "string") {
-      set_mtime(validated.mtime);
-    }
-    return validated.data;
-  }
-  log_error(res);
-  throw new FetchError("Invalid response: missing data or mtime key.");
+  return json;
 }
 
 /**
- * Handles text content for a Promise returned by fetch, also handling an HTTP
- * error status.
+ * Fetch text content, also handling an HTTP error status.
  */
-export async function handleText(response: Response): Promise<string> {
+export async function fetch_text(
+  input: string | URL,
+  init?: RequestInit,
+): Promise<string> {
+  const response = await fetch(input, init);
   if (!response.ok) {
-    const msg = await response.text().catch(() => response.statusText);
-    throw new FetchError(msg);
+    const message = await response.text().catch(() => null);
+    throw new FetchHTTPError(message, response.status);
   }
   return response.text();
 }

--- a/frontend/src/lib/result.ts
+++ b/frontend/src/lib/result.ts
@@ -28,7 +28,7 @@ interface BaseResult<T, E> {
   or_else<F>(op: (v: E) => T): Result<T, F>;
 
   /** Returns the contained Ok value or throw an Error for Err. */
-  unwrap(): T;
+  unwrap(unwrap_error?: new (error: E) => Error): T;
 
   /** Returns the contained Err value or throw an Error for Ok. */
   unwrap_err(): E;
@@ -105,7 +105,10 @@ export class Err<E> implements BaseResult<never, E> {
     return new Err(op(this.error));
   }
 
-  unwrap(): never {
+  unwrap(unwrap_error?: new (error: E) => Error): never {
+    if (unwrap_error) {
+      throw new unwrap_error(this.error);
+    }
     throw new Error("unwrap() called on error.");
   }
 

--- a/frontend/src/reports/route.ts
+++ b/frontend/src/reports/route.ts
@@ -2,7 +2,7 @@ import { type Component, mount, unmount } from "svelte";
 
 import { _ } from "../i18n.ts";
 import { getScriptTagValue } from "../lib/dom.ts";
-import { fetch, handleText } from "../lib/fetch.ts";
+import { fetch_text } from "../lib/fetch.ts";
 import { string } from "../lib/validation.ts";
 import { read_mtime } from "../stores/mtime.ts";
 import ReportLoadError from "./ReportLoadError.svelte";
@@ -65,7 +65,7 @@ class BackendRoute implements BaseRoute {
     }
     const get_url = new URL(url);
     get_url.searchParams.set("partial", "true");
-    const content = await fetch(get_url).then(handleText);
+    const content = await fetch_text(get_url);
     if (previous.route !== this) {
       previous.destroy();
     }

--- a/frontend/test/misc.test.ts
+++ b/frontend/test/misc.test.ts
@@ -1,9 +1,14 @@
-import { deepEqual, equal, ok } from "node:assert/strict";
+import { deepEqual, equal, ok, rejects } from "node:assert/strict";
 import { test } from "node:test";
 
 import { is_non_empty, last_element, move } from "../src/lib/array.ts";
 import { shallow_equal } from "../src/lib/equals.ts";
 import { errorWithCauses } from "../src/lib/errors.ts";
+import {
+  fetch_json,
+  fetch_text,
+  FetchInvalidResponseError,
+} from "../src/lib/fetch.ts";
 import { getInterval } from "../src/lib/interval.ts";
 import { parseJSON } from "../src/lib/json.ts";
 import { is_empty } from "../src/lib/objects.ts";
@@ -59,4 +64,64 @@ test("print out error with causes", () => {
 
   equal(errorWithCauses(err1), "a reason");
   equal(errorWithCauses(err2), "b reason\n  Caused by: a reason");
+});
+
+test("request handling - successful JSON response", async (t) => {
+  const url = new URL("https://localhost");
+  t.mock.method(
+    globalThis,
+    "fetch",
+    () => new Response(JSON.stringify({ data: "some data" }), { status: 200 }),
+  );
+  const response = await fetch_json(url);
+  equal(response.data, "some data");
+});
+
+test("request handling - successful text response", async (t) => {
+  const url = new URL("https://localhost");
+  t.mock.method(
+    globalThis,
+    "fetch",
+    () => new Response("some string", { status: 200 }),
+  );
+  const response = await fetch_text(url);
+  equal(response, "some string");
+});
+
+test("request handling - non-JSON response", async (t) => {
+  const url = new URL("https://localhost");
+  t.mock.method(
+    globalThis,
+    "fetch",
+    () => new Response("nojson", { status: 200 }),
+  );
+  await rejects(fetch_json(url), FetchInvalidResponseError);
+});
+
+test("request handling - HTTP errors on in handleText", async (t) => {
+  const url = new URL("https://localhost");
+  t.mock.method(
+    globalThis,
+    "fetch",
+    () => new Response("some message", { status: 401 }),
+  );
+  await rejects(fetch_text(url), {
+    message: "HTTP 401 - some message",
+  });
+});
+
+test("request handling - HTTP errors on fetchJSON", async (t) => {
+  const url = new URL("https://localhost");
+  t.mock.method(
+    globalThis,
+    "fetch",
+    () =>
+      new Response(JSON.stringify({ error: "some message" }), { status: 401 }),
+  );
+  await rejects(fetch_json(url), { message: "HTTP 401 - some message" });
+
+  t.mock.method(globalThis, "fetch", () => {
+    throw new TypeError();
+  });
+  await rejects(fetch_json(url), TypeError);
 });

--- a/frontend/test/result.test.ts
+++ b/frontend/test/result.test.ts
@@ -4,7 +4,7 @@ import { test } from "node:test";
 import type { Result } from "../src/lib/result.ts";
 import { collect, Err, err, Ok, ok as res_ok } from "../src/lib/result.ts";
 
-test("basic result operations", () => {
+test("basic ok result operations", () => {
   const obj = { a: "a" };
   const ok_obj = res_ok(obj);
   ok(ok_obj instanceof Ok);
@@ -12,17 +12,33 @@ test("basic result operations", () => {
   equal(ok_obj.is_err, false);
   equal(ok_obj.or_else(), ok_obj);
   equal(ok_obj.unwrap(), obj);
+  equal(ok_obj.map_err(), ok_obj);
   equal(ok_obj.unwrap_or(), obj);
   throws(() => ok_obj.unwrap_err());
   equal(ok_obj.and_then((obj) => res_ok(obj.a)).unwrap(), "a");
+});
 
+test("basic err result operations", () => {
+  const obj = { a: "a" };
   const err_obj: Result<unknown, unknown> = err(obj);
   ok(err_obj instanceof Err);
   equal(err_obj.is_ok, false);
   equal(err_obj.is_err, true);
+  equal(err_obj.unwrap_or("asdf"), "asdf");
+  deepEqual(
+    err_obj.or_else(() => res_ok("asdf")),
+    res_ok("asdf"),
+  );
   equal(err_obj.and_then(), err_obj);
+  equal(err_obj.map_err(() => "test").unwrap_err(), "test");
   equal(err_obj.unwrap_err(), obj);
   equal(err_obj.unwrap_or(null), null);
+  class CustomError extends Error {
+    constructor() {
+      super("error msg");
+    }
+  }
+  throws(() => err_obj.unwrap(CustomError), CustomError);
   throws(() => err_obj.unwrap());
 });
 


### PR DESCRIPTION
The tests highlighted some dead code and allowed streamlining the logic.

Also, the credentials: 'same-origin' is the default according to MDN, so
there does not seem to be the need for the fetch wrapper.

<!--
Hi, thank you for opening a PR!

Please ensure that your change passes tests and the various linters by running
`make test` and `make lint`. If testable, your changes should be covered by
unit tests.

Explain your changes below and link to related issues.
-->
