### PR TITLE
Enforce minimum node version to prevent Error 'TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension ".ts"'

### DIFF
--- a/frontend/.npmrc
+++ b/frontend/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true


### PR DESCRIPTION
To prevent others from making the same rookie mistake like me in #2142, this simple patch makes the check for the minimal node version mandatory. 

There is a failing test, but given that I have edited no code and just added a 1-line file `frontend/.npmrc`, it seems unrelated:

```
test at test/store.test.ts:32:1
✖ localStorage-synced stores (4.460862ms)
  SecurityError: Cannot initialize local storage without a `--localstorage-file` path
      at Object.get [as localStorage] (node:internal/webstorage:28:17)
      at get localStorage (node:internal/util:660:20)
      at TestContext.<anonymous> (file:///opt/beancount/fava/frontend/test/store.test.ts:38:3)
      at Test.runInAsyncScope (node:async_hooks:213:14)
      at Test.run (node:internal/test_runner/test:1106:25)
      at async Test.processPendingSubtests (node:internal/test_runner/test:788:7)
make: *** [Makefile:58: test-js] Fehler 1
```

<!--
Hi, thank you for opening a PR!

Please ensure that your change passes tests and the various linters by running
`make test` and `make lint`. If testable, your changes should be covered by
unit tests.

Explain your changes below and link to related issues.
-->
