### PR TITLE
Fix Tab key navigation in metadata form after key editing

### DIFF
--- a/frontend/src/entry-forms/EntryMetadata.svelte
+++ b/frontend/src/entry-forms/EntryMetadata.svelte
@@ -11,7 +11,7 @@
   let meta_entries = $derived(meta.entries());
 </script>
 
-{#each meta_entries as [key, value], index (key)}
+{#each meta_entries as [key, value], index (index)}
   <div class="flex-row">
     <button
       type="button"


### PR DESCRIPTION
Change the each block key from '(key)' to '(index)' to prevent DOM element remounting when the key value changes, which was breaking Tab navigation from key input to value input after editing the key field.

<!--
Hi, thank you for opening a PR!

Please ensure that your change passes tests and the various linters by running
`make test` and `make lint`. If testable, your changes should be covered by
unit tests.

Explain your changes below and link to related issues.
-->
