### PR TITLE
fix: narration isn't stored when the focus is on the narration input

### DIFF
--- a/frontend/src/entry-forms/Transaction.svelte
+++ b/frontend/src/entry-forms/Transaction.svelte
@@ -129,7 +129,13 @@
       <AutocompleteInput
         className="narration"
         placeholder={_("Narration")}
-        bind:value={narration}
+        bind:value={
+          () => entry.narration,
+          (newNarration: string) => {
+            narration = newNarration;
+            entry = entry.set_narration_tags_links(narration);
+          }
+        }
         suggestions={narration_suggestions}
         onSelect={autocompleteSelectNarration}
         onBlur={() => {


### PR DESCRIPTION
This PR fixes an issue:

If you type text in the narration text field in the Add Entry dialog, then press Enter within the narration text field, the narration text is not saved.