### PR TITLE
fix: update narration tags/links on Enter key press

### DIFF
--- a/frontend/src/entry-forms/Transaction.svelte
+++ b/frontend/src/entry-forms/Transaction.svelte
@@ -132,6 +132,9 @@
         bind:value={narration}
         suggestions={narration_suggestions}
         onSelect={autocompleteSelectNarration}
+        onEnter={() => {
+          entry = entry.set_narration_tags_links(narration);
+        }}
         onBlur={() => {
           entry = entry.set_narration_tags_links(narration);
         }}


### PR DESCRIPTION
Add onEnter handler to narration input in Transaction.svelte to ensure
narration tags and links are processed when the user presses Enter.


<!--
Hi, thank you for opening a PR!

Please ensure that your change passes tests and the various linters by running
`make test` and `make lint`. If testable, your changes should be covered by
unit tests.

Explain your changes below and link to related issues.
-->
