### PR TITLE
Fix failing tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -184,7 +184,7 @@ def snapshot(
         out = re.sub(r"mtime=\d+", "mtime=MTIME", out)
         out = re.sub(r'id="ledger-mtime">\d+', 'id="ledger-mtime">MTIME', out)
         # replace env-dependant info
-        out = out.replace('have_excel": false', 'have_excel": true')
+        out = re.sub(r'have_excel":\s*(false|False)', 'have_excel": true', out)
 
         for dir_path, replacement in [
             (f"{test_data_dir}{os.sep}", "TEST_DATA_DIR/"),


### PR DESCRIPTION
I'm trying to update fava package in nixpkgs to v1.30.9 because v1.30.7 fails to build with Python 3.14. This was addressed in https://github.com/beancount/fava/commit/91fba48fe22f5061b03b2f4d0f7ea3624d0f3a1b. However when trying to build v1.30.8 or v1.30.9 I get a bunch of failing tests
```
_____________________________ test_get_ledger_data _____________________________

app = <Flask 'fava'>
snapshot = <function snapshot.<locals>.snapshot_data at 0x1071af950>

    def test_get_ledger_data(app: Flask, snapshot: SnapshotFunc) -> None:
        """The currently filtered journal can be downloaded."""
        with app.test_request_context("/long-example/"):
            app.preprocess_request()
>           snapshot(get_ledger_data(), json=True)

tests/test_internal_api.py:24:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
tests/conftest.py:202: in snapshot_data
    compare_snapshot(filename, out, json=json)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

name = 'test_internal_api-test_get_ledger_data.json'
expected = '{"account_details":{"Assets:Testing:MultipleCommodities":{"balance_string":null,"close_date":null,"last_entry":{"date...va","query_string":"journal"}],"years":["2016","2015","2014","2009","2007","2004","2000","1995","1980","1900","1792"]}'

    def check_snapshot(name: str, expected: str, *, json: bool) -> None:
        snap_file = snap_dir / name
        seen_snapshots.add(snap_file)

        contents = snap_file.read_text("utf-8") if snap_file.exists() else ""
        expected_to_compare = loads(expected) if json else expected
        contents_to_compare = (
            loads(contents) if json and contents else contents
        )
        if should_update:
            if expected_to_compare != contents_to_compare:
                snap_file.write_text(expected, "utf-8")
        else:
>           assert expected_to_compare == contents_to_compare, (
                "Snaphot test failed. Snapshots can be updated with "
                "`pytest --snapshot-update`"
            )
E           AssertionError: Snaphot test failed. Snapshots can be updated with `pytest --snapshot-update`
E           assert {'account_det...D', ...], ...} == {'account_det...D', ...], ...}
E
E             Omitting 19 identical items, use -vv to show
E             Differing items:
E             {'have_excel': False} != {'have_excel': True}
E             Use -v to get more diff

tests/conftest.py:114: AssertionError
```

This PR makes replacement case-insensitive and allows tests to pass without an error. Feel free to suggest a better way if possible.
