### PR TITLE
ci: use trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,6 +17,11 @@ permissions:
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest
+    environment:
+      name: pypi
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
@@ -37,7 +42,4 @@ jobs:
       - run: git diff --exit-code
       - name: Publish release
         if: github.event_name == 'push' && github.ref_type == 'tag'
-        env:
-          UV_PUBLISH_USERNAME: __token__
-          UV_PUBLISH_PASSWORD: ${{ secrets.PYPI_TOKEN }}
         run: uv publish


### PR DESCRIPTION
> This approach eliminates the security risks associated with long-lived write tokens, which can be compromised, accidentally exposed in logs, or require manual rotation. (https://docs.npmjs.com/trusted-publishers#how-trusted-publishing-works)

Someone who is an administrator of the `fava` package will need to finish setting this up: https://docs.astral.sh/uv/guides/integration/github/#publishing-to-pypi

<!--
Hi, thank you for opening a PR!

Please ensure that your change passes tests and the various linters by running
`make test` and `make lint`. If testable, your changes should be covered by
unit tests.

Explain your changes below and link to related issues.
-->
