### PR TITLE
fix: Error when encountering multiple importers with same name.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -248,6 +248,7 @@ max-args = 9
 "tests/conftest.py" = ["S101"]
 "tests/test_*.py" = ["D", "PLC2701", "S101", "SLF001"]
 "tests/data/import_config.py" = ["D", "INP", "S101"]
+"tests/data/import_config_with_duplicate_names.py" = ["INP"]
 "src/fava/core/filters.py" = ["D"]
 
 # pylint is not run as part of linting for Fava anymore but we keep these disables

--- a/src/fava/core/ingest.py
+++ b/src/fava/core/ingest.py
@@ -361,6 +361,9 @@ def load_import_config(
             )
             raise ImportConfigLoadError(msg)
         wrapped_importer = WrappedImporter(importer)
+        if wrapped_importer.name in importers:
+            msg = f"Duplicate importer name found: {wrapped_importer.name}"
+            raise ImportConfigLoadError(msg)
         importers[wrapped_importer.name] = wrapped_importer
     return importers, hooks
 

--- a/tests/__snapshots__/test_json_api-test_api_imports.json
+++ b/tests/__snapshots__/test_json_api-test_api_imports.json
@@ -70,6 +70,11 @@
     "name": "TEST_DATA_DIR/import_config.py"
   },
   {
+    "basename": "import_config_with_duplicate_names.py",
+    "importers": [],
+    "name": "TEST_DATA_DIR/import_config_with_duplicate_names.py"
+  },
+  {
     "basename": "invalid-unicode.beancount",
     "importers": [],
     "name": "TEST_DATA_DIR/invalid-unicode.beancount"

--- a/tests/data/import_config_with_duplicate_names.py
+++ b/tests/data/import_config_with_duplicate_names.py
@@ -1,0 +1,34 @@
+"""Test importer config having multiple importers with same name."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from beangulp import Importer
+
+try:
+    from typing import override
+except ImportError:
+    from typing_extensions import override
+
+
+class TestImporter(Importer):
+    """Simple importer using string in filename to distinguish accounts."""
+
+    def __init__(self, account: str, file_id: str) -> None:
+        self._account = account
+        self._file_id = file_id
+
+    @override
+    def identify(self, filepath: str) -> bool:
+        return self._file_id in Path(filepath).name
+
+    @override
+    def account(self, filepath: str) -> str:
+        return self._account
+
+
+CONFIG: list[Importer] = [
+    TestImporter(account="Assets:Checking", file_id="1111"),
+    TestImporter(account="Assets:Savings", file_id="8888"),
+]

--- a/tests/test_core_ingest.py
+++ b/tests/test_core_ingest.py
@@ -149,6 +149,14 @@ def test_load_import_config() -> None:
     with pytest.raises(ImportConfigLoadError, match=r"CONFIG is missing"):
         load_import_config(Path(__file__))
 
+    with pytest.raises(
+        ImportConfigLoadError, match=r"Duplicate importer name found"
+    ):
+        load_import_config(
+            Path(__file__).parent
+            / Path("data/import_config_with_duplicate_names.py")
+        )
+
 
 def test_ingest_no_config(small_example_ledger: FavaLedger) -> None:
     assert small_example_ledger.ingest.import_data() == []


### PR DESCRIPTION
When loading importers from the CONFIG list in an import_config file and finding multiple importers with the same name raise an ImportConfigLoadError. Fixes #2186 by raising an error.

