### PR TITLE
Track currently-selected chart name and chart mode in URL parameters

### DIFF
--- a/frontend/src/charts/BarChart.svelte
+++ b/frontend/src/charts/BarChart.svelte
@@ -6,6 +6,7 @@
   import { urlForAccount } from "../helpers.ts";
   import { barChartMode, chartToggledCurrencies } from "../stores/chart.ts";
   import { ctx, currentTimeFilterDateFormat, short } from "../stores/format.ts";
+  import { url_chart_mode } from "../stores/url.ts";
   import Axis from "./Axis.svelte";
   import type { BarChart } from "./bar.ts";
   import {
@@ -44,10 +45,19 @@
     Math.min(width - margin.left - margin.right, maxWidth),
   );
 
-  /** Whether to display stacked bars. */
-  let showStackedBars = $derived(
-    $barChartMode === "stacked" && chart.hasStackedData,
+  // URL chart_mode takes precedence over store value if it's a valid bar mode
+  const valid_bar_modes = ["stacked", "single"] as const;
+  let mode = $derived(
+    $url_chart_mode != null &&
+      valid_bar_modes.includes(
+        $url_chart_mode as (typeof valid_bar_modes)[number],
+      )
+      ? ($url_chart_mode as (typeof valid_bar_modes)[number])
+      : $barChartMode,
   );
+
+  /** Whether to display stacked bars. */
+  let showStackedBars = $derived(mode === "stacked" && chart.hasStackedData);
   /** The currently hovered account. */
   let highlighted: string | null = $state(null);
 

--- a/frontend/src/charts/Chart.svelte
+++ b/frontend/src/charts/Chart.svelte
@@ -1,14 +1,16 @@
 <script lang="ts">
   import type { Snippet } from "svelte";
 
+  import { getUrlPath } from "../helpers.ts";
   import { router } from "../router.ts";
   import {
     barChartMode,
     chartToggledCurrencies,
     hierarchyChartMode,
+    lastActiveChartModePerReport,
     lineChartMode,
   } from "../stores/chart.ts";
-  import { show_charts } from "../stores/url.ts";
+  import { current_url, show_charts, url_chart_mode } from "../stores/url.ts";
   import BarChart from "./BarChart.svelte";
   import ChartLegend from "./ChartLegend.svelte";
   import HierarchyContainer from "./HierarchyContainer.svelte";
@@ -28,6 +30,100 @@
 
   /** Width of the chart. */
   let width: number | undefined = $state();
+
+  // Extract the report name from the current URL
+  let report_name = $derived.by(() => {
+    const path = getUrlPath($current_url);
+    if (path.is_ok) {
+      const match = /^([^/]+)/.exec(path.value);
+      return match ? match[1] : null;
+    }
+    return null;
+  });
+
+  // Get the stored chart mode for this report (falls back to global store default)
+  let stored_chart_mode = $derived(
+    report_name != null
+      ? lastActiveChartModePerReport.get(report_name)
+      : undefined,
+  );
+
+  // Derive effective modes: URL > per-report storage > global store
+  const valid_hierarchy_modes = ["treemap", "sunburst", "icicle"];
+  const valid_bar_modes = ["stacked", "single"];
+  const valid_line_modes = ["line", "area"];
+
+  let effective_hierarchy_mode = $derived.by(() => {
+    if (
+      $url_chart_mode != null &&
+      valid_hierarchy_modes.includes($url_chart_mode)
+    ) {
+      return $url_chart_mode;
+    }
+    if (
+      stored_chart_mode != null &&
+      valid_hierarchy_modes.includes(stored_chart_mode)
+    ) {
+      return stored_chart_mode;
+    }
+    return $hierarchyChartMode;
+  });
+
+  let effective_bar_mode = $derived.by(() => {
+    if ($url_chart_mode != null && valid_bar_modes.includes($url_chart_mode)) {
+      return $url_chart_mode;
+    }
+    if (
+      stored_chart_mode != null &&
+      valid_bar_modes.includes(stored_chart_mode)
+    ) {
+      return stored_chart_mode;
+    }
+    return $barChartMode;
+  });
+
+  let effective_line_mode = $derived.by(() => {
+    if ($url_chart_mode != null && valid_line_modes.includes($url_chart_mode)) {
+      return $url_chart_mode;
+    }
+    if (
+      stored_chart_mode != null &&
+      valid_line_modes.includes(stored_chart_mode)
+    ) {
+      return stored_chart_mode;
+    }
+    return $lineChartMode;
+  });
+
+  // Determine the current effective mode based on chart type
+  let current_effective_mode = $derived.by(() => {
+    if (chart.type === "hierarchy") {
+      return effective_hierarchy_mode;
+    } else if (chart.type === "barchart" && chart.hasStackedData) {
+      return effective_bar_mode;
+    } else if (chart.type === "linechart") {
+      return effective_line_mode;
+    }
+    return null;
+  });
+
+  // Sync effective mode to URL when it doesn't match (e.g., on page load)
+  $effect(() => {
+    if (
+      current_effective_mode != null &&
+      current_effective_mode !== $url_chart_mode
+    ) {
+      router.set_search_param("chart_mode", current_effective_mode);
+    }
+  });
+
+  /** Update the URL chart_mode parameter and save per-report. */
+  function set_chart_mode(value: string): void {
+    if (report_name != null) {
+      lastActiveChartModePerReport.set(report_name, value);
+    }
+    router.set_search_param("chart_mode", value);
+  }
 </script>
 
 <div class="flex-row">
@@ -35,7 +131,7 @@
     {#if chart.type === "barchart"}
       <ChartLegend
         legend={chart.currencies}
-        color={!($barChartMode === "stacked" && chart.hasStackedData)}
+        color={!(effective_bar_mode === "stacked" && chart.hasStackedData)}
         toggled={chartToggledCurrencies}
       />
     {/if}
@@ -46,7 +142,7 @@
         toggled={chartToggledCurrencies}
       />
     {/if}
-    {#if chart.type === "hierarchy" && $hierarchyChartMode === "treemap" && chart.treemap_currency}
+    {#if chart.type === "hierarchy" && effective_hierarchy_mode === "treemap" && chart.treemap_currency}
       <ChartLegend
         legend={chart.currencies}
         color={false}
@@ -55,11 +151,23 @@
     {/if}
     <span class="spacer"></span>
     {#if chart.type === "hierarchy"}
-      <ModeSwitch store={hierarchyChartMode} />
+      <ModeSwitch
+        store={hierarchyChartMode}
+        url_value={$url_chart_mode}
+        onchange={set_chart_mode}
+      />
     {:else if chart.type === "linechart"}
-      <ModeSwitch store={lineChartMode} />
+      <ModeSwitch
+        store={lineChartMode}
+        url_value={$url_chart_mode}
+        onchange={set_chart_mode}
+      />
     {:else if chart.type === "barchart" && chart.hasStackedData}
-      <ModeSwitch store={barChartMode} />
+      <ModeSwitch
+        store={barChartMode}
+        url_value={$url_chart_mode}
+        onchange={set_chart_mode}
+      />
     {/if}
   {:else}<span class="spacer"></span>{/if}
   {@render children?.()}

--- a/frontend/src/charts/HierarchyContainer.svelte
+++ b/frontend/src/charts/HierarchyContainer.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { _ } from "../i18n.ts";
   import { hierarchyChartMode } from "../stores/chart.ts";
+  import { url_chart_mode } from "../stores/url.ts";
   import type { HierarchyChart } from "./hierarchy.ts";
   import Icicle from "./Icicle.svelte";
   import Sunburst from "./Sunburst.svelte";
@@ -17,7 +18,16 @@
   let currencies = $derived(chart.currencies);
 
   let treemap_currency = $derived(chart.treemap_currency);
-  let mode = $derived($hierarchyChartMode);
+  // URL chart_mode takes precedence over store value if it's a valid hierarchy mode
+  const valid_hierarchy_modes = ["treemap", "sunburst", "icicle"] as const;
+  let mode = $derived(
+    $url_chart_mode != null &&
+      valid_hierarchy_modes.includes(
+        $url_chart_mode as (typeof valid_hierarchy_modes)[number],
+      )
+      ? ($url_chart_mode as (typeof valid_hierarchy_modes)[number])
+      : $hierarchyChartMode,
+  );
   let treemap = $derived(
     mode === "treemap" ? data.get($treemap_currency ?? "") : undefined,
   );

--- a/frontend/src/router.ts
+++ b/frontend/src/router.ts
@@ -44,6 +44,8 @@ const navigation_api = "navigation" in window ? window.navigation : null;
  */
 type FavaQueryParameters =
   | "account"
+  | "chart"
+  | "chart_mode"
   | "charts"
   | "conversion"
   | "filter"
@@ -353,12 +355,14 @@ export class Router {
   /**
    * Set the URL parameter and push a history state for it if changed.
    *
-   * For `charts` and `query_string`, this will not load the target URL.
+   * For `charts`, `chart`, `chart_mode`, and `query_string`, this will not load the target URL.
    */
   set_search_param(key: "charts", value: "false" | ""): void;
   set_search_param(
     key:
       | "account"
+      | "chart"
+      | "chart_mode"
       | "conversion"
       | "filter"
       | "interval"
@@ -370,7 +374,12 @@ export class Router {
     const target = new URL(this.current);
     set_query_param(target, key, value);
     if (target.href !== this.current.href) {
-      const load = !(key === "charts" || key === "query_string");
+      const load = !(
+        key === "charts" ||
+        key === "chart" ||
+        key === "chart_mode" ||
+        key === "query_string"
+      );
       this.navigate(target, load);
     }
   }

--- a/frontend/src/stores/url.ts
+++ b/frontend/src/stores/url.ts
@@ -58,3 +58,13 @@ export const syncedSearchParams = derived(searchParams, ($searchParams) => {
   }
   return params;
 });
+
+/** The currently selected chart name from URL. */
+export const url_chart = derived(searchParams, ($searchParams) =>
+  $searchParams.get("chart"),
+);
+
+/** The currently selected chart mode from URL. */
+export const url_chart_mode = derived(searchParams, ($searchParams) =>
+  $searchParams.get("chart_mode"),
+);


### PR DESCRIPTION
Addresses #1947 by adding URL parameters for the chart name and chart mode. 

For example, the Balance Sheet with the Assets chart and the Icicle chart mode uses the balance_sheet/?chart_mode=icicle&chart=Assets parameters.

The chart mode is stored in a per-report localStorage (fava-last-active-chart-modes), so that switching to another page and back preserves the chart mode and associated parameters.

The priority order for determining the chart mode is:

1. URL parameter (chart_mode=...)
2. The aforementioned localStorage
3. Global localStorage store as a fallback



