### PR TITLE
fix: update current router URL on external location changes

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -49,6 +49,7 @@
         "@types/d3-shape": "^3.0.2",
         "@types/d3-time": "^3.0.0",
         "@types/d3-time-format": "^4.0.0",
+        "@types/dom-navigation": "^1.0.6",
         "@types/jsdom": "^27.0.0",
         "@types/node": "^22.1.0",
         "chokidar": "^5.0.0",
@@ -1392,6 +1393,13 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.3.tgz",
       "integrity": "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/dom-navigation": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@types/dom-navigation/-/dom-navigation-1.0.6.tgz",
+      "integrity": "sha512-4srBpebg8rFDm0LafYuWhZMgLoSr5J4gx4q1uaTqOXwVk00y+CkTdJ4SC57sR1cMhP0ZRjApMRdHVcFYOvPGTw==",
       "dev": true,
       "license": "MIT"
     },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,6 +30,7 @@
     "@types/d3-shape": "^3.0.2",
     "@types/d3-time": "^3.0.0",
     "@types/d3-time-format": "^4.0.0",
+    "@types/dom-navigation": "^1.0.6",
     "@types/jsdom": "^27.0.0",
     "@types/node": "^22.1.0",
     "chokidar": "^5.0.0",

--- a/frontend/src/router.ts
+++ b/frontend/src/router.ts
@@ -267,26 +267,13 @@ export class Router {
   };
 
   /**
-   * Subscribe to all URL changes.
-   * This keeps the current URL synchronized, even if an external router (i.e. an extension module with its own router) updates the location.
+   * Synchronize the current URL, even if an external router (i.e. an extension module with its own router) updates the location.
    * The router must maintain an up-to-date URL, otherwise changing global filters (time, account, filter) would redirect to a stale URL.
    */
-  #subscribe_url_changes = (): void => {
-    const original_pushstate = window.history.pushState.bind(window.history);
-    window.history.pushState = (...args: Parameters<History["pushState"]>) => {
-      original_pushstate.apply(window.history, args);
-      this.current = new URL(window.location.href);
-    };
-
-    const original_replacestate = window.history.replaceState.bind(
-      window.history,
-    );
-    window.history.replaceState = (
-      ...args: Parameters<History["pushState"]>
-    ) => {
-      original_replacestate.apply(window.history, args);
-      this.current = new URL(window.location.href);
-    };
+  #on_navigate = (event: NavigateEvent): void => {
+    if (event.destination.sameDocument) {
+      this.current = new URL(event.destination.url);
+    }
   };
 
   /**
@@ -300,7 +287,9 @@ export class Router {
     window.addEventListener("beforeunload", this.#beforeunload);
     window.addEventListener("popstate", this.#popstate);
     document.addEventListener("click", this.#intercept_link_click);
-    this.#subscribe_url_changes();
+    if ("navigation" in window) {
+      window.navigation.addEventListener("navigate", this.#on_navigate);
+    }
 
     handleExtensionPageLoad();
   }


### PR DESCRIPTION
When extension modules bring their own router (e.g. `react-router` or `@tanstack/router`), Fava's router is not aware of URL changes, and the `router.current` property will get stale.

This is a problem when the global filters are changed (i.e. time, account or filter), because then Fava will redirect to that stale URL.

This PR subscribes to all navigation changes, and updates the `router.current` param of the router.