### PR TITLE
router: check if just going back is an option when closing modals

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -49,6 +49,7 @@
         "@types/d3-shape": "^3.0.2",
         "@types/d3-time": "^3.0.0",
         "@types/d3-time-format": "^4.0.0",
+        "@types/dom-navigation": "^1.0.6",
         "@types/jsdom": "^27.0.0",
         "@types/node": "^22.1.0",
         "chokidar": "^5.0.0",
@@ -1392,6 +1393,13 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.3.tgz",
       "integrity": "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/dom-navigation": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@types/dom-navigation/-/dom-navigation-1.0.6.tgz",
+      "integrity": "sha512-4srBpebg8rFDm0LafYuWhZMgLoSr5J4gx4q1uaTqOXwVk00y+CkTdJ4SC57sR1cMhP0ZRjApMRdHVcFYOvPGTw==",
       "dev": true,
       "license": "MIT"
     },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,6 +30,7 @@
     "@types/d3-shape": "^3.0.2",
     "@types/d3-time": "^3.0.0",
     "@types/d3-time-format": "^4.0.0",
+    "@types/dom-navigation": "^1.0.6",
     "@types/jsdom": "^27.0.0",
     "@types/node": "^22.1.0",
     "chokidar": "^5.0.0",

--- a/frontend/src/router.ts
+++ b/frontend/src/router.ts
@@ -36,6 +36,9 @@ const is_external_link = (link: HTMLAnchorElement | SVGAElement) =>
   (link instanceof HTMLAnchorElement &&
     (link.host !== window.location.host || !link.protocol.startsWith("http")));
 
+/** The navigation API is still rather new so only optionally depend on it for now. */
+const navigation_api = "navigation" in window ? window.navigation : null;
+
 /**
  * The various query parameters used in Fava.
  */
@@ -363,6 +366,14 @@ export class Router {
     if (this.current.hash) {
       const target = new URL(this.current);
       target.hash = "";
+      if (navigation_api?.currentEntry != null && navigation_api.canGoBack) {
+        const entries = navigation_api.entries();
+        const previous_entry = entries[navigation_api.currentEntry.index - 1];
+        if (previous_entry?.url === target.href) {
+          navigation_api.back();
+          return;
+        }
+      }
       this.navigate(target, false);
     }
   };


### PR DESCRIPTION
With the new navigation API, we can check if the closing of the modal
would just be the same as going back in the navigation history and not
push an additional state in this case.


Prior attempt was done in #2075, with the new navigation API this is now possible.

cc @andreasgerstmayr 
<!--
Hi, thank you for opening a PR!

Please ensure that your change passes tests and the various linters by running
`make test` and `make lint`. If testable, your changes should be covered by
unit tests.

Explain your changes below and link to related issues.
-->
