### PR TITLE
feat: add option to control metadata indicator visibility

### DIFF
--- a/src/fava/core/fava_options.py
+++ b/src/fava/core/fava_options.py
@@ -108,6 +108,7 @@ class FavaOptions:
     show_accounts_with_zero_balance: bool = True
     show_accounts_with_zero_transactions: bool = True
     show_closed_accounts: bool = False
+    show_metadata_indicators: bool = True
     sidebar_show_queries: int = 5
     upcoming_events: int = 7
     uptodate_indicator_grey_lookback_days: int = 60

--- a/src/fava/help/options.md
+++ b/src/fava/help/options.md
@@ -179,6 +179,17 @@ shown.
 
 ______________________________________________________________________
 
+## `show-metadata-indicators`
+
+Default: `true`
+
+Whether to show metadata indicators in journals. For each metadata key on an
+entry or posting, a small badge with the first two characters of the key is
+shown in the indicators column, with the full key and value available on hover.
+Set this to `false` to hide these indicators.
+
+______________________________________________________________________
+
 ## `collapse-pattern`
 
 Default: Not set

--- a/src/fava/templates/_journal_table.html
+++ b/src/fava/templates/_journal_table.html
@@ -40,6 +40,7 @@
 
 {% macro journal_table_contents(entries, show_change_and_balance=False, ledger=None) %}
 {% set ledger = ledger or g.ledger %}
+{% set show_metadata_indicators = ledger.fava_options.show_metadata_indicators %}
 {% autoescape false %}
 {% for entry in entries %}
     {% if show_change_and_balance %}
@@ -88,10 +89,10 @@
         {% endif %}
         </span>
         <span class='indicators'>
-          {{- _render_metadata_indicators(metadata_items) -}}
+          {%- if show_metadata_indicators %}{{- _render_metadata_indicators(metadata_items) -}}{% endif -%}
           {%- for posting in entry.postings -%}
           <span{% if posting.flag %} class='{{ posting.flag|flag_to_type }}'{% endif %}></span>
-          {{- _render_metadata_indicators(posting.meta|meta_items) -}}
+          {%- if show_metadata_indicators %}{{- _render_metadata_indicators(posting.meta|meta_items) -}}{% endif -%}
           {%- endfor -%}
         </span>
         {% if type == 'balance' %}

--- a/tests/__snapshots__/test_internal_api-test_get_ledger_data.json
+++ b/tests/__snapshots__/test_internal_api-test_get_ledger_data.json
@@ -733,6 +733,7 @@
     "show_accounts_with_zero_balance": false,
     "show_accounts_with_zero_transactions": true,
     "show_closed_accounts": false,
+    "show_metadata_indicators": true,
     "sidebar_show_queries": 5,
     "upcoming_events": 7,
     "uptodate_indicator_grey_lookback_days": 60,

--- a/tests/__snapshots__/test_json_api-test_api-options.json
+++ b/tests/__snapshots__/test_json_api-test_api-options.json
@@ -56,6 +56,7 @@
     "locale": "None",
     "show-accounts-with-zero-balance": "False",
     "show-accounts-with-zero-transactions": "True",
+    "show-metadata-indicators": "True",
     "show-closed-accounts": "False",
     "sidebar-show-queries": "5",
     "upcoming-events": "7",


### PR DESCRIPTION
Add a new Fava option 'show-metadata-indicators' (default: true) that allows users to disable the display of metadata indicator badges in the journal.

This addresses issue #2180 where metadata indicators were consuming valuable screen space and hiding important information like payee and narration text.

Users can now disable indicators by adding to their Beancount file:
  2024-01-01 custom "fava-option" "show-metadata-indicators" "false"

The option is backward-compatible and defaults to showing indicators, maintaining existing behavior for current users.

<!--
Hi, thank you for opening a PR!

Please ensure that your change passes tests and the various linters by running
`make test` and `make lint`. If testable, your changes should be covered by
unit tests.

Explain your changes below and link to related issues.
-->
