### PR TITLE
frontend: use darker text color on charts

### DIFF
--- a/frontend/css/charts.css
+++ b/frontend/css/charts.css
@@ -1,6 +1,6 @@
 svg text {
   font-family: var(--font-family);
-  fill: var(--text-color-lightest);
+  fill: var(--text-color-chart);
 }
 
 .tooltip {

--- a/frontend/css/charts.css
+++ b/frontend/css/charts.css
@@ -1,6 +1,6 @@
 svg text {
   font-family: var(--font-family);
-  fill: var(--text-color-chart);
+  fill: var(--text-color-lightest);
 }
 
 .tooltip {

--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -36,6 +36,7 @@
   --text-color: light-dark(hsl(0deg 0% 25%), hsl(0deg 0% 80%));
   --text-color-lighter: light-dark(hsl(0deg 0% 30%), hsl(0deg 0% 75%));
   --text-color-lightest: light-dark(hsl(0deg 0% 40%), hsl(0deg 0% 65%));
+  --text-color-chart: light-dark(hsl(0deg 0% 30%), hsl(0deg 0% 15%));
   --link-color: light-dark(hsl(203deg 100% 32%), hsl(203deg 100% 68%));
   --link-hover-color: var(--text-color-lighter);
 

--- a/frontend/src/charts/Icicle.svelte
+++ b/frontend/src/charts/Icicle.svelte
@@ -96,4 +96,8 @@
   g:hover > g.current {
     opacity: 1;
   }
+
+  text {
+    fill: var(--text-color-chart);
+  }
 </style>

--- a/frontend/src/charts/Treemap.svelte
+++ b/frontend/src/charts/Treemap.svelte
@@ -82,4 +82,8 @@
   svg {
     shape-rendering: crispedges;
   }
+
+  text {
+    fill: var(--text-color-chart);
+  }
 </style>


### PR DESCRIPTION
fixes #2215 

Dark:
<img width="1532" height="472" alt="image" src="https://github.com/user-attachments/assets/00aca004-1dae-4411-b58c-b338db003a9f" />
<img width="1522" height="490" alt="image" src="https://github.com/user-attachments/assets/08b93bdf-000e-4409-84f2-099ffa7ee932" />
Light:
<img width="1528" height="475" alt="image" src="https://github.com/user-attachments/assets/c9eb075d-7b63-4904-999c-7400aedda9d2" />
<img width="1535" height="505" alt="image" src="https://github.com/user-attachments/assets/e0f274be-b6d4-4227-9a5b-c6561d422837" />
