### PR TITLE
Preserve date when autocompleting a transaction using narration

### DIFF
--- a/frontend/src/entry-forms/Transaction.svelte
+++ b/frontend/src/entry-forms/Transaction.svelte
@@ -73,8 +73,7 @@
       return;
     }
     const data = await get_narration_transaction({ narration });
-    data.set("date", entry.date);
-    entry = data;
+    entry = data.set("date", entry.date); // Copy to "entry" and preserve the date set in the dialog
     narration = entry.get_narration_tags_links();
   }
 


### PR DESCRIPTION
<!--
Hi, thank you for opening a PR!

Please ensure that your change passes tests and the various linters by running
`make test` and `make lint`. If testable, your changes should be covered by
unit tests.

Explain your changes below and link to related issues.
-->
I haven't found a related issue.

The original code introduced in #2072 already tried to preserve the currently visible date in the Add transaction dialog when autocompleted a transaction by entering a narration.

However, the code does not work because when `data.set()` returns the changed `data` object it is never captured. Therefore, `entry = data` always copies the unchanged `data` to `entry` which means the current date in the dialog is always overwritten with the date of the autocompleted entry.

The proposed change captures `data` directly into `entry` and at the same time preserves the already entered date in the dialog.