### PR TITLE
fix: redirect to current URL if filter changes

### DIFF
--- a/frontend/src/sidebar/FilterForm.svelte
+++ b/frontend/src/sidebar/FilterForm.svelte
@@ -59,11 +59,13 @@
    * it seems to work around a Safari bug, see #809 and #1528.
    */
   function submit() {
-    const url = new URL(router.current);
+    // Do not use router.current here, as this value might be stale
+    // if a Fava extension uses a custom router.
+    const url = new URL(window.location.href);
     set_query_param(url, "account", account_filter_value);
     set_query_param(url, "filter", fql_filter_value);
     set_query_param(url, "time", time_filter_value);
-    if (url.href !== router.current.href) {
+    if (url.href !== window.location.href) {
       target = url;
       setTimeout(() => {
         if (target) {


### PR DESCRIPTION
This is an alternative approach to resolve #2196 / #2209.
Afaics changing the global filters is the only place where a stale `router.current` value causes problems. 