### PR TITLE
ci: add concurrency settings to GitHub Actions workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
+
 jobs:
   test-py:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
there are some jobs never exit when esbuild failed to compiling svelet.

we should also fix it in esbuild side, but add this is also a good idea.

<img width="1307" height="678" alt="image" src="https://github.com/user-attachments/assets/1043e6fd-65c2-40c0-8592-0e31f0f47127" />
