### PR TITLE
build: remove watch mode

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -34,8 +34,8 @@ You can run the tests with ``make test`` and the linters by running ``make
 lint``. There are further make targets defined, see the `Makefile` for details.
 After any changes to the Javascript code, you will need to re-build the
 frontend, which you can do by running ``make``. If you are working on the
-frontend code, running ``npm run dev`` in the ``frontend`` folder will watch
-for file changes and rebuild the Javascript bundle continuously.
+frontend code, you can e.g. use `entr` to rerun the build on file changes: ``fd |
+entr -s make``.
 
 If you need a newer version of Beancount than the latest released one, you can
 install from source like so (more details `here

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -52,7 +52,6 @@
         "@types/dom-navigation": "^1.0.6",
         "@types/jsdom": "^27.0.0",
         "@types/node": "^22.1.0",
-        "chokidar": "^5.0.0",
         "esbuild": "^0.27.0",
         "esbuild-svelte": "^0.9.0",
         "eslint": "^9.27.0",
@@ -1940,16 +1939,16 @@
       }
     },
     "node_modules/chokidar": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
-      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "readdirp": "^5.0.0"
+        "readdirp": "^4.0.1"
       },
       "engines": {
-        "node": ">= 20.19.0"
+        "node": ">= 14.16.0"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -3971,13 +3970,13 @@
       "license": "MIT"
     },
     "node_modules/readdirp": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
-      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 20.19.0"
+        "node": ">= 14.18.0"
       },
       "funding": {
         "type": "individual",
@@ -4505,22 +4504,6 @@
         "typescript": ">=5.0.0"
       }
     },
-    "node_modules/svelte-check/node_modules/chokidar": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
-      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "readdirp": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 14.16.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/svelte-check/node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -4537,20 +4520,6 @@
         "picomatch": {
           "optional": true
         }
-      }
-    },
-    "node_modules/svelte-check/node_modules/readdirp": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
-      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14.18.0"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/svelte-eslint-parser": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "node build.ts",
-    "dev": "node build.ts --dev --watch",
+    "dev": "node build.ts --dev",
     "sync-pre-commit": "node sync-pre-commit.ts",
     "test": "node --conditions browser --import ./setup.js test.ts",
     "test:watch": "node --conditions browser --import ./setup.js test.ts --watch"
@@ -33,7 +33,6 @@
     "@types/dom-navigation": "^1.0.6",
     "@types/jsdom": "^27.0.0",
     "@types/node": "^22.1.0",
-    "chokidar": "^5.0.0",
     "esbuild": "^0.27.0",
     "esbuild-svelte": "^0.9.0",
     "eslint": "^9.27.0",


### PR DESCRIPTION
This broke when having Svelte errors for example and  can just as easily
be achieved by e.g.

    fd . | entr -s make

or other tools to rerun commands on file changes. It wasn't a proper
watch mode anyway.

<!--
Hi, thank you for opening a PR!

Please ensure that your change passes tests and the various linters by running
`make test` and `make lint`. If testable, your changes should be covered by
unit tests.

Explain your changes below and link to related issues.
-->
