### PR TITLE
Update beancount_syntax.md

### DIFF
--- a/src/fava/help/beancount_syntax.md
+++ b/src/fava/help/beancount_syntax.md
@@ -1,7 +1,8 @@
 # Beancount Syntax
 
 Below is a short reference of the Beancount language syntax. Also see the full
-[Syntax Documentation](https://beancount.github.io/docs/beancount_language_syntax.html) and the
+[Syntax Documentation](https://beancount.github.io/docs/beancount_language_syntax.html)
+and the
 [Syntax Cheat Sheet](https://beancount.github.io/docs/beancount_cheat_sheet.html).
 
 Beancount defines a language in which financial transactions are entered into a
@@ -136,7 +137,8 @@ Automatic insertion of transaction to fulfill the following assertion:
 
 ### Options
 
-See the [Beancount Options Reference](https://beancount.github.io/docs/beancount_options_reference.html)
+See the
+[Beancount Options Reference](https://beancount.github.io/docs/beancount_options_reference.html)
 for the full list of supported options.
 
 <pre><textarea is="beancount-textarea">


### PR DESCRIPTION
Added links to the https://beancount.github.io/ documentation site instead of the http://furius.ca/ redirect to the google docs. 

Is the https://beancount.github.io/ site the source of truth?  I know the current state of the documentation/links is a little scattered.  If this is OK, I will also work on some more updates.

<!--
Hi, thank you for opening a PR!

Please ensure that your change passes tests and the various linters by running
`make test` and `make lint`. If testable, your changes should be covered by
unit tests.

Explain your changes below and link to related issues.
-->
