### PR TITLE
Add chart tab selection to account report URL params

### DIFF
--- a/frontend/src/reports/accounts/AccountReport.svelte
+++ b/frontend/src/reports/accounts/AccountReport.svelte
@@ -1,10 +1,13 @@
 <script lang="ts">
   import ChartSwitcher from "../../charts/ChartSwitcher.svelte";
   import { ParsedHierarchyChart } from "../../charts/hierarchy.ts";
+  import type { ParsedFavaChart } from "../../charts/index.ts";
   import { urlForAccount } from "../../helpers.ts";
   import { _ } from "../../i18n.ts";
   import { is_non_empty } from "../../lib/array.ts";
   import { intervalLabel } from "../../lib/interval.ts";
+  import { router } from "../../router.ts";
+  import { lastActiveChartName } from "../../stores/chart.ts";
   import { currentTimeFilterDateFormat } from "../../stores/format.ts";
   import { interval } from "../../stores/url.ts";
   import IntervalTreeTable from "../../tree-table/IntervalTreeTable.svelte";
@@ -14,6 +17,7 @@
   let {
     account,
     report_type,
+    initial_chart_index,
     charts,
     journal,
     interval_balances,
@@ -42,6 +46,33 @@
         ]
       : charts,
   );
+
+  const to_chart_name = (s: string | null, charts: ParsedFavaChart[]): string =>
+    charts[parseInt(s ?? "0", 10)]?.label ?? charts[0]?.label ?? "";
+
+  // On load, set the selected chart from the URL
+  $effect(() => {
+    lastActiveChartName.set(to_chart_name(initial_chart_index, all_charts));
+  });
+
+  // Derive the index from the chart name for the URL building
+  let chart_index: string = $derived.by(() => {
+    const idx = all_charts.findIndex((c) => c.label === $lastActiveChartName);
+    return idx <= 0 ? "0" : String(idx);
+  });
+
+  // On chart change, write selected chart index to the URL
+  $effect(() => {
+    const target = new URL(router.current);
+    if (chart_index === "0") {
+      target.searchParams.delete("c");
+    } else {
+      target.searchParams.set("c", chart_index);
+    }
+    if (target.href !== router.current.href) {
+      router.navigate(target, false);
+    }
+  });
 </script>
 
 <ChartSwitcher charts={all_charts} />
@@ -51,7 +82,7 @@
     <h3>
       {#if report_type !== "journal"}
         <a
-          href={$urlForAccount(account)}
+          href={$urlForAccount(account, { c: chart_index })}
           title={_("Journal of all entries for this Account and Sub-Accounts")}
         >
           {_("Account Journal")}
@@ -62,7 +93,7 @@
     </h3>
     <h3>
       {#if report_type !== "changes"}
-        <a href={$urlForAccount(account, { r: "changes" })}>
+        <a href={$urlForAccount(account, { r: "changes", c: chart_index })}>
           {_("Changes")} ({interval_label})
         </a>
       {:else}
@@ -71,7 +102,7 @@
     </h3>
     <h3>
       {#if report_type !== "balances"}
-        <a href={$urlForAccount(account, { r: "balances" })}>
+        <a href={$urlForAccount(account, { r: "balances", c: chart_index })}>
           {_("Balances")} ({interval_label})
         </a>
       {:else}

--- a/frontend/src/reports/accounts/index.ts
+++ b/frontend/src/reports/accounts/index.ts
@@ -18,6 +18,7 @@ const to_report_type = (s: string | null): AccountReportType =>
 export interface AccountReportProps {
   account: string;
   report_type: AccountReportType;
+  initial_chart_index: string | null;
   charts: ParsedFavaChart[];
   journal: DocumentFragment | null;
   interval_balances: AccountTreeNode[] | null;
@@ -52,6 +53,7 @@ export const account_report = new Route<AccountReportProps>(
   async (url) => {
     const account = get_account_from_url(url).unwrap();
     const report_type = to_report_type(url.searchParams.get("r"));
+    const initial_chart_index = url.searchParams.get("c");
     const { charts, journal, interval_balances, dates, budgets } =
       await get_account_report({
         ...getURLFilters(url),
@@ -67,6 +69,7 @@ export const account_report = new Route<AccountReportProps>(
       budgets,
       account,
       report_type,
+      initial_chart_index,
     };
   },
   (url) => {


### PR DESCRIPTION
In my Fava setup, I have a couple of fixed links to certain account reports. It's nice to be able to pre-select in the link the report shown via the `r` URL param, but a similar param is so far missing to pre-select the chart shown. This change adds that capability.

Memoize the active chart index via `c` query parameter in URL, allowing to deep link the chart selection. The default chart 'Account Balance' at index 0 is omitted from the URL analogous to the default report selection.

The values for the selected chart are the chart index in order to provide both a language agnostic solution and allowing to deep link into e.g. the hierarchy chart for the last month (because a label would change depending on the date, while the index does not).

Most of the logic is part of the frontend/template code because it needs to run after the addition of the hierarchy charts, which happens only there.

This purely being frontend changes, I did not add or modify any tests. I tested manually with `long-example.beancount` using both the English and the German languages.

-- 

AI usage disclosure: Since I'm not a frontend dev and only occasionally write TS, Claude Sonnet 4.6 was used to explore the code, find the right places to place modifications and suggest code snippets - all edits where made manually though and carefully reviewed.