### PR TITLE
feat: Add sorting by Cost/Change column on account journal page

### DIFF
--- a/frontend/src/reports/journal/JournalHeaders.svelte
+++ b/frontend/src/reports/journal/JournalHeaders.svelte
@@ -52,7 +52,17 @@
       </button>
       <span class="num">{_("Units")}</span>
       {#if show_change_and_balance}
-        <span class="num">{_("Cost")} / {_("Change")}</span>
+        <button
+          type="button"
+          class="num unset"
+          data-order={name === "change" ? order : undefined}
+          {disabled}
+          onclick={() => {
+            set_sort_column("change");
+          }}
+        >
+          {_("Cost")} / {_("Change")}
+        </button>
         <span class="num">{_("Price")} / {_("Balance")}</span>
       {:else}
         <span class="num">{_("Cost")}</span>
@@ -69,5 +79,14 @@
 
   button {
     position: relative;
+  }
+
+  button.num {
+    padding-left: 18px;
+  }
+
+  button.num[data-order]::after {
+    right: auto;
+    left: 4px;
   }
 </style>

--- a/frontend/src/reports/journal/sort.ts
+++ b/frontend/src/reports/journal/sort.ts
@@ -1,18 +1,20 @@
 import { get_direction, sortElements } from "../../sort/index.ts";
 import type { JournalSort } from "../../stores/journal.ts";
 
-export type JournalSortColumn = "date" | "flag" | "narration";
+export type JournalSortColumn = "date" | "flag" | "narration" | "change";
 
 const journal_column_types = {
   date: "num",
   flag: "string",
   narration: "string",
+  change: "num",
 };
 
 const journal_column_selectors = {
   date: ".datecell",
   flag: ".flag",
   narration: ".description",
+  change: ".change",
 };
 
 export function sort_journal(ol: HTMLOListElement, sort: JournalSort): void {

--- a/frontend/src/stores/journal.ts
+++ b/frontend/src/stores/journal.ts
@@ -29,6 +29,9 @@ const default_journal_sort: JournalSort = ["date", "desc"];
 /** The column and order that the journal should be sorted in. */
 export const journal_sort = localStorageSyncedStore<JournalSort>(
   "journal-sort-order",
-  tuple(constants("date", "flag", "narration"), constants("asc", "desc")),
+  tuple(
+    constants("date", "flag", "narration", "change"),
+    constants("asc", "desc"),
+  ),
   () => default_journal_sort,
 );

--- a/src/fava/translations/messages.pot
+++ b/src/fava/translations/messages.pot
@@ -89,7 +89,7 @@ msgstr ""
 
 #: frontend/src/entry-forms/Balance.svelte:28
 #: frontend/src/modals/AddEntry.svelte:20
-#: frontend/src/reports/journal/JournalHeaders.svelte:56
+#: frontend/src/reports/journal/JournalHeaders.svelte:66
 #: frontend/src/reports/statistics/UpdateActivity.svelte:39
 msgid "Balance"
 msgstr ""
@@ -244,8 +244,8 @@ msgid "Date"
 msgstr ""
 
 #: frontend/src/reports/commodities/CommodityTable.svelte:19
-#: frontend/src/reports/journal/JournalHeaders.svelte:56
-#: frontend/src/reports/journal/JournalHeaders.svelte:59
+#: frontend/src/reports/journal/JournalHeaders.svelte:66
+#: frontend/src/reports/journal/JournalHeaders.svelte:69
 msgid "Price"
 msgstr ""
 
@@ -465,12 +465,12 @@ msgstr ""
 msgid "F"
 msgstr ""
 
-#: frontend/src/reports/journal/JournalHeaders.svelte:55
-#: frontend/src/reports/journal/JournalHeaders.svelte:58
+#: frontend/src/reports/journal/JournalHeaders.svelte:64
+#: frontend/src/reports/journal/JournalHeaders.svelte:68
 msgid "Cost"
 msgstr ""
 
-#: frontend/src/reports/journal/JournalHeaders.svelte:55
+#: frontend/src/reports/journal/JournalHeaders.svelte:64
 msgid "Change"
 msgstr ""
 


### PR DESCRIPTION
 On the account journal page, the "Cost / Change" column header is now clickable to sort entries by their change amount (ascending/descending toggle). This follows the same      
  pattern used by the existing sortable columns (Date, Flag, Narration).                                                                                                           
                                                                                                                                                                                   
  The sort arrow indicator is positioned on the left side of the header to avoid overlapping with the right-aligned numeric text.                                                  
                                                                                                                                                                                   
  ### Changes                                                                                                                                                                      
  - `frontend/src/reports/journal/sort.ts` — add `"change"` column type and `.change` CSS selector                                                                                 
  - `frontend/src/stores/journal.ts` — add `"change"` to sort column validation                                                                                                    
  - `frontend/src/reports/journal/JournalHeaders.svelte` — convert "Cost / Change" span to a sortable button with left-aligned arrow indicator                                     
                                                                                                                                                                                   
  ### Testing                                                                                                                                                                      
  - `make lint` — all checks pass                                                                                                                                                  
  - `svelte-check` — 0 errors, 0 warnings                                                                                                                                          
  - Manual: verified sorting works on `/edit-example/account/Expenses/`  