### PR TITLE
import: skip duplicate files in duplicate or overlapping import dirs

### DIFF
--- a/src/fava/core/ingest.py
+++ b/src/fava/core/ingest.py
@@ -20,6 +20,7 @@ from beangulp.importer import Importer
 from fava.core.module_base import FavaModule
 from fava.helpers import BeancountError
 from fava.helpers import FavaAPIError
+from fava.util import listify
 from fava.util.date import local_today
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -200,31 +201,8 @@ class WrappedImporter:
 
 
 # Copied here from beangulp to minimise the imports.
+# Skip files over 8MB
 _FILE_TOO_LARGE_THRESHOLD = 8 * 1024 * 1024
-
-
-def find_imports(
-    config: Sequence[WrappedImporter], directory: Path
-) -> Iterable[FileImporters]:
-    """Pair files and matching importers.
-
-    Yields:
-        For each file in directory, a pair of its filename and the matching
-        importers.
-    """
-    for path in walk_dir(directory):
-        stat = path.stat()
-        if stat.st_size > _FILE_TOO_LARGE_THRESHOLD:  # pragma: no cover
-            continue
-
-        importers = [
-            importer.file_import_info(path)
-            for importer in config
-            if importer.identify(path)
-        ]
-        yield FileImporters(
-            name=str(path), basename=path.name, importers=importers
-        )
 
 
 def extract_from_file(
@@ -348,23 +326,39 @@ class IngestModule(FavaModule):
             msg = f"Error in import config '{module_path}': {error!s}"
             self._error(msg)
 
-    def import_data(self) -> list[FileImporters]:
+    @listify
+    def import_data(self) -> Iterable[FileImporters]:
         """Identify files and importers that can be imported.
 
         Returns:
             A list of :class:`.FileImportInfo`.
         """
         if not self.importers:
-            return []
+            return
 
         importers = list(self.importers.values())
+        seen = set()
 
-        ret: list[FileImporters] = []
         for directory in self.ledger.fava_options.import_dirs:
-            full_path = self.ledger.join_path(directory)
-            ret.extend(find_imports(importers, full_path))
+            for path in walk_dir(self.ledger.join_path(directory)):
+                if path in seen:
+                    continue
+                seen.add(path)
 
-        return ret
+                if (
+                    path.stat().st_size > _FILE_TOO_LARGE_THRESHOLD
+                ):  # pragma: no cover
+                    continue
+
+                yield FileImporters(
+                    name=str(path),
+                    basename=path.name,
+                    importers=[
+                        importer.file_import_info(path)
+                        for importer in importers
+                        if importer.identify(path)
+                    ],
+                )
 
     def extract(self, filename: str, importer_name: str) -> list[Directive]:
         """Extract entries from filename with the specified importer.

--- a/src/fava/translations/messages.pot
+++ b/src/fava/translations/messages.pot
@@ -308,12 +308,12 @@ msgstr ""
 msgid "Line"
 msgstr ""
 
-#: frontend/src/reports/errors/Errors.svelte:48
+#: frontend/src/reports/errors/Errors.svelte:49
 #, python-format
 msgid "Show source %(file)s:%(lineno)s"
 msgstr ""
 
-#: frontend/src/reports/errors/Errors.svelte:75
+#: frontend/src/reports/errors/Errors.svelte:77
 msgid "No errors."
 msgstr ""
 

--- a/tests/__snapshots__/test_core_ingest-test_ingest_examplefile-2.json
+++ b/tests/__snapshots__/test_core_ingest-test_ingest_examplefile-2.json
@@ -45,7 +45,7 @@
         "meta": {
           "__tolerances__": { "EUR": 0.005 },
           "filename": "TEST_DATA_DIR/import.beancount",
-          "lineno": 8
+          "lineno": 9
         },
         "narration": " BANKOMAT  00000483 K2 UM 11:56",
         "payee": "",
@@ -56,7 +56,7 @@
             "flag": null,
             "meta": {
               "filename": "TEST_DATA_DIR/import.beancount",
-              "lineno": 9
+              "lineno": 10
             },
             "price": null,
             "units": { "currency": "EUR", "number": -100.0 }

--- a/tests/__snapshots__/test_core_ingest-test_ingest_examplefile.json
+++ b/tests/__snapshots__/test_core_ingest-test_ingest_examplefile.json
@@ -45,7 +45,7 @@
         "meta": {
           "__tolerances__": { "EUR": 0.005 },
           "filename": "TEST_DATA_DIR/import.beancount",
-          "lineno": 8
+          "lineno": 9
         },
         "narration": " BANKOMAT  00000483 K2 UM 11:56",
         "payee": "",
@@ -56,7 +56,7 @@
             "flag": null,
             "meta": {
               "filename": "TEST_DATA_DIR/import.beancount",
-              "lineno": 9
+              "lineno": 10
             },
             "price": null,
             "units": { "currency": "EUR", "number": -100.0 }

--- a/tests/__snapshots__/test_json_api-test_api_imports-2.json
+++ b/tests/__snapshots__/test_json_api-test_api_imports-2.json
@@ -45,7 +45,7 @@
         "meta": {
           "__tolerances__": { "EUR": 0.005 },
           "filename": "TEST_DATA_DIR/import.beancount",
-          "lineno": 8
+          "lineno": 9
         },
         "narration": " BANKOMAT  00000483 K2 UM 11:56",
         "payee": "",
@@ -56,7 +56,7 @@
             "flag": null,
             "meta": {
               "filename": "TEST_DATA_DIR/import.beancount",
-              "lineno": 9
+              "lineno": 10
             },
             "price": null,
             "units": { "currency": "EUR", "number": -100.0 }

--- a/tests/data/import.beancount
+++ b/tests/data/import.beancount
@@ -1,6 +1,7 @@
 option "title" "import"
 2017-01-01 custom "fava-option" "import-config" "import_config.py"
 2017-01-01 custom "fava-option" "import-dirs" "."
+2017-01-01 custom "fava-option" "import-dirs" "."
 option "documents" "./"
 2017-01-01 open Assets:Checking
 2017-01-01 open Expenses:Widgets

--- a/tests/test_core_ingest.py
+++ b/tests/test_core_ingest.py
@@ -173,7 +173,9 @@ def test_ingest_examplefile(
     ingest_ledger = get_ledger("import")
 
     files = ingest_ledger.ingest.import_data()
-    assert len(files) > 10  # all files in the test datafolder
+    assert len(files) == len(
+        list(test_data_dir.iterdir())
+    )  # all files in the test datafolder
 
     with pytest.raises(ImporterExtractError):
         entries = ingest_ledger.ingest.extract(


### PR DESCRIPTION
Fixes #2253 