### PR TITLE
Navigation error query holdings

### DIFF
--- a/frontend/src/reports/holdings/Holdings.svelte
+++ b/frontend/src/reports/holdings/Holdings.svelte
@@ -53,7 +53,7 @@
 </div>
 
 <p>
-  <a href={$urlFor("query", { query_string })}>{_("Query")}</a>
+  <a href={$urlFor("query/", { query_string })}>{_("Query")}</a>
   <QueryLinks query={query_string} />
 </p>
 <QueryTable table={query_result_table} filter_empty="units" />

--- a/frontend/src/reports/statistics/Statistics.svelte
+++ b/frontend/src/reports/statistics/Statistics.svelte
@@ -20,7 +20,7 @@
 <div class="left">
   <h3>
     {_("Postings per Account")}
-    (<a href={$urlFor("query", { query_string: postings_per_account_query })}>
+    (<a href={$urlFor("query/", { query_string: postings_per_account_query })}>
       {_("Query")}
     </a>)
   </h3>

--- a/frontend/test/urls.test.ts
+++ b/frontend/test/urls.test.ts
@@ -37,3 +37,13 @@ test("extract relative path from URL", () => {
     "Ä€/asdf",
   );
 });
+
+test("report name extraction", () => {
+  const getReport = (path: string) => path.slice(0, path.indexOf("/"));
+
+  equal(getReport("holdings/"), "holdings");
+  equal(getReport("query/"), "query");
+  // This demonstrates the current behavior where a missing trailing slash
+  // leads to an incorrect report name being extracted.
+  equal(getReport("query"), "quer");
+});


### PR DESCRIPTION
This merge request fixes #2268 by ensuring there is a trailing slash after the "query".
I have added a new test case for the issue. 
All tests are passing, linting does not show any errors.