### PR TITLE
fix: use field-sizing: content for AutocompleteInput width on wide chars

### DIFF
--- a/frontend/src/AutocompleteInput.svelte
+++ b/frontend/src/AutocompleteInput.svelte
@@ -221,6 +221,7 @@
   }
 
   input {
+    field-sizing: content;
     width: 100%;
   }
 


### PR DESCRIPTION
## Fix autocomplete input width for CJK and wide characters

Closes #2250

### Root cause

`AutocompleteInput.svelte` sets the HTML `size` attribute from
`Math.max(value.length, placeholder.length) + 1`. The `length`
property counts UTF-16 code units, not display columns, so CJK and
other wide characters are counted as width 1 when they occupy width 2.
The result is an input that renders too narrow when the placeholder or
value contains wide characters.

### Fix

Added `field-sizing: content` to the `input` CSS rule in
`AutocompleteInput.svelte`. Browsers that support it (Chromium-based
and Safari) will auto-size the input to its rendered content, handling
wide characters correctly.

The existing length-based `size` attribute is kept unchanged as the
fallback. Firefox does not yet support `field-sizing`, so Firefox
behaviour is identical to before - no regression.

### Change

One line added to the `input` style block in
`frontend/src/AutocompleteInput.svelte`:

```css
input {
  field-sizing: content;  /* added */
  width: 100%;
}
```

### Checks

`make lint` passes: pre-commit (all files), `tsc`, `svelte-check`, and the `ty` Python type check are all clean.

`make test`: the frontend suite (`npm run test`) passes 86/86. The Python suite reports one snapshot mismatch in `tests/test_json_api.py::test_api[options-/long-example/api/options]`. That same test fails identically on an unmodified `master` checkout on this machine, so it is a pre-existing environment-specific snapshot drift, not a regression from this change. This PR only adds one CSS property in a Svelte file, which cannot affect the Python JSON API output.
