### PR TITLE
Prevent frontend documents/ crash from multiple doc refs

### DIFF
--- a/frontend/src/reports/documents/Table.svelte
+++ b/frontend/src/reports/documents/Table.svelte
@@ -46,7 +46,7 @@
     </tr>
   </thead>
   <tbody>
-    {#each sorted_documents as doc (doc.filename)}
+    {#each sorted_documents as doc (doc.entry_hash)}
       <tr
         class:selected={selected === doc}
         draggable={true}

--- a/src/fava/json_api.py
+++ b/src/fava/json_api.py
@@ -608,16 +608,17 @@ def get_documents() -> Sequence[Document]:
     g.ledger.changed()
     # Deduplicate by filename: prefer explicit directives (lineno > 0) over
     # auto-discovered ones (lineno == 0).
-    seen: dict[str, Document] = {}
+    seen: dict[Path, Document] = {}
     for entry in g.filtered.entries:
         if not isinstance(entry, Document):
             continue
-        existing = seen.get(entry.filename)
+        key = Path(entry.filename)
+        existing = seen.get(key)
         if existing is None or (
             existing.meta.get("lineno", 0) == 0
             and entry.meta.get("lineno", 0) != 0
         ):
-            seen[entry.filename] = entry
+            seen[key] = entry
     return [serialise(e) for e in seen.values()]
 
 

--- a/src/fava/json_api.py
+++ b/src/fava/json_api.py
@@ -606,9 +606,19 @@ def get_imports() -> Sequence[FileImporters]:
 def get_documents() -> Sequence[Document]:
     """Get all (filtered) documents."""
     g.ledger.changed()
-    return [
-        serialise(e) for e in g.filtered.entries if isinstance(e, Document)
-    ]
+    # Deduplicate by filename: prefer explicit directives (lineno > 0) over
+    # auto-discovered ones (lineno == 0).
+    seen: dict[str, Document] = {}
+    for entry in g.filtered.entries:
+        if not isinstance(entry, Document):
+            continue
+        existing = seen.get(entry.filename)
+        if existing is None or (
+            existing.meta.get("lineno", 0) == 0
+            and entry.meta.get("lineno", 0) != 0
+        ):
+            seen[entry.filename] = entry
+    return [serialise(e) for e in seen.values()]
 
 
 @dataclass(frozen=True)

--- a/tests/test_json_api.py
+++ b/tests/test_json_api.py
@@ -5,11 +5,13 @@ from difflib import Differ
 from http import HTTPStatus
 from io import BytesIO
 from pathlib import Path
+from textwrap import dedent
 from typing import Any
 from typing import TYPE_CHECKING
 
 import pytest
 
+from fava.application import create_app
 from fava.beans.funcs import hash_entry
 from fava.context import g
 from fava.core.file import _sha256_str
@@ -824,6 +826,73 @@ def test_api_filter_error(
         "/long-example/api/commodities?time=20",
     )
     assert_api_error(response, status=HTTPStatus.BAD_REQUEST)
+
+
+def test_api_documents_deduplication(tmp_path: Path) -> None:
+    """Documents endpoint deduplicates when explicit directive and
+    auto-discovery both reference the same file."""
+    doc_dir = tmp_path / "documents"
+    account_dir = doc_dir / "Assets" / "Bank"
+    account_dir.mkdir(parents=True)
+    statement = account_dir / "2020-01-31 statement.pdf"
+    statement.touch()
+
+    beancount_file = tmp_path / "dedup-test.beancount"
+    beancount_file.write_text(
+        dedent(f"""\
+            option "title" "Dedup Test"
+            option "operating_currency" "USD"
+            option "documents" "{doc_dir}"
+
+            2020-01-01 open Assets:Bank USD
+
+            2020-01-31 document Assets:Bank "{statement}"
+        """)
+    )
+
+    dedup_app = create_app([str(beancount_file)], load=True)
+    dedup_app.testing = True
+    client = dedup_app.test_client()
+
+    response = client.get("/dedup-test/api/documents")
+    data = assert_api_success(response)
+
+    # Only one document should be returned even though Beancount creates two
+    # Document entries (explicit directive + auto-discovery).
+    assert len(data) == 1
+    assert data[0]["filename"] == str(statement)
+    # Explicit directive (lineno > 0) should be preferred over auto-discovered.
+    assert data[0]["meta"]["lineno"] > 0
+
+
+def test_api_documents_dedup_two_explicit(tmp_path: Path) -> None:
+    """Documents endpoint keeps first entry when two explicit directives
+    reference the same file."""
+    statement = tmp_path / "statement.pdf"
+    statement.touch()
+
+    beancount_file = tmp_path / "dedup-explicit.beancount"
+    beancount_file.write_text(
+        dedent(f"""\
+            option "title" "Dedup Explicit"
+            option "operating_currency" "USD"
+
+            2020-01-01 open Assets:Bank USD
+
+            2020-01-31 document Assets:Bank "{statement}"
+            2020-01-31 document Assets:Bank "{statement}"
+        """)
+    )
+
+    dedup_app = create_app([str(beancount_file)], load=True)
+    dedup_app.testing = True
+    client = dedup_app.test_client()
+
+    response = client.get("/dedup-explicit/api/documents")
+    data = assert_api_success(response)
+
+    assert len(data) == 1
+    assert data[0]["filename"] == str(statement)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_json_api.py
+++ b/tests/test_json_api.py
@@ -842,11 +842,11 @@ def test_api_documents_deduplication(tmp_path: Path) -> None:
         dedent(f"""\
             option "title" "Dedup Test"
             option "operating_currency" "USD"
-            option "documents" "{doc_dir}"
+            option "documents" "{doc_dir.as_posix()}"
 
             2020-01-01 open Assets:Bank USD
 
-            2020-01-31 document Assets:Bank "{statement}"
+            2020-01-31 document Assets:Bank "{statement.as_posix()}"
         """)
     )
 
@@ -860,7 +860,7 @@ def test_api_documents_deduplication(tmp_path: Path) -> None:
     # Only one document should be returned even though Beancount creates two
     # Document entries (explicit directive + auto-discovery).
     assert len(data) == 1
-    assert data[0]["filename"] == str(statement)
+    assert Path(data[0]["filename"]) == statement
     # Explicit directive (lineno > 0) should be preferred over auto-discovered.
     assert data[0]["meta"]["lineno"] > 0
 
@@ -879,8 +879,8 @@ def test_api_documents_dedup_two_explicit(tmp_path: Path) -> None:
 
             2020-01-01 open Assets:Bank USD
 
-            2020-01-31 document Assets:Bank "{statement}"
-            2020-01-31 document Assets:Bank "{statement}"
+            2020-01-31 document Assets:Bank "{statement.as_posix()}"
+            2020-01-31 document Assets:Bank "{statement.as_posix()}"
         """)
     )
 
@@ -892,7 +892,7 @@ def test_api_documents_dedup_two_explicit(tmp_path: Path) -> None:
     data = assert_api_success(response)
 
     assert len(data) == 1
-    assert data[0]["filename"] == str(statement)
+    assert Path(data[0]["filename"]) == statement
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
If a document filename is encountered multiple times, from transaction metadata and/or being auto-found via an `options` directive, Svelte code would cause a UI error without displaying any data. Fixes #2281 

Change summary:

- `src/fava/json_api.py` — `get_documents()` now deduplicates by filename, preferring explicit directives over auto-discovered ones
- `frontend/src/reports/documents/Table.svelte` — Svelte `{#each}` key changed from `doc.filename` to `doc.entry_hash`
- `tests/test_json_api.py` — Two new tests: one for explicit + auto-discovered dedup, one for two explicit directives

