### PR TITLE
Support extensions triggering file import

### DIFF
--- a/frontend/src/modals/GlobalExtract.svelte
+++ b/frontend/src/modals/GlobalExtract.svelte
@@ -1,0 +1,73 @@
+<script lang="ts">
+  import { get_extract, save_entries } from "../api/index.ts";
+  import type { Entry } from "../entries/index.ts";
+  import { is_non_empty } from "../lib/array.ts";
+  import { notify, notify_err } from "../notifications.ts";
+  import Extract from "../reports/import/Extract.svelte";
+  import { loading_state, router } from "../router.ts";
+  import { hash } from "../stores/url.ts";
+
+  let shown = $derived($hash.startsWith("extract?"));
+
+  let extract_params = $derived(
+    shown ? new URLSearchParams($hash.slice(8)) : null,
+  );
+  let filename = $derived(extract_params?.get("filename"));
+  let importer = $derived(extract_params?.get("importer"));
+
+  let entries = $state<Entry[]>([]);
+
+  $effect(() => {
+    let active = true;
+
+    if (shown) {
+      if (filename != null && importer != null) {
+        void loading_state
+          .await(get_extract({ filename, importer }))
+          .then((res) => {
+            if (!active) {
+              return;
+            }
+            if (res.length > 0) {
+              entries = res;
+            } else {
+              notify("No entries to import from this file.", "warning");
+              close();
+            }
+          })
+          .catch((err: unknown) => {
+            if (!active) {
+              return;
+            }
+            notify_err(err);
+            close();
+          });
+      } else {
+        close();
+      }
+    } else {
+      entries = [];
+    }
+
+    return () => {
+      active = false;
+    };
+  });
+
+  function close() {
+    router.close_overlay();
+  }
+
+  async function save() {
+    const without_duplicates = entries.filter((e) => !e.is_duplicate());
+    close();
+
+    if (is_non_empty(without_duplicates)) {
+      await save_entries(without_duplicates);
+    }
+  }
+</script>
+
+{#if shown && entries.length > 0}
+  <Extract bind:entries {close} {save} />
+{/if}

--- a/frontend/src/modals/Modals.svelte
+++ b/frontend/src/modals/Modals.svelte
@@ -3,9 +3,11 @@
   import Context from "./Context.svelte";
   import DocumentUpload from "./DocumentUpload.svelte";
   import Export from "./Export.svelte";
+  import GlobalExtract from "./GlobalExtract.svelte";
 </script>
 
 <AddEntry />
 <Context />
 <DocumentUpload />
 <Export />
+<GlobalExtract />

--- a/frontend/test/GlobalExtract.test.ts
+++ b/frontend/test/GlobalExtract.test.ts
@@ -1,0 +1,186 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import { equal, ok } from "node:assert/strict";
+import { before, beforeEach, test } from "node:test";
+
+import { setup_jsdom } from "./dom.ts";
+
+// Setup JSDOM immediately before any other ESM modules are loaded
+setup_jsdom();
+// Router constructor expects an <article> element to be present in the document
+const article = document.createElement("article");
+document.body.appendChild(article);
+
+// Now we can safely import other modules that depend on `window` being defined at top-level
+const { flushSync, mount } = await import("svelte");
+const { current_url } = await import("../src/stores/url.ts");
+const { default: GlobalExtract } = await import(
+  "../src/modals/GlobalExtract.svelte"
+);
+const { initialiseLedgerData } = await import("./helpers.ts");
+
+before(initialiseLedgerData);
+beforeEach(() => {
+  setup_jsdom();
+  // Ensure the article element is recreated for any router operations during tests
+  const article = document.createElement("article");
+  document.body.appendChild(article);
+});
+
+test("GlobalExtract: mounts and does nothing if hash is empty", () => {
+  current_url.set(new URL("http://localhost:3000"));
+
+  mount(GlobalExtract, {
+    target: document.body,
+  });
+  flushSync();
+
+  const modal = document.body.querySelector("form");
+  ok(!modal);
+});
+
+test("GlobalExtract: automatically closes (clears hash) if hash is malformed (missing parameters)", () => {
+  current_url.set(
+    new URL("http://localhost:3000/#extract?filename=only_filename"),
+  );
+
+  mount(GlobalExtract, {
+    target: document.body,
+  });
+  flushSync();
+
+  equal(window.location.hash, "");
+});
+
+test("GlobalExtract: fetches and displays extract modal on valid hash", async (t) => {
+  current_url.set(
+    new URL(
+      "http://localhost:3000/#extract?filename=file.csv&importer=my-importer",
+    ),
+  );
+
+  const mock_entry = {
+    t: "Balance",
+    meta: { filename: "/home/test/test.beancount", lineno: 1 },
+    date: "2022-12-12",
+    entry_hash: "ENTRY_HASH",
+    account: "Expenses:Food",
+    amount: { number: "10", currency: "USD" },
+  };
+
+  t.mock.method(globalThis, "fetch", (urlStr: string | URL) => {
+    const url = new URL(urlStr);
+    if (url.pathname.endsWith("/api/extract")) {
+      return new Response(JSON.stringify({ data: [mock_entry] }));
+    }
+    return new Response(JSON.stringify({ data: [] }));
+  });
+
+  mount(GlobalExtract, {
+    target: document.body,
+  });
+
+  flushSync();
+  await new Promise((resolve) => setTimeout(resolve, 10));
+  flushSync();
+
+  const modalHeader = document.body.querySelector("h3");
+  ok(modalHeader);
+  equal(modalHeader.textContent, "Import");
+});
+
+test("GlobalExtract: closes and warns if API returns empty list", async (t) => {
+  current_url.set(
+    new URL(
+      "http://localhost:3000/#extract?filename=file.csv&importer=my-importer",
+    ),
+  );
+
+  t.mock.method(globalThis, "fetch", (urlStr: string | URL) => {
+    const url = new URL(urlStr);
+    if (url.pathname.endsWith("/api/extract")) {
+      return new Response(JSON.stringify({ data: [] }));
+    }
+    return new Response(JSON.stringify({ data: [] }));
+  });
+
+  mount(GlobalExtract, {
+    target: document.body,
+  });
+
+  flushSync();
+  await new Promise((resolve) => setTimeout(resolve, 10));
+  flushSync();
+
+  equal(window.location.hash, "");
+
+  const notification = document.body.querySelector(".notifications li.warning");
+  ok(notification);
+  equal(notification.textContent, "No entries to import from this file.");
+});
+
+test("GlobalExtract: saves non-duplicate entries and closes on save", async (t) => {
+  current_url.set(
+    new URL(
+      "http://localhost:3000/#extract?filename=file.csv&importer=my-importer",
+    ),
+  );
+
+  const mock_entry = {
+    t: "Balance",
+    meta: { filename: "/home/test/test.beancount", lineno: 1 },
+    date: "2022-12-12",
+    entry_hash: "ENTRY_HASH",
+    account: "Expenses:Food",
+    amount: { number: "10", currency: "USD" },
+  };
+
+  interface MockSavedEntry {
+    account: string;
+  }
+  let savedEntries: MockSavedEntry[] = [];
+  t.mock.method(
+    globalThis,
+    "fetch",
+    (urlStr: string | URL, init?: RequestInit) => {
+      const url = new URL(urlStr);
+      if (url.pathname.endsWith("/api/extract")) {
+        return new Response(JSON.stringify({ data: [mock_entry] }));
+      }
+      if (url.pathname.endsWith("/api/add_entries")) {
+        if (init?.body != null) {
+          const body = JSON.parse(init.body as string) as {
+            entries: MockSavedEntry[];
+          };
+          savedEntries = body.entries;
+        }
+        return new Response(JSON.stringify({ data: "Success" }));
+      }
+      return new Response(JSON.stringify({ data: [] }));
+    },
+  );
+
+  mount(GlobalExtract, {
+    target: document.body,
+  });
+
+  flushSync();
+  await new Promise((resolve) => setTimeout(resolve, 10));
+  flushSync();
+
+  const form = document.body.querySelector("form");
+  ok(form instanceof HTMLFormElement);
+  form.dispatchEvent(
+    new window.Event("submit", { bubbles: true, cancelable: true }),
+  );
+
+  flushSync();
+  await new Promise((resolve) => setTimeout(resolve, 10));
+  flushSync();
+
+  equal(window.location.hash, "");
+
+  equal(savedEntries.length, 1);
+  const firstEntry = savedEntries[0];
+  ok(firstEntry);
+  equal(firstEntry.account, "Expenses:Food");
+});


### PR DESCRIPTION
This functionality enables extensions to trigger a normal file import process. (for reference - https://github.com/mescanne/beancount-blue)

Background:
I'm building an extension to enable API-driven sync and imports. I'm using the standard Beancount and Fava file import pattern (where files contain configuration and do not move) and would like to leverage Fava's normal import process, but not import screen. Another PR will be raised to cover bulk importing.

Implementation:
* Adds a globally hoisted `<GlobalExtract>` modal that triggers on the URL hash pattern `#extract?filename=...&importer=...`.
* The loading state is delegated to Fava's global `loading_state.await()`, keeping the PR focused and inheriting generic UI loading enhancements natively.

Let me know of any questions or feedback!

Thanks
