### PR TITLE
Improve balance amount input on mobile

### DIFF
--- a/frontend/src/entry-forms/Balance.svelte
+++ b/frontend/src/entry-forms/Balance.svelte
@@ -38,7 +38,8 @@
     --autocomplete-wrapper-flex="1"
   />
   <input
-    type="tel"
+    type="text"
+    inputmode="decimal"
     pattern="-?[0-9.,]*"
     placeholder={_("Number")}
     size={10}

--- a/frontend/test/entry-forms.test.ts
+++ b/frontend/test/entry-forms.test.ts
@@ -1,0 +1,28 @@
+import { equal, ok } from "node:assert/strict";
+import { beforeEach, test } from "node:test";
+
+import { flushSync, mount } from "svelte";
+
+import { Balance } from "../src/entries/index.ts";
+import BalanceForm from "../src/entry-forms/Balance.svelte";
+import { setup_jsdom } from "./dom.ts";
+import { initialiseLedgerData } from "./helpers.ts";
+
+test.before(initialiseLedgerData);
+beforeEach(setup_jsdom);
+
+test("Balance form uses a decimal keyboard hint for the amount input", () => {
+  mount(BalanceForm, {
+    target: document.body,
+    props: {
+      entry: Balance.empty("2026-05-27"),
+    },
+  });
+  flushSync();
+
+  const input = document.body.querySelector('input[placeholder="Number"]');
+  ok(input instanceof HTMLInputElement);
+  equal(input.type, "text");
+  equal(input.inputMode, "decimal");
+  equal(input.pattern, "-?[0-9.,]*");
+});


### PR DESCRIPTION
## Summary
- Change the balance amount field from a telephone input to a text input with `inputmode="decimal"` so iOS shows a decimal-friendly keyboard.
- Add a frontend regression test covering the amount input type, input mode, and preserved pattern.