### PR TITLE
i18n(ko): fix translation bugs and complete missing entries

### DIFF
--- a/src/fava/translations/ko/LC_MESSAGES/messages.po
+++ b/src/fava/translations/ko/LC_MESSAGES/messages.po
@@ -152,7 +152,7 @@ msgstr "연도별"
 
 #: frontend/src/lib/interval.ts:23 src/fava/util/date.py:148
 msgid "Quarterly"
-msgstr "연도별"
+msgstr "분기별"
 
 #: frontend/src/lib/interval.ts:24 src/fava/util/date.py:174
 msgid "Monthly"
@@ -180,7 +180,6 @@ msgstr "계속 추가"
 
 #: frontend/src/modals/Context.svelte:36 frontend/src/modals/Context.svelte:40
 #: frontend/src/modals/EntryContextBalances.svelte:25
-#, fuzzy
 msgid "Context"
 msgstr "관련 내역"
 
@@ -229,7 +228,7 @@ msgstr "오류"
 
 #: frontend/src/reports/accounts/AccountReport.svelte:55
 msgid "Journal of all entries for this Account and Sub-Accounts"
-msgstr "거래"
+msgstr "이 계정 및 하위 계정의 전체 저널"
 
 #: frontend/src/reports/accounts/AccountReport.svelte:57
 #: frontend/src/reports/accounts/AccountReport.svelte:60
@@ -462,219 +461,221 @@ msgstr "예산 항목"
 
 #: frontend/src/reports/journal/JournalFilters.svelte:43
 msgid "Metadata"
-msgstr ""
+msgstr "메타데이터"
 
 #: frontend/src/reports/journal/JournalFilters.svelte:43
 msgid "Toggle metadata"
-msgstr ""
+msgstr "메타데이터 표시 전환"
 
 #: frontend/src/reports/journal/JournalFilters.svelte:44
 msgid "Toggle postings"
-msgstr ""
+msgstr "분개 표시 전환"
 
 #: frontend/src/reports/journal/JournalHeaders.svelte:40
 msgid "F"
-msgstr ""
+msgstr "F"
 
 #: frontend/src/reports/journal/JournalHeaders.svelte:55
 #: frontend/src/reports/journal/JournalHeaders.svelte:58
 msgid "Cost"
-msgstr ""
+msgstr "원가"
 
 #: frontend/src/reports/journal/JournalHeaders.svelte:55
 msgid "Change"
-msgstr ""
+msgstr "변동"
 
 #: frontend/src/reports/journal/index.ts:58
 #: frontend/src/sidebar/AsideContents.svelte:30
 msgid "Journal"
-msgstr ""
+msgstr "저널"
 
 #: frontend/src/reports/options/Options.svelte:13
 msgid "Color scheme"
-msgstr ""
+msgstr "색상 테마"
 
 #: frontend/src/reports/options/Options.svelte:20
 msgid "Fava options"
-msgstr ""
+msgstr "Fava 옵션"
 
 #: frontend/src/reports/options/Options.svelte:21
 msgid "help"
-msgstr ""
+msgstr "도움말"
 
 #: frontend/src/reports/options/Options.svelte:25
 msgid "Beancount options"
-msgstr ""
+msgstr "Beancount 옵션"
 
 #: frontend/src/reports/query/QueryEditor.svelte:21
 msgid "…enter a BQL query. 'help' to list available commands."
-msgstr ""
+msgstr "…BQL 쿼리를 입력하세요. 'help'로 명령 목록 확인."
 
 #: frontend/src/reports/query/QueryEditor.svelte:40
 msgid "Submit"
-msgstr ""
+msgstr "실행"
 
 #: frontend/src/reports/query/QueryLinks.svelte:21
 msgid "Download as"
-msgstr ""
+msgstr "다운로드"
 
 #: frontend/src/reports/statistics/EntriesByType.svelte:14
 msgid "Type"
-msgstr ""
+msgstr "유형"
 
 #: frontend/src/reports/statistics/EntriesByType.svelte:15
 msgid "# Entries"
-msgstr ""
+msgstr "항목 수"
 
 #: frontend/src/reports/statistics/EntriesByType.svelte:41
 msgid "Total"
-msgstr ""
+msgstr "합계"
 
 #: frontend/src/reports/statistics/Statistics.svelte:22
 msgid "Postings per Account"
-msgstr ""
+msgstr "계정별 분개 수"
 
 #: frontend/src/reports/statistics/Statistics.svelte:32
 msgid "Update Activity"
-msgstr ""
+msgstr "업데이트 활동"
 
 #: frontend/src/reports/statistics/Statistics.svelte:35
 msgid ""
 "Click to copy balance directives for accounts (except green ones) to the "
 "clipboard."
-msgstr ""
+msgstr "계정 잔액 지시문을 클립보드에 복사합니다 (녹색 계정 제외)."
 
 #: frontend/src/reports/statistics/Statistics.svelte:40
 msgid "Copy balance directives"
-msgstr ""
+msgstr "잔액 지시문 복사"
 
 #: frontend/src/reports/statistics/Statistics.svelte:47
 msgid "Entries per Type"
-msgstr ""
+msgstr "유형별 항목 수"
 
 #: frontend/src/reports/statistics/UpdateActivity.svelte:36
 msgid "Last Entry"
-msgstr ""
+msgstr "최근 항목"
 
 #: frontend/src/reports/statistics/index.ts:37
 #: frontend/src/sidebar/AsideContents.svelte:54
 msgid "Statistics"
-msgstr ""
+msgstr "통계"
 
 #: frontend/src/reports/tree_reports/index.ts:38
 #: frontend/src/sidebar/AsideContents.svelte:27
 msgid "Income Statement"
-msgstr ""
+msgstr "손익계산서"
 
 #: frontend/src/reports/tree_reports/index.ts:49
 #: frontend/src/sidebar/AsideContents.svelte:28
 msgid "Balance Sheet"
-msgstr ""
+msgstr "대차대조표"
 
 #: frontend/src/reports/tree_reports/index.ts:63
 #: frontend/src/sidebar/AsideContents.svelte:29
 msgid "Trial Balance"
-msgstr ""
+msgstr "합계잔액시산표"
 
 #: frontend/src/sidebar/AccountSelector.svelte:22
 msgid "Go to account"
-msgstr ""
+msgstr "계정으로 이동"
 
 #: frontend/src/sidebar/AsideContents.svelte:61
 msgid "Add Journal Entry"
-msgstr ""
+msgstr "거래 추가"
 
 #: frontend/src/sidebar/AsideContents.svelte:76 src/fava/templates/help.html:3
 msgid "Help"
-msgstr ""
+msgstr "도움말"
 
 #: frontend/src/sidebar/FilterForm.svelte:87
 msgid "Time"
-msgstr ""
+msgstr "기간"
 
 #: frontend/src/sidebar/FilterForm.svelte:109
 msgid "Filter by tag, payee, …"
-msgstr ""
+msgstr "태그, 거래처 등으로 필터링"
 
 #: frontend/src/stores/accounts.ts:113 src/fava/json_api.py:682
 #: src/fava/json_api.py:700
 msgid "Net Profit"
-msgstr ""
+msgstr "순이익"
 
 #: frontend/src/stores/chart.ts:28
 msgid "Treemap"
-msgstr ""
+msgstr "트리맵"
 
 #: frontend/src/stores/chart.ts:29
 msgid "Sunburst"
-msgstr ""
+msgstr "선버스트"
 
 #: frontend/src/stores/chart.ts:30
 msgid "Icicle"
-msgstr ""
+msgstr "아이시클"
 
 #: frontend/src/stores/chart.ts:43
 msgid "Line chart"
-msgstr ""
+msgstr "선형 차트"
 
 #: frontend/src/stores/chart.ts:44
 msgid "Area chart"
-msgstr ""
+msgstr "영역 차트"
 
 #: frontend/src/stores/chart.ts:57
 msgid "Stacked Bars"
-msgstr ""
+msgstr "누적 막대"
 
 #: frontend/src/stores/chart.ts:58
 msgid "Single Bars"
-msgstr ""
+msgstr "단일 막대"
 
 #: frontend/src/stores/color_scheme.ts:15
 msgid "System"
-msgstr ""
+msgstr "시스템"
 
 #: frontend/src/stores/color_scheme.ts:16
 msgid "Dark"
-msgstr ""
+msgstr "어둡게"
 
 #: frontend/src/stores/color_scheme.ts:17
 msgid "Light"
-msgstr ""
+msgstr "밝게"
 
 #: frontend/src/tree-table/AccountCellHeader.svelte:23
 msgid ""
 "Hold Shift while clicking to expand all children.\n"
 "Hold Ctrl or Cmd while clicking to expand one level."
 msgstr ""
+"Shift+클릭으로 모든 하위 항목 펼치기.\n"
+"Ctrl 또는 Cmd+클릭으로 한 단계 펼치기."
 
 #: frontend/src/tree-table/AccountCellHeader.svelte:34
 msgid "Expand all accounts"
-msgstr ""
+msgstr "모든 계정 펼치기"
 
 #: frontend/src/tree-table/AccountCellHeader.svelte:39
 msgid "Expand all"
-msgstr ""
+msgstr "모두 펼치기"
 
 #: frontend/src/tree-table/TreeTable.svelte:41
 msgid "Other"
-msgstr ""
+msgstr "기타"
 
 #: src/fava/internal_api.py:171
 msgid "Account Balance"
-msgstr ""
+msgstr "계정 잔액"
 
 #: src/fava/internal_api.py:219
 msgid "Net Worth"
-msgstr ""
+msgstr "순자산"
 
 #: src/fava/json_api.py:688
 msgid "Income"
-msgstr ""
+msgstr "수익"
 
 #: src/fava/json_api.py:694
 msgid "Expenses"
-msgstr ""
+msgstr "지출"
 
 #: src/fava/templates/help.html:8
 msgid "Help pages"
-msgstr ""
+msgstr "도움말 페이지"


### PR DESCRIPTION
## Summary

- Fix `"Quarterly"` mistranslated as `"연도별"` (연도별 = Yearly); corrected to `"분기별"`
- Fix `"Journal of all entries for this Account and Sub-Accounts"` mistranslated as `"거래"` (거래 = Transaction); corrected to `"이 계정 및 하위 계정의 전체 저널"`
- Remove `#, fuzzy` flag from `"Context"` entry
- Complete ~40 missing translations (`msgstr ""`) in the lower half of the file

## Test plan

- [ ] Verify Korean locale renders correctly in fava UI
- [ ] Confirm "Quarterly" interval displays as "분기별" (not "연도별")