### PR TITLE
Adaptive price base

### DIFF
--- a/src/fava/application.py
+++ b/src/fava/application.py
@@ -230,6 +230,7 @@ def _setup_template_config(fava_app: Flask, *, incognito: bool) -> None:
     fava_app.add_template_filter(template_filters.flag_to_type)
     fava_app.add_template_filter(template_filters.format_currency)
     fava_app.add_template_filter(template_filters.meta_items)
+    fava_app.add_template_filter(template_filters.price_base)
     fava_app.add_template_filter(
         template_filters.replace_numbers
         if incognito

--- a/src/fava/template_filters.py
+++ b/src/fava/template_filters.py
@@ -51,6 +51,12 @@ def format_currency(value: Decimal, currency: str | None = None) -> str:
     return g.ledger.format_decimal(value or ZERO, currency)
 
 
+def price_base(value: Decimal) -> Decimal:
+    """Return a scaled base amount for displaying a price."""
+    exponent = max(0, round(-value.log10())) if value > ZERO else 0
+    return Decimal(10) ** exponent
+
+
 FLAGS_TO_TYPES = {"*": "cleared", "!": "pending"}
 
 

--- a/src/fava/templates/_journal_table.html
+++ b/src/fava/templates/_journal_table.html
@@ -1,4 +1,4 @@
-{% from 'macros/_commodity_macros.html' import render_num, render_amount %}
+{% from 'macros/_commodity_macros.html' import render_num, render_amount, render_price %}
 
 {% set short_type = {
    'balance': 'Bal',
@@ -133,7 +133,7 @@
                 <span class='num'>{{ posting.cost.number|incognito }} {{ posting.cost.currency }}
                     {{- ', {}'.format(posting.cost.date) if posting.cost.date else '' }}
                     {{- ', "{}"'.format(posting.cost.label) if posting.cost.label else '' }}</span>
-                {{ render_amount(ledger, posting.price) }}
+                {{ render_price(ledger, posting.units.currency, posting.price) }}
             </p>
             {{ _render_metadata(posting.meta|meta_items) }}
         </li>

--- a/src/fava/templates/macros/_commodity_macros.html
+++ b/src/fava/templates/macros/_commodity_macros.html
@@ -16,7 +16,7 @@
 {% if price is none or price.number is none -%}
   <span class='num'></span>
 {%- else -%}
-  {% set base = price.number|price_base %}
+  {% set base = price.number|price_base -%}
   <span class='num' title='{{ ledger.commodities.name(price.currency) }}'>
     {{- base|format_currency(base_currency)|incognito }} {{ base_currency }} = {{ (base * price.number)|format_currency(price.currency)|incognito }} {{ price.currency -}}
   </span>

--- a/src/fava/templates/macros/_commodity_macros.html
+++ b/src/fava/templates/macros/_commodity_macros.html
@@ -11,3 +11,14 @@
 {% macro render_num(ledger, currency, number) -%}
 <span title='{{ ledger.commodities.name(currency) }}'>{{ number|format_currency(currency)|incognito }} {{ currency }}</span>
 {%- endmacro %}
+
+{% macro render_price(ledger, base_currency, price) %}
+{% if price is none or price.number is none -%}
+  <span class='num'></span>
+{%- else -%}
+  {% set base = price.number|price_base %}
+  <span class='num' title='{{ ledger.commodities.name(price.currency) }}'>
+    {{- base|format_currency(base_currency)|incognito }} {{ base_currency }} = {{ (base * price.number)|format_currency(price.currency)|incognito }} {{ price.currency -}}
+  </span>
+{%- endif %}
+{% endmacro %}

--- a/tests/test_template_filters.py
+++ b/tests/test_template_filters.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 from fava.template_filters import basename
 from fava.template_filters import format_currency
 from fava.template_filters import passthrough_numbers
+from fava.template_filters import price_base
 from fava.template_filters import replace_numbers
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -27,6 +28,15 @@ def test_format_currency(app: Flask) -> None:
     with app.test_request_context("/long-example/"):
         app.preprocess_request()
         assert format_currency(Decimal("2.12")) == "2.12"
+
+
+def test_price_base() -> None:
+    assert price_base(Decimal(2)) == Decimal(1)
+    assert price_base(Decimal("0.5")) == Decimal(1)
+    assert price_base(Decimal("0.2")) == Decimal(10)
+    assert price_base(Decimal("0.02")) == Decimal(100)
+    assert price_base(Decimal("0.000123")) == Decimal(10000)
+    assert price_base(Decimal()) == Decimal(1)
 
 
 def test_basename() -> None:

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -27,6 +27,23 @@ def test_render_amount(app: Flask, example_ledger: FavaLedger) -> None:
         assert macro(example_ledger, create.amount("10 TEST")) == res
 
 
+def test_render_price(app: Flask, example_ledger: FavaLedger) -> None:
+    with app.test_request_context("/long-example/"):
+        app.preprocess_request()
+        macro = get_template_attribute(
+            "macros/_commodity_macros.html",
+            "render_price",
+        )
+        res = "<span class='num'></span>"
+        assert macro(example_ledger, "USD", None) == res
+        res = "  <span class='num' title='TEST'>100.00 USD = 2.00 TEST</span>"
+        assert macro(example_ledger, "USD", create.amount("0.02 TEST")) == res
+        res = (
+            "  <span class='num' title='US Dollar'>1.00 TEST = 2.00 USD</span>"
+        )
+        assert macro(example_ledger, "TEST", create.amount("2 USD")) == res
+
+
 def test_account_name(app: Flask, example_ledger: FavaLedger) -> None:
     with app.test_request_context("/long-example/"):
         app.preprocess_request()

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -36,11 +36,9 @@ def test_render_price(app: Flask, example_ledger: FavaLedger) -> None:
         )
         res = "<span class='num'></span>"
         assert macro(example_ledger, "USD", None) == res
-        res = "  <span class='num' title='TEST'>100.00 USD = 2.00 TEST</span>"
+        res = "<span class='num' title='TEST'>100.00 USD = 2.00 TEST</span>"
         assert macro(example_ledger, "USD", create.amount("0.02 TEST")) == res
-        res = (
-            "  <span class='num' title='US Dollar'>1.00 TEST = 2.00 USD</span>"
-        )
+        res = "<span class='num' title='US Dollar'>1.00 TEST = 2.00 USD</span>"
         assert macro(example_ledger, "TEST", create.amount("2 USD")) == res
 
 


### PR DESCRIPTION
When there is a commodity conversion, in the price column it always shows the per unit price of the target commodity, e.g. if I sell 1 VOO for 695 USD, the price would show 695 USD. This is usually okay for shares where the counterpart commodity is the denominated currency, so the price is usually quite recognizable. However, it may not work well when both sides are fiat currencies and they have very different scale of value. As an example, when converting from USD to JPY or AUD to JPY, the price just shows as `0.01 USD` or `0.01 AUD`, which is not very useful to know the actual exchange rate involved.

This PR changes how price is displayed. It chooses an adaptive price base according to the difference between the pair of commodities. For example, in the case of USD to JPY and AUD to JPY, it would show something like `100 JPY = 0.66 USD` and `100 JPY = 0.91 AUD`, which is much more useful than above.

Disclosure: the implementation is mostly done by AI, but I reviewed the code and think it is a reasonable implementation.