### PR TITLE
Hierarchy visualization in account trees

### DIFF
--- a/frontend/css/base.css
+++ b/frontend/css/base.css
@@ -359,7 +359,7 @@ kbd {
 }
 
 .dimmed {
-  opacity: 0.8;
+  opacity: 0.6;
 }
 
 /*

--- a/frontend/css/fonts.css
+++ b/frontend/css/fonts.css
@@ -5,5 +5,6 @@
 /* Interface fonts */
 @import url("@fontsource/fira-mono/400.css");
 @import url("@fontsource/fira-mono/500.css");
+@import url("@fontsource/fira-mono/700.css");
 @import url("@fontsource/fira-sans/400.css");
 @import url("@fontsource/fira-sans/500.css");

--- a/frontend/css/journal-table.css
+++ b/frontend/css/journal-table.css
@@ -20,6 +20,7 @@
 
   .num {
     font-family: var(--font-family-monospaced);
+    font-weight: 600;
     text-align: right;
   }
 

--- a/frontend/css/journal-table.css
+++ b/frontend/css/journal-table.css
@@ -20,7 +20,7 @@
 
   .num {
     font-family: var(--font-family-monospaced);
-    font-weight: 600;
+    font-weight: 700;
     text-align: right;
   }
 

--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -1,7 +1,7 @@
 :root {
   /* Fonts */
   --font-family: "Fira Sans", sans-serif;
-  --font-family-monospaced: "Fira Mono", monospace;
+  --font-family-monospaced: "Fira Code", "Fira Mono", monospace;
   --font-family-editor: "Source Code Pro", monospace;
 
   color-scheme: light dark;

--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -1,7 +1,7 @@
 :root {
   /* Fonts */
   --font-family: "Fira Sans", sans-serif;
-  --font-family-monospaced: "Fira Code", "Fira Mono", monospace;
+  --font-family-monospaced: "Fira Mono", monospace;
   --font-family-editor: "Source Code Pro", monospace;
 
   color-scheme: light dark;

--- a/frontend/src/tree-table/AccountCell.svelte
+++ b/frontend/src/tree-table/AccountCell.svelte
@@ -18,7 +18,6 @@
 
   let { account, children } = $derived(node);
   let is_toggled = $derived($toggled_accounts.has(account));
-  const level = $derived(String(account.split(":").length - 1));
 </script>
 
 <span class="droptarget" data-account-name={account}>
@@ -33,7 +32,7 @@
       {is_toggled ? "▸" : "▾"}
     </button>
   {/if}
-  <a href={$urlForAccount(account)} class="account acclevel{level}">
+  <a href={$urlForAccount(account)} class="account">
     {leaf(account)}
   </a>
   <AccountIndicator {account} small />
@@ -58,16 +57,6 @@
     min-width: calc(14em - var(--account-indent, 0em));
     max-width: calc(30em - var(--account-indent, 0em));
     margin-left: var(--account-indent, 0);
-  }
-
-  .acclevel1 {
-    /* font-size: 16px; */
-    font-weight: 600;
-  }
-
-  .acclevel2 {
-    font-weight: 600;
-    opacity: 0.7;
   }
 
   /* Indent each level of account by one more 1em. */

--- a/frontend/src/tree-table/AccountCell.svelte
+++ b/frontend/src/tree-table/AccountCell.svelte
@@ -43,6 +43,7 @@
   button {
     position: absolute;
     padding: 0 3px;
+    font-size: 17px;
     color: var(--treetable-expander);
   }
 
@@ -72,14 +73,21 @@
   /* Indent each level of account by one more 1em. */
   :global(ol ol) span {
     --account-indent: 1em;
+
+    font-weight: 700;
   }
 
   :global(ol ol ol) span {
     --account-indent: 2em;
+
+    font-weight: 700;
+    opacity: 0.7; /* Will be inherited to levels below */
   }
 
   :global(ol ol ol ol) span {
     --account-indent: 3em;
+
+    font-weight: 500; /* Will be inherited to levels below */
   }
 
   :global(ol ol ol ol ol) span {

--- a/frontend/src/tree-table/AccountCell.svelte
+++ b/frontend/src/tree-table/AccountCell.svelte
@@ -18,6 +18,7 @@
 
   let { account, children } = $derived(node);
   let is_toggled = $derived($toggled_accounts.has(account));
+  const level = $derived(String(account.split(":").length - 1));
 </script>
 
 <span class="droptarget" data-account-name={account}>
@@ -32,7 +33,7 @@
       {is_toggled ? "▸" : "▾"}
     </button>
   {/if}
-  <a href={$urlForAccount(account)} class="account">
+  <a href={$urlForAccount(account)} class="account acclevel{level}">
     {leaf(account)}
   </a>
   <AccountIndicator {account} small />
@@ -56,6 +57,16 @@
     min-width: calc(14em - var(--account-indent, 0em));
     max-width: calc(30em - var(--account-indent, 0em));
     margin-left: var(--account-indent, 0);
+  }
+
+  .acclevel1 {
+    /* font-size: 16px; */
+    font-weight: 600;
+  }
+
+  .acclevel2 {
+    font-weight: 600;
+    opacity: 0.7;
   }
 
   /* Indent each level of account by one more 1em. */


### PR DESCRIPTION
Currently, on the Balance Sheet (and similar pages), all account names are formatted the same and if you have an account hierarchy with hundreds of accounts their relationship is difficult to comprehend.

This change makes it easier to get an overview of long and multi-level account trees by using subtle highlights.

What was changed:
- New formatting was added for account level 1 and 2. It was deliberately kept simple. Font size is kept the same, only weight and opacity is changed to visualize the hierarchy. This affects Income Statement, Balance Sheet, and Trial Balance.
- No formatting changes were made at level 3 and below.
- Corrected the transparency of dimmed numbers. They had no sufficient contrast with non-dimmed numbers, so they were made more transparent.
- Weight of numbers was increased to make them more legible and increase contrast between dimmed and non-dimmed numbers.
- Formatting of top-level account names (Equity, Expenses, etc.) was not touched, but in the future they would definitely benefit from changing to a title font, or something like that.

Here is a before and after screenshot:
<img width="1864" height="1269" alt="tree-formatting-old" src="https://github.com/user-attachments/assets/7b3c8765-5dd9-405b-a57c-2e0293892433" />

<img width="1867" height="1267" alt="tree-formatting-new" src="https://github.com/user-attachments/assets/2d2ddf83-c28e-416f-b68f-549819a5df15" />
