### PR TITLE
fix print viewport

### DIFF
--- a/frontend/css/layout.css
+++ b/frontend/css/layout.css
@@ -85,7 +85,33 @@ article:has(> .fixed-fullsize-container) {
 }
 
 @media print {
+  /*
+  Print using normal block flow. Firefox does not fragment a CSS grid
+  container across printed pages reliably, which clipped long reports to a
+  single viewport and stranded the account chart/journal on page 2 with
+  whitespace above it. Block flow releases the `100vh` body height and lays
+  out header -> chart -> journal naturally, paginating row by row.
+  (aside is hidden in print.)
+  */
   body {
-    grid-template: "header" max-content "main" 1fr;
+    display: block;
+    width: auto;
+    height: auto;
+    min-height: 0;
+  }
+
+  article {
+    overflow: visible;
+  }
+
+  .fixed-fullsize-container {
+    height: auto;
+    max-height: none;
+  }
+
+  /* Don't split a single transaction across a page break — keeps line items
+     intact for crossing off against a statement. */
+  .journal > li {
+    break-inside: avoid;
   }
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -4417,6 +4417,21 @@
         }
       }
     },
+    "node_modules/svelte-check/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/svelte-eslint-parser": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/svelte-eslint-parser/-/svelte-eslint-parser-1.8.0.tgz",


### PR DESCRIPTION
<!--
Hi, thank you for opening a PR!

Please ensure that your change passes tests and the various linters by running
`make test` and `make lint`. If testable, your changes should be covered by
unit tests.

Explain your changes below and link to related issues.
-->
Firefox does not fragment a CSS grid container across printed pages reliably, which clipped long reports to a single viewport and stranded the account chart/journal on page 2 with whitespace above it. Block flow releases the `100vh` body height and lays out header -> chart -> journal naturally, paginating row by row. (aside is hidden in print.)