### PR TITLE
charts: add brush for date selection; refactors

### DIFF
--- a/frontend/src/api/validators.ts
+++ b/frontend/src/api/validators.ts
@@ -1,5 +1,5 @@
 import { account_hierarchy_validator } from "../charts/hierarchy.ts";
-import { chart_validator } from "../charts/index.ts";
+import { charts_validator } from "../charts/index.ts";
 import { entryBaseValidator } from "../entries/index.ts";
 import type { ValidationT } from "../lib/validation.ts";
 import {
@@ -160,13 +160,13 @@ export const source_validator = object<SourceFile>({
 });
 
 export const tree_report_validator = object({
-  charts: chart_validator,
+  charts: charts_validator,
   trees: array(account_hierarchy_validator),
   date_range: optional(date_range),
 });
 
 export const account_report_validator = object({
-  charts: chart_validator,
+  charts: charts_validator,
   journal: optional(string),
   dates: optional(array(date_range)),
   interval_balances: optional(array(account_hierarchy_validator)),

--- a/frontend/src/charts/Axis.svelte
+++ b/frontend/src/charts/Axis.svelte
@@ -1,3 +1,7 @@
+<!--
+  @component
+  A chart axis (for either an x or y axis).
+-->
 <script lang="ts">
   import type { Axis } from "d3-axis";
   import type { NumberValue } from "d3-scale";
@@ -13,21 +17,21 @@
     /** True if this is a y axis. */
     y?: boolean;
     /** Show a pronounced line at zero (for y axis). */
-    lineAtZero?: number;
-    /** Height of the chart (needed for the correct offset of an x axis) */
-    innerHeight?: number;
+    line_at_zero?: number;
+    /** Height of the chart (needed for the correct offset of an x axis). */
+    inner_height?: number;
   }
 
   let {
     axis,
     x = false,
     y = false,
-    lineAtZero,
-    innerHeight = 0,
+    line_at_zero,
+    inner_height = 0,
   }: Props = $props();
 
   let transform = $derived(
-    x ? `translate(0,${innerHeight.toString()})` : undefined,
+    x ? `translate(0,${inner_height.toString()})` : undefined,
   );
 </script>
 
@@ -42,8 +46,8 @@
     });
   }}
 >
-  {#if y && lineAtZero != null}
-    <g class="zero" transform={`translate(0,${lineAtZero.toString()})`}>
+  {#if y && line_at_zero != null}
+    <g class="zero" transform={`translate(0,${line_at_zero.toString()})`}>
       <line x2={-axis.tickSizeInner()} />
     </g>
   {/if}

--- a/frontend/src/charts/BarChart.svelte
+++ b/frontend/src/charts/BarChart.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { extent } from "d3-array";
+  import { extent, least } from "d3-array";
   import { axisBottom, axisLeft } from "d3-axis";
   import { scaleBand, scaleLinear, scaleOrdinal } from "d3-scale";
 
@@ -7,6 +7,7 @@
   import { barChartMode, chartToggledCurrencies } from "../stores/chart.ts";
   import { ctx, currentTimeFilterDateFormat, short } from "../stores/format.ts";
   import Axis from "./Axis.svelte";
+  import Brush from "./Brush.svelte";
   import type { BarChart } from "./bar.ts";
   import {
     currenciesScale,
@@ -26,41 +27,41 @@
   let { chart, width }: Props = $props();
 
   const today = new Date();
-  const maxColumnWidth = 100;
+
+  // Constant dimensions
+  const max_column_width = 100;
   const margin = { top: 10, right: 10, bottom: 30, left: 40 };
   const height = 250;
+  const inner_height = height - margin.top - margin.bottom;
 
+  // Chart data
   let accounts = $derived(chart.accounts);
+  let { currencies, bar_groups, stacks } = $derived(
+    chart.filter($chartToggledCurrencies),
+  );
 
-  let filtered = $derived(chart.filter($chartToggledCurrencies));
-  let currencies = $derived(filtered.currencies);
-  let bar_groups = $derived(filtered.bar_groups);
-  let stacks = $derived(filtered.stacks);
-
-  let innerHeight = $derived(height - margin.top - margin.bottom);
-  let maxWidth = $derived(bar_groups.length * maxColumnWidth);
-  let offset = $derived(margin.left + Math.max(0, width - maxWidth) / 2);
-  let innerWidth = $derived(
-    Math.min(width - margin.left - margin.right, maxWidth),
+  // Computed dimensions
+  let max_width = $derived(bar_groups.length * max_column_width);
+  let offset = $derived(margin.left + Math.max(0, width - max_width) / 2);
+  let inner_width = $derived(
+    Math.min(width - margin.left - margin.right, max_width),
   );
 
   /** Whether to display stacked bars. */
-  let showStackedBars = $derived(
+  let show_stacked_bars = $derived(
     $barChartMode === "stacked" && chart.hasStackedData,
   );
-  /** The currently hovered account. */
-  let highlighted: string | null = $state(null);
 
   // Scales
   let x0 = $derived(
-    scaleBand([0, innerWidth])
+    scaleBand([0, inner_width])
       .domain(bar_groups.map((d) => d.label))
       .padding(0.1),
   );
   let x1 = $derived(scaleBand([0, x0.bandwidth()]).domain(currencies));
 
-  let yExtent = $derived(
-    showStackedBars
+  let y_extent = $derived(
+    show_stacked_bars
       ? extent(stacks.flatMap(([, s]) => s.flat(2)))
       : extent(
           bar_groups.flatMap((d) => d.values),
@@ -68,32 +69,44 @@
         ),
   );
   let y = $derived(
-    scaleLinear([innerHeight, 0]).domain(padExtent(includeZero(yExtent))),
+    scaleLinear([inner_height, 0]).domain(padExtent(includeZero(y_extent))),
   );
 
-  let colorScale = $derived(
+  let account_color_scale = $derived(
     scaleOrdinal(hclColorRange(accounts.length)).domain(accounts),
   );
 
   // Axes
-  let xAxis = $derived(
+  let x_axis = $derived(
     axisBottom(x0)
       .tickSizeOuter(0)
-      .tickValues(filterTicks(x0.domain(), innerWidth / 70)),
+      .tickValues(filterTicks(x0.domain(), inner_width / 70)),
   );
-  let yAxis = $derived(
-    axisLeft(y).tickPadding(6).tickSize(-innerWidth).tickFormat($short),
+  let y_axis = $derived(
+    axisLeft(y).tickPadding(6).tickSize(-inner_width).tickFormat($short),
   );
+
+  /** Invert a pixel x position to the date of the nearest bar group. */
+  function invert(px: number): Date {
+    const half = x0.bandwidth() / 2;
+    const closest = least(bar_groups, ({ label }) =>
+      Math.abs(px - (x0(label) ?? 0) - half),
+    );
+    return closest?.date ?? new Date();
+  }
 </script>
 
 <svg viewBox={`0 0 ${width.toString()} ${height.toString()}`}>
-  <g transform={`translate(${offset.toString()},${margin.top.toString()})`}>
-    <Axis x axis={xAxis} {innerHeight} />
-    <Axis y axis={yAxis} lineAtZero={y(0)} />
+  <Brush
+    {invert}
+    height={inner_height}
+    transform={`translate(${offset.toString()},${margin.top.toString()})`}
+  >
+    <Axis x axis={x_axis} {inner_height} />
+    <Axis y axis={y_axis} line_at_zero={y(0)} />
     {#each bar_groups as group (group.date)}
       <g
-        class="group"
-        class:desaturate={group.date > today}
+        class={["group", group.date > today && "desaturate"]}
         {@attach followingTooltip(() => chart.tooltipText($ctx, group))}
         transform={`translate(${(x0(group.label) ?? 0).toString()},0)`}
       >
@@ -101,7 +114,7 @@
           class="group-box"
           x={(x0.bandwidth() - x0.step()) / 2}
           width={x0.step()}
-          height={innerHeight}
+          height={inner_height}
         />
         <a
           href={urlForTimeFilter(group.date)}
@@ -109,12 +122,12 @@
         >
           <rect
             class="axis-group-box"
-            transform={`translate(0,${innerHeight.toString()})`}
+            y={inner_height}
             width={x0.bandwidth()}
             height={margin.bottom}
           />
         </a>
-        {#if !showStackedBars}
+        {#if !show_stacked_bars}
           {#each group.values as { currency, value, budget } (currency)}
             <rect
               fill={$currenciesScale(currency)}
@@ -134,36 +147,20 @@
         {/if}
       </g>
     {/each}
-    {#if showStackedBars}
-      {#each stacks as [currency, account_stacks] (currency)}
-        {#each account_stacks as stack (stack.key)}
-          {@const account = stack.key}
-          <a href={$urlForAccount(account)}>
-            <g
-              class="category"
-              class:faded={highlighted != null && account !== highlighted}
-              onmouseover={() => {
-                highlighted = account;
-              }}
-              onfocus={() => {
-                highlighted = account;
-              }}
-              onmouseout={() => {
-                highlighted = null;
-              }}
-              onblur={() => {
-                highlighted = null;
-              }}
-              role="img"
-            >
+    {#if show_stacked_bars}
+      <g class="stacks">
+        {#each stacks as [currency, account_stacks] (currency)}
+          {#each account_stacks as stack (stack.key)}
+            {@const account = stack.key}
+            <a href={$urlForAccount(account)}>
               {#each stack as bar (bar.data.date)}
                 <rect
-                  class:desaturate={bar.data.date > today}
+                  class={[bar.data.date > today && "desaturate"]}
                   width={x1.bandwidth()}
                   x={(x0(bar.data.label) ?? 0) + (x1(currency) ?? 0)}
                   y={y(Math.max(bar[0], bar[1]))}
                   height={Math.abs(y(bar[1]) - y(bar[0]))}
-                  fill={colorScale(account)}
+                  fill={account_color_scale(account)}
                   {@attach followingTooltip(() =>
                     chart.tooltipTextAccount(
                       $ctx,
@@ -174,24 +171,20 @@
                   )}
                 />
               {/each}
-            </g>
-          </a>
+            </a>
+          {/each}
         {/each}
-      {/each}
+      </g>
     {/if}
-  </g>
+  </Brush>
 </svg>
 
 <style>
-  .category.faded {
+  .stacks:hover a:not(:hover) {
     opacity: 0.5;
   }
 
-  .axis-group-box {
-    cursor: pointer;
-    opacity: 0;
-  }
-
+  .axis-group-box,
   .group-box {
     opacity: 0;
   }

--- a/frontend/src/charts/Brush.svelte
+++ b/frontend/src/charts/Brush.svelte
@@ -1,0 +1,134 @@
+<!--
+  @component
+  A `<g>` wrapper for a brush for a horizontal time selection by dragging.
+
+  Can show a positioned tooltip by providing a find function.
+-->
+<script lang="ts">
+  import { pointer } from "d3-selection";
+  import type { Snippet } from "svelte";
+  import type { SVGAttributes } from "svelte/elements";
+
+  import { router } from "../router.ts";
+  import { currentTimeFilterDateFormat } from "../stores/format.ts";
+  import { hide, type TooltipFindNode, tooltip } from "./tooltip.ts";
+
+  /** Ignore tiny drags less than 5px. */
+  const DRAG_THRESHOLD = 5;
+
+  interface Props extends Pick<SVGAttributes<SVGGElement>, "transform"> {
+    /** Function to invert an x position to its date. */
+    invert: (px: number) => Date;
+    /** Height of the `<g>`. */
+    height: number;
+    /** Optional content for a following tooltip to show. */
+    find?: TooltipFindNode;
+    children: Snippet;
+  }
+
+  let { invert, height, children, find, transform }: Props = $props();
+
+  let x_start = $state(0);
+  let x_current = $state(0);
+  let active_pointer_id = $state<number>();
+
+  let active = $derived(
+    active_pointer_id != null && Math.abs(x_current - x_start) > DRAG_THRESHOLD,
+  );
+
+  function onpointerdown(event: PointerEvent) {
+    if (
+      active_pointer_id != null ||
+      event.button !== 0 ||
+      event.ctrlKey ||
+      event.metaKey ||
+      event.shiftKey
+    ) {
+      return;
+    }
+    [x_start] = pointer(event);
+    x_current = x_start;
+    active_pointer_id = event.pointerId;
+    event.preventDefault();
+  }
+
+  function onpointermove(event: PointerEvent & { currentTarget: SVGGElement }) {
+    const [x_pointer, y_pointer] = pointer(event);
+    if (find != null) {
+      const res = find(x_pointer, y_pointer);
+      const matrix = event.currentTarget.getScreenCTM();
+      if (res && matrix) {
+        const [x, y, content] = res;
+        const t = tooltip();
+        t.style.opacity = "1";
+        t.replaceChildren(...content);
+        t.style.left = `${(window.scrollX + x + matrix.e).toString()}px`;
+        t.style.top = `${(window.scrollY + y + matrix.f - 15).toString()}px`;
+      } else {
+        hide();
+      }
+    }
+    if (event.pointerId !== active_pointer_id) {
+      return;
+    }
+    x_current = x_pointer;
+  }
+
+  function onpointerup(event: PointerEvent) {
+    if (event.pointerId !== active_pointer_id) {
+      return;
+    }
+    if (active) {
+      const [x_end] = pointer(event);
+      const start_date = invert(Math.min(x_start, x_end));
+      const end_date = invert(Math.max(x_start, x_end));
+      const start = $currentTimeFilterDateFormat(start_date);
+      const end = $currentTimeFilterDateFormat(end_date);
+      const time_filter = start === end ? start : `${start} - ${end}`;
+      router.set_search_param("time", time_filter);
+    }
+    active_pointer_id = undefined;
+  }
+
+  function onpointerleave() {
+    // Cancel when leaving the container element
+    active_pointer_id = undefined;
+    hide();
+  }
+</script>
+
+<g
+  class={{ active }}
+  role="application"
+  {transform}
+  {onpointerdown}
+  {onpointermove}
+  {onpointerleave}
+  {onpointerup}
+>
+  {@render children()}
+  {#if active}
+    <rect
+      x={Math.min(x_start, x_current)}
+      y="0"
+      {height}
+      width={Math.abs(x_current - x_start)}
+    />
+  {/if}
+</g>
+
+<style>
+  g {
+    pointer-events: all;
+    touch-action: pan-y pinch-zoom;
+  }
+
+  g.active {
+    cursor: ew-resize;
+  }
+
+  rect {
+    opacity: 0.1;
+    fill: var(--text-color);
+  }
+</style>

--- a/frontend/src/charts/Chart.svelte
+++ b/frontend/src/charts/Chart.svelte
@@ -27,7 +27,7 @@
   let { chart, children }: Props = $props();
 
   /** Width of the chart. */
-  let width: number | undefined = $state();
+  let width = $state<number>();
 </script>
 
 <div class="flex-row">

--- a/frontend/src/charts/ChartLegend.svelte
+++ b/frontend/src/charts/ChartLegend.svelte
@@ -1,3 +1,7 @@
+<!--
+  @component
+  A chart legend, allowing toggling of items.
+-->
 <script lang="ts">
   import type { Writable } from "svelte/store";
 

--- a/frontend/src/charts/HierarchyContainer.svelte
+++ b/frontend/src/charts/HierarchyContainer.svelte
@@ -41,30 +41,28 @@
     height={treemap_height}
   />
 {:else if mode === "sunburst"}
+  {@const single_width = width / currencies.length}
   <svg viewBox={`0 0 ${width.toString()} ${sunburst_height.toString()}`}>
     {#each [...data] as [chart_currency, d], i (chart_currency)}
-      <g
-        transform={`translate(${((width * i) / currencies.length).toString()},0)`}
-      >
+      <g transform={`translate(${(single_width * i).toString()},0)`}>
         <Sunburst
           data={d}
           currency={chart_currency}
-          width={width / currencies.length}
+          width={single_width}
           height={sunburst_height}
         />
       </g>
     {/each}
   </svg>
 {:else if mode === "icicle"}
+  {@const single_width = width / currencies.length}
   <svg viewBox={`0 0 ${width.toString()} ${icicle_height.toString()}`}>
     {#each [...data] as [chart_currency, d], i (chart_currency)}
-      <g
-        transform={`translate(${((width * i) / currencies.length).toString()},0)`}
-      >
+      <g transform={`translate(${(single_width * i).toString()},0)`}>
         <Icicle
           data={d}
           currency={chart_currency}
-          width={width / currencies.length}
+          width={single_width}
           height={icicle_height}
         />
       </g>

--- a/frontend/src/charts/Icicle.svelte
+++ b/frontend/src/charts/Icicle.svelte
@@ -1,14 +1,14 @@
 <script lang="ts">
   import { partition } from "d3-hierarchy";
 
-  import { formatPercentage } from "../format.ts";
   import { urlForAccount } from "../helpers.ts";
   import { leaf } from "../lib/account.ts";
   import { ctx } from "../stores/format.ts";
   import { sunburstScale } from "./helpers.ts";
-  import type {
-    AccountHierarchyDatum,
-    AccountHierarchyNode,
+  import {
+    type AccountHierarchyDatum,
+    type AccountHierarchyNode,
+    balance_with_percentage,
   } from "./hierarchy.ts";
   import { domHelpers, followingTooltip } from "./tooltip.ts";
 
@@ -24,33 +24,24 @@
   let root = $derived(partition<AccountHierarchyDatum>()(data));
   let nodes = $derived(root.descendants().filter((d) => !d.data.dummy));
 
-  let current: string | null = $state(null);
-
-  function tooltipText(d: AccountHierarchyNode) {
-    const val = d.value ?? 0;
-    const rootValue = root.value ?? 1;
-
-    return [
-      domHelpers.t(
-        `${$ctx.amount(val, currency)} (${formatPercentage(val / rootValue)})`,
-      ),
-      domHelpers.em(d.data.account),
-    ];
-  }
+  let current = $state<string>();
 </script>
 
 <g
   {width}
   {height}
   onmouseleave={() => {
-    current = null;
+    current = undefined;
   }}
   role="img"
 >
   {#each nodes as d (d.data.account)}
     {@const account = d.data.account}
     <g
-      {@attach followingTooltip(() => tooltipText(d))}
+      {@attach followingTooltip(() => [
+        balance_with_percentage($ctx, d, currency),
+        domHelpers.em(account),
+      ])}
       class:current={current != null ? current.startsWith(account) : false}
     >
       <a

--- a/frontend/src/charts/LineChart.svelte
+++ b/frontend/src/charts/LineChart.svelte
@@ -8,10 +8,10 @@
   import { chartToggledCurrencies, lineChartMode } from "../stores/chart.ts";
   import { ctx, short } from "../stores/format.ts";
   import Axis from "./Axis.svelte";
+  import Brush from "./Brush.svelte";
   import { currenciesScale, includeZero, padExtent } from "./helpers.ts";
   import type { LineChart, LineChartDatum } from "./line.ts";
   import type { TooltipFindNode } from "./tooltip.ts";
-  import { positionedTooltip } from "./tooltip.ts";
 
   interface Props {
     chart: LineChart;
@@ -20,91 +20,101 @@
 
   let { chart, width }: Props = $props();
 
+  const uid = $props.id();
   const today = new Date();
+
+  // Constant dimensions
   const margin = { top: 10, right: 10, bottom: 30, left: 40 };
   const height = 250;
-  let innerWidth = $derived(width - margin.left - margin.right);
-  let innerHeight = $derived(height - margin.top - margin.bottom);
+  const inner_height = height - margin.top - margin.bottom;
+
+  // Derived dimensions
+  let inner_width = $derived(width - margin.left - margin.right);
 
   let data = $derived(chart.filter($chartToggledCurrencies));
 
   // Scales and quadtree
-  let allValues = $derived(data.flatMap((d) => d.values));
+  let all_values = $derived(data.flatMap((d) => d.values));
 
-  let xExtent = $derived([
+  let x_extent = $derived([
     min(data, (s) => s.values[0]?.date) ?? today,
     max(data, (s) => s.values[s.values.length - 1]?.date) ?? today,
   ] as const);
-  let x = $derived(scaleUtc([0, innerWidth]).domain(xExtent));
-  let valueExtent = $derived(extent(allValues, (v) => v.value));
+  let x = $derived(scaleUtc([0, inner_width]).domain(x_extent));
+  let value_extent = $derived(extent(all_values, (v) => v.value));
   // Include zero in area charts so the entire area is shown, not a cropped part of it
-  let yExtent = $derived(
-    $lineChartMode === "area" ? includeZero(valueExtent) : valueExtent,
+  let y_extent = $derived(
+    $lineChartMode === "area" ? includeZero(value_extent) : value_extent,
   );
   // Span y-axis as max minus min value plus 5 percent margin
-  let y = $derived(scaleLinear([innerHeight, 0]).domain(padExtent(yExtent)));
+  let y = $derived(scaleLinear([inner_height, 0]).domain(padExtent(y_extent)));
 
   // Quadtree for hover.
   let quad = $derived(
     quadtree(
-      allValues,
+      all_values,
       (d) => x(d.date),
       (d) => y(d.value),
     ),
   );
 
-  let lineShape = $derived(
+  let line_shape = $derived(
     line<LineChartDatum>()
       .x((d) => x(d.date))
       .y((d) => y(d.value))
       .curve(curveStepAfter),
   );
 
-  let areaShape = $derived(
+  let area_shape = $derived(
     area<LineChartDatum>()
       .x((d) => x(d.date))
       .y1((d) => y(d.value))
-      .y0(Math.min(innerHeight, y(0)))
+      .y0(Math.min(inner_height, y(0)))
       .curve(curveStepAfter),
   );
 
   // Axes
-  let xAxis = $derived(axisBottom(x).tickSizeOuter(0));
-  let yAxis = $derived(
-    axisLeft(y).tickPadding(6).tickSize(-innerWidth).tickFormat($short),
+  let x_axis = $derived(axisBottom(x).tickSizeOuter(0));
+  let y_axis = $derived(
+    axisLeft(y).tickPadding(6).tickSize(-inner_width).tickFormat($short),
   );
 
-  const tooltipFindNode: TooltipFindNode = (xPos, yPos) => {
-    const d = quad.find(xPos, yPos);
+  const tooltip_find: TooltipFindNode = (x_pointer, y_pointer) => {
+    const d = quad.find(x_pointer, y_pointer);
     return d && [x(d.date), y(d.value), chart.tooltipText($ctx, d)];
   };
 
-  let futureFilter = $derived(
-    xExtent[1] > today ? "url(#desaturateFuture)" : undefined,
+  let desaturate_filter_id = $derived(`desaturate-future-${uid}`);
+  let desaturate_future_filter = $derived(
+    x_extent[1] > today ? `url(#${desaturate_filter_id})` : undefined,
   );
 </script>
 
 <svg viewBox={`0 0 ${width.toString()} ${height.toString()}`}>
-  <filter id="desaturateFuture">
-    <feColorMatrix type="saturate" values="0.5" x={x(today)} />
-    <feBlend in2="SourceGraphic" />
-  </filter>
-  <g
-    {@attach positionedTooltip(tooltipFindNode)}
+  <defs>
+    <filter id={desaturate_filter_id}>
+      <feColorMatrix type="saturate" values="0.5" x={x(today)} />
+      <feBlend in2="SourceGraphic" />
+    </filter>
+  </defs>
+  <Brush
+    invert={x.invert.bind(x)}
+    height={inner_height}
+    find={tooltip_find}
     transform={`translate(${margin.left.toString()},${margin.top.toString()})`}
   >
-    <Axis x axis={xAxis} {innerHeight} />
-    <Axis y axis={yAxis} />
+    <Axis x axis={x_axis} {inner_height} />
+    <Axis y axis={y_axis} />
     {#if $lineChartMode === "area"}
-      <g class="area" filter={futureFilter}>
+      <g class="area" filter={desaturate_future_filter}>
         {#each data as d (d.name)}
-          <path d={areaShape(d.values)} fill={$currenciesScale(d.name)} />
+          <path d={area_shape(d.values)} fill={$currenciesScale(d.name)} />
         {/each}
       </g>
     {/if}
-    <g class="lines" filter={futureFilter}>
+    <g class="lines" filter={desaturate_future_filter}>
       {#each data as d (d.name)}
-        <path d={lineShape(d.values)} stroke={$currenciesScale(d.name)} />
+        <path d={line_shape(d.values)} stroke={$currenciesScale(d.name)} />
       {/each}
     </g>
     {#if $lineChartMode === "line"}
@@ -123,14 +133,10 @@
         {/each}
       </g>
     {/if}
-  </g>
+  </Brush>
 </svg>
 
 <style>
-  svg > g {
-    pointer-events: all;
-  }
-
   .lines path {
     fill: none;
     stroke-width: 2px;

--- a/frontend/src/charts/ScatterPlot.svelte
+++ b/frontend/src/charts/ScatterPlot.svelte
@@ -6,10 +6,11 @@
 
   import { day } from "../format.ts";
   import Axis from "./Axis.svelte";
+  import Brush from "./Brush.svelte";
   import { scatterplotScale } from "./helpers.ts";
   import type { ScatterPlot, ScatterPlotDatum } from "./scatterplot.ts";
   import type { TooltipFindNode } from "./tooltip.ts";
-  import { domHelpers, positionedTooltip } from "./tooltip.ts";
+  import { domHelpers } from "./tooltip.ts";
 
   interface Props {
     chart: ScatterPlot;
@@ -19,28 +20,32 @@
   let { chart, width }: Props = $props();
 
   const today = new Date();
+
+  // Constant dimensions
   const margin = { top: 10, right: 10, bottom: 30, left: 70 };
   const height = 250;
-  let innerWidth = $derived(width - margin.left - margin.right);
-  let innerHeight = $derived(height - margin.top - margin.bottom);
+  const inner_height = height - margin.top - margin.bottom;
+
+  // Derived dimensions
+  let inner_width = $derived(width - margin.left - margin.right);
 
   // Scales
-  let dateExtent = $derived(extent(chart.data, (d) => d.date));
+  let date_extent = $derived(extent(chart.data, (d) => d.date));
   let x = $derived(
-    scaleUtc([0, innerWidth]).domain(dateExtent[0] ? dateExtent : [0, 1]),
+    scaleUtc([0, inner_width]).domain(date_extent[0] ? date_extent : [0, 1]),
   );
   let y = $derived(
-    scalePoint([innerHeight, 0])
+    scalePoint([inner_height, 0])
       .domain(chart.data.map((d) => d.type))
       .padding(1),
   );
 
   // Axes
-  let xAxis = $derived(axisBottom(x).tickSizeOuter(0));
-  let yAxis = $derived(
+  let x_axis = $derived(axisBottom(x).tickSizeOuter(0));
+  let y_axis = $derived(
     axisLeft(y)
       .tickPadding(6)
-      .tickSize(-innerWidth)
+      .tickSize(-inner_width)
       .tickFormat((d) => d),
   );
 
@@ -54,22 +59,24 @@
   );
 
   function tooltipText(d: ScatterPlotDatum) {
-    return [domHelpers.t(d.description), domHelpers.em(day(d.date))];
+    return [d.description, domHelpers.em(day(d.date))];
   }
 
-  const tooltipFindNode: TooltipFindNode = (xPos, yPos) => {
-    const d = quad.find(xPos, yPos);
+  const tooltip_find: TooltipFindNode = (x_pointer, y_pointer) => {
+    const d = quad.find(x_pointer, y_pointer);
     return d && [x(d.date), y(d.type) ?? 0, tooltipText(d)];
   };
 </script>
 
 <svg viewBox={`0 0 ${width.toString()} ${height.toString()}`}>
-  <g
-    {@attach positionedTooltip(tooltipFindNode)}
+  <Brush
+    invert={x.invert.bind(x)}
+    height={inner_height}
+    find={tooltip_find}
     transform={`translate(${margin.left.toString()},${margin.top.toString()})`}
   >
-    <Axis x axis={xAxis} {innerHeight} />
-    <Axis y axis={yAxis} />
+    <Axis x axis={x_axis} {inner_height} />
+    <Axis y axis={y_axis} />
     <g>
       {#each chart.data as dot (`${dot.date.toString()}-${dot.type}`)}
         <circle
@@ -81,14 +88,10 @@
         />
       {/each}
     </g>
-  </g>
+  </Brush>
 </svg>
 
 <style>
-  svg > g {
-    pointer-events: all;
-  }
-
   .desaturate {
     filter: saturate(50%);
   }

--- a/frontend/src/charts/SelectCombobox.svelte
+++ b/frontend/src/charts/SelectCombobox.svelte
@@ -40,7 +40,7 @@
   // svelte-ignore state_referenced_locally
   let index = $state(options.indexOf(value));
   /** The popup list element. */
-  let ul: HTMLUListElement | undefined = $state();
+  let ul = $state<HTMLUListElement>();
 
   const uid = $props.id();
   const listbox_id = `combobox-listbox-${uid}`;

--- a/frontend/src/charts/Sunburst.svelte
+++ b/frontend/src/charts/Sunburst.svelte
@@ -5,13 +5,13 @@
   import { arc } from "d3-shape";
   import { untrack } from "svelte";
 
-  import { formatPercentage } from "../format.ts";
   import { urlForAccount } from "../helpers.ts";
   import { ctx } from "../stores/format.ts";
   import { sunburstScale } from "./helpers.ts";
-  import type {
-    AccountHierarchyDatum,
-    AccountHierarchyNode,
+  import {
+    type AccountHierarchyDatum,
+    type AccountHierarchyNode,
+    balance_with_percentage,
   } from "./hierarchy.ts";
 
   interface Props {
@@ -30,23 +30,15 @@
     root.descendants().filter((d) => !d.data.dummy && d.depth > 0),
   );
 
-  let current: AccountHierarchyNode | null = $state(null);
+  let current = $state<AccountHierarchyNode>();
 
   $effect.pre(() => {
     // if-expression to run on each change of chart
     void data;
     untrack(() => {
-      current = null;
+      current = undefined;
     });
   });
-
-  function balanceText(d: AccountHierarchyNode): string {
-    const val = d.value ?? 0;
-    const total = root.value ?? 0;
-    return total
-      ? `${$ctx.amount(val, currency)} (${formatPercentage(val / total)})`
-      : $ctx.amount(val, currency);
-  }
 
   const x = scaleLinear([0, 2 * Math.PI]);
   let y = $derived(scaleSqrt([0, radius]));
@@ -64,7 +56,7 @@
   {height}
   transform={`translate(${(width / 2).toString()},${(height / 2).toString()})`}
   onmouseleave={() => {
-    current = null;
+    current = undefined;
   }}
   role="img"
 >
@@ -73,7 +65,7 @@
     {(current ?? root).data.account}
   </text>
   <text class="balance" dy="1.2em" text-anchor="middle">
-    {balanceText(current ?? root)}
+    {balance_with_percentage($ctx, current ?? root, currency)}
   </text>
   {#each nodes as d (d.data.account)}
     <a href={$urlForAccount(d.data.account)} aria-label={d.data.account}>

--- a/frontend/src/charts/Treemap.svelte
+++ b/frontend/src/charts/Treemap.svelte
@@ -1,14 +1,14 @@
 <script lang="ts">
   import { treemap } from "d3-hierarchy";
 
-  import { formatPercentage } from "../format.ts";
   import { urlForAccount } from "../helpers.ts";
   import { leaf } from "../lib/account.ts";
   import { ctx } from "../stores/format.ts";
   import { treemapScale } from "./helpers.ts";
-  import type {
-    AccountHierarchyDatum,
-    AccountHierarchyNode,
+  import {
+    type AccountHierarchyDatum,
+    type AccountHierarchyNode,
+    balance_with_percentage,
   } from "./hierarchy.ts";
   import { domHelpers, followingTooltip } from "./tooltip.ts";
 
@@ -29,22 +29,11 @@
 
   function fill(d: AccountHierarchyNode) {
     const node = d.data.dummy && d.parent ? d.parent : d;
-    if (node.depth === 1 || !node.parent) {
-      return $treemapScale(node.data.account);
-    }
-    return $treemapScale(node.parent.data.account);
-  }
-
-  function tooltipText(d: AccountHierarchyNode) {
-    const val = d.value ?? 0;
-    const rootValue = root.value ?? 1;
-
-    return [
-      domHelpers.t(
-        `${$ctx.amount(val, currency)} (${formatPercentage(val / rootValue)})`,
-      ),
-      domHelpers.em(d.data.account),
-    ];
+    return $treemapScale(
+      node.depth === 1 || !node.parent
+        ? node.data.account
+        : node.parent.data.account,
+    );
   }
 </script>
 
@@ -53,7 +42,10 @@
     {@const account = d.data.account}
     <g
       transform={`translate(${d.x0.toString()},${d.y0.toString()})`}
-      {@attach followingTooltip(() => tooltipText(d))}
+      {@attach followingTooltip(() => [
+        balance_with_percentage($ctx, d, currency),
+        domHelpers.em(account),
+      ])}
     >
       <rect fill={fill(d)} width={d.x1 - d.x0} height={d.y1 - d.y0} />
       <a href={$urlForAccount(account)}>

--- a/frontend/src/charts/bar.ts
+++ b/frontend/src/charts/bar.ts
@@ -96,7 +96,7 @@ export class BarChart {
 
   /** The tooltip for a hovered account in the stacked bar chart. */
   tooltipTextAccount(
-    c: FormatterContext,
+    $ctx: FormatterContext,
     d: BarChartDatum,
     account: string,
     $chartToggledCurrencies: readonly string[],
@@ -106,7 +106,7 @@ export class BarChart {
     d.values.forEach(({ currency }) => {
       if (!$chartToggledCurrencies.includes(currency)) {
         const value = d.account_balances[account]?.[currency] ?? 0;
-        content.push(domHelpers.t(c.amount(value, currency)));
+        content.push($ctx.amount(value, currency));
         content.push(domHelpers.br());
       }
     });
@@ -115,18 +115,13 @@ export class BarChart {
   }
 
   /** The tooltip for a hovered bar group in the bar chart. */
-  tooltipText(c: FormatterContext, d: BarChartDatum): TooltipContent {
+  tooltipText($ctx: FormatterContext, d: BarChartDatum): TooltipContent {
     const content = [];
-    d.values.forEach((a) => {
+    d.values.forEach(({ value, currency, budget }) => {
       content.push(
-        domHelpers.t(
-          a.budget
-            ? `${c.amount(a.value, a.currency)} / ${c.amount(
-                a.budget,
-                a.currency,
-              )}`
-            : c.amount(a.value, a.currency),
-        ),
+        budget
+          ? `${$ctx.amount(value, currency)} / ${$ctx.amount(budget, currency)}`
+          : $ctx.amount(value, currency),
       );
       content.push(domHelpers.br());
     });

--- a/frontend/src/charts/hierarchy.ts
+++ b/frontend/src/charts/hierarchy.ts
@@ -4,6 +4,7 @@ import { hierarchy as d3Hierarchy } from "d3-hierarchy";
 import type { Writable } from "svelte/store";
 import { writable } from "svelte/store";
 
+import type { FormatterContext } from "../format.ts";
 import type { TreeNode } from "../lib/tree.ts";
 import type { Validator } from "../lib/validation.ts";
 import {
@@ -66,6 +67,19 @@ type AccountHierarchyInputDatum = TreeNode<{
 
 /** A d3-hierarchy node for an account. */
 export type AccountHierarchyNode = HierarchyNode<AccountHierarchyDatum>;
+
+/** Render the account balance with a percentage of the total. */
+export function balance_with_percentage(
+  $ctx: FormatterContext,
+  d: AccountHierarchyNode,
+  currency: string,
+): string {
+  const value = d.value ?? 0;
+  const root_value = d.ancestors().at(-1)?.value ?? 0;
+  return root_value
+    ? `${$ctx.amount(value, currency)} (${$ctx.percentage(value / root_value)})`
+    : $ctx.amount(value, currency);
+}
 
 /**
  * Add internal nodes as dummy leaf nodes to their own children.

--- a/frontend/src/charts/index.ts
+++ b/frontend/src/charts/index.ts
@@ -25,7 +25,7 @@ export interface ParsedFavaChart {
   with_context($chartContext: ChartContext): FavaChart;
 }
 
-export const chart_validator: Validator<ParsedFavaChart[]> = array(
+export const charts_validator: Validator<ParsedFavaChart[]> = array(
   tagged_union("type", {
     balances: ParsedLineChart.validator,
     bar: ParsedBarChart.validator,

--- a/frontend/src/charts/line.ts
+++ b/frontend/src/charts/line.ts
@@ -44,14 +44,14 @@ export class LineChart {
   readonly label: string | null;
   private readonly data: readonly LineChartSeries[];
   readonly tooltipText: (
-    c: FormatterContext,
+    $ctx: FormatterContext,
     d: LineChartDatum,
   ) => TooltipContent;
 
   constructor(
     label: string | null,
     data: readonly LineChartSeries[],
-    tooltipText: (c: FormatterContext, d: LineChartDatum) => TooltipContent,
+    tooltipText: ($ctx: FormatterContext, d: LineChartDatum) => TooltipContent,
   ) {
     this.label = label;
     this.data = sort(data, (d) => -d.values.length);
@@ -110,7 +110,7 @@ export class ParsedLineChart implements ParsedFavaChart {
     }));
 
     return new LineChart(this.label, data, (c, d) => [
-      domHelpers.t(c.amount(d.value, d.name)),
+      c.amount(d.value, d.name),
       domHelpers.em(day(d.date)),
     ]);
   }

--- a/frontend/src/charts/tooltip.ts
+++ b/frontend/src/charts/tooltip.ts
@@ -1,8 +1,7 @@
-import { pointer } from "d3-selection";
 import type { Attachment } from "svelte/attachments";
 
 /** The tooltip `<div>`, lazily created. */
-const tooltip = (() => {
+export const tooltip = (() => {
   let value: HTMLDivElement | null = null;
   return () => {
     if (value == null) {
@@ -15,7 +14,7 @@ const tooltip = (() => {
 })();
 
 /** Hide the tooltip. */
-const hide = (): void => {
+export const hide = (): void => {
   const t = tooltip();
   t.style.opacity = "0";
 };
@@ -23,53 +22,44 @@ const hide = (): void => {
 /** Some small utilities to create tooltip contents. */
 export const domHelpers = {
   /** Create a <br> element. */
-  br: (): HTMLBRElement => document.createElement("br"),
+  br: () => document.createElement("br"),
   /** Create a <em> element with the given content. */
-  em: (content: string): HTMLElement => {
+  em: (content) => {
     const em = document.createElement("em");
     em.textContent = content;
     return em;
   },
-  /** Create a text node for the given text. */
-  t: (text: string): Text => document.createTextNode(text),
-  /** Create a <pre> element with the given content. */
-  pre: (content: string): HTMLPreElement => {
-    const pre = document.createElement("pre");
-    pre.textContent = content;
-    return pre;
-  },
-};
+} satisfies Record<string, (x: string) => HTMLElement>;
 
-export type TooltipContent = (HTMLElement | Text)[];
+export type TooltipContent = (HTMLElement | string)[];
 
 /**
  * Svelte attachment to have the given element act on mouse to show a tooltip.
  *
  * The tooltip will be positioned at the cursor and is given a tooltip getter
- * per <g> element.
+ * per element.
  */
 export const followingTooltip = (
   getter: () => TooltipContent,
-): Attachment<SVGGElement> => {
+): Attachment<SVGElement> => {
   return (node) => {
-    /** Event listener to have the tooltip follow the mouse. */
-    function followMouse(event: MouseEvent) {
+    const mouseenter = () => {
+      const t = tooltip();
+      t.replaceChildren(...getter());
+    };
+    function mousemove(event: MouseEvent) {
       const t = tooltip();
       t.style.opacity = "1";
       t.style.left = `${event.pageX.toString()}px`;
       t.style.top = `${(event.pageY - 15).toString()}px`;
     }
-    const mouseenter = () => {
-      const t = tooltip();
-      t.replaceChildren(...getter());
-    };
     node.addEventListener("mouseenter", mouseenter);
-    node.addEventListener("mousemove", followMouse);
+    node.addEventListener("mousemove", mousemove);
     node.addEventListener("mouseleave", hide);
 
     return () => {
       node.removeEventListener("mouseenter", mouseenter);
-      node.removeEventListener("mousemove", followMouse);
+      node.removeEventListener("mousemove", mousemove);
       node.removeEventListener("mouseleave", hide);
       hide();
     };
@@ -78,44 +68,6 @@ export const followingTooltip = (
 
 /** A function to find the closest node and the content to show in the tooltip. */
 export type TooltipFindNode = (
-  x: number,
-  y: number,
+  x_pointer: number,
+  y_pointer: number,
 ) => [number, number, TooltipContent] | undefined;
-
-/**
- * Svelte attachment to have the given <g> element act on mouse to show a tooltip.
- *
- * The parameter to the tooltip is a function that takes a position (relative
- * to the container) as input and should return the position of the tooltip,
- * i.e., the found node, again relative to the container and the desired
- * content of the tooltip.
- */
-export const positionedTooltip = (
-  find: TooltipFindNode,
-): Attachment<SVGGElement> => {
-  return (node) => {
-    function mousemove(event: MouseEvent) {
-      const [xPointer, yPointer] = pointer(event);
-      const res = find(xPointer, yPointer);
-      const matrix = node.getScreenCTM();
-      if (res && matrix) {
-        const [x, y, content] = res;
-        const t = tooltip();
-        t.style.opacity = "1";
-        t.replaceChildren(...content);
-        t.style.left = `${(window.scrollX + x + matrix.e).toString()}px`;
-        t.style.top = `${(window.scrollY + y + matrix.f - 15).toString()}px`;
-      } else {
-        hide();
-      }
-    }
-    node.addEventListener("mousemove", mousemove);
-    node.addEventListener("mouseleave", hide);
-
-    return () => {
-      node.removeEventListener("mousemove", mousemove);
-      node.removeEventListener("mouseleave", hide);
-      hide();
-    };
-  };
-};

--- a/frontend/src/format.ts
+++ b/frontend/src/format.ts
@@ -28,9 +28,9 @@ export function localeFormatter(
   return fmt.format.bind(fmt);
 }
 
-const formatterPer = format(".2f");
-export function formatPercentage(number: number): string {
-  return `${formatterPer(Math.abs(number) * 100)}%`;
+const percentage_format = format(".2f");
+function percentage(number: number): string {
+  return `${percentage_format(Math.abs(number) * 100)}%`;
 }
 
 /** Obscure numbers for incognito mode. */
@@ -42,6 +42,8 @@ export interface FormatterContext {
   amount: (num: number, currency: string) => string;
   /** Render an number for a currency like "2.00". */
   num: (num: number, currency: string) => string;
+  /** Render a percentage, e.g. a 0.8345 as "83.45%". */
+  percentage: (num: number) => string;
 }
 
 /** Build the formatter context for the given configuration */
@@ -63,11 +65,9 @@ export function formatter_context(
   const num = incognito
     ? (n: number, c: string) => replaceNumbers(num_raw(n, c))
     : num_raw;
+  const amount = (n: number, c: string) => `${num(n, c)} ${c}`;
 
-  return {
-    amount: (n, c) => `${num(n, c)} ${c}`,
-    num,
-  };
+  return { amount, num, percentage };
 }
 
 type DateFormatter = (date: Date) => string;

--- a/frontend/src/reports/commodities/index.ts
+++ b/frontend/src/reports/commodities/index.ts
@@ -23,7 +23,7 @@ export const commodities = new Route<CommoditiesReportProps>(
         const values = prices.map((d) => ({ name, date: d[0], value: d[1] }));
 
         return new LineChart(name, [{ name, values }], (c, d) => [
-          domHelpers.t(`1 ${base} = ${c.amount(d.value, quote)}`),
+          `1 ${base} = ${c.amount(d.value, quote)}`,
           domHelpers.em(day(d.date)),
         ]);
       });

--- a/frontend/src/svelte-custom-elements.ts
+++ b/frontend/src/svelte-custom-elements.ts
@@ -10,7 +10,7 @@ import {
   account_hierarchy_validator,
 } from "./charts/hierarchy.ts";
 import type { ParsedFavaChart } from "./charts/index.ts";
-import { chart_validator } from "./charts/index.ts";
+import { charts_validator } from "./charts/index.ts";
 import { domHelpers } from "./charts/tooltip.ts";
 import type { Result } from "./lib/result.ts";
 import { log_error } from "./log.ts";
@@ -59,7 +59,7 @@ const components = [
   new SvelteCustomElementComponent<{ charts: readonly ParsedFavaChart[] }>(
     "charts",
     ChartSwitcher,
-    (data) => chart_validator(data).map((charts) => ({ charts })),
+    (data) => charts_validator(data).map((charts) => ({ charts })),
   ),
   new SvelteCustomElementComponent<{ table: QueryResultTable }>(
     "query-table",

--- a/frontend/test/charts.test.ts
+++ b/frontend/test/charts.test.ts
@@ -10,7 +10,7 @@ import {
   padExtent,
 } from "../src/charts/helpers.ts";
 import { ParsedHierarchyChart } from "../src/charts/hierarchy.ts";
-import { chart_validator } from "../src/charts/index.ts";
+import { charts_validator } from "../src/charts/index.ts";
 import { LineChart, ParsedLineChart } from "../src/charts/line.ts";
 import { ScatterPlot } from "../src/charts/scatterplot.ts";
 import { loadJSONSnapshot } from "./helpers.ts";
@@ -41,7 +41,7 @@ test("handle data for hierarchical chart", async () => {
   const ctx = { currencies: ["USD"], dateFormat: () => "DATE" };
   ok(ParsedHierarchyChart.validator({ label: "name", data: "" }).is_err);
   const data = await loadJSONSnapshot("test_internal_api-test_chart_api.json");
-  const validated = chart_validator(data).unwrap();
+  const validated = charts_validator(data).unwrap();
 
   const [hierarchy, balances, net_worth] = validated;
   ok(hierarchy instanceof ParsedHierarchyChart);


### PR DESCRIPTION
In line and bar charts as well as scatter plots, allow dragging to
result in a time filter.

Also minor refactors and touchups.

<!--
Hi, thank you for opening a PR!

Please ensure that your change passes tests and the various linters by running
`make test` and `make lint`. If testable, your changes should be covered by
unit tests.

Explain your changes below and link to related issues.
-->

See also #2262, which this implementation is inspired by
