### PR TITLE
filters: use `field-sizing: content`

### DIFF
--- a/frontend/src/AutocompleteInput.svelte
+++ b/frontend/src/AutocompleteInput.svelte
@@ -72,9 +72,6 @@
   let index = $state.raw(-1);
   let input: HTMLInputElement | undefined = $state.raw();
 
-  let size = $derived(
-    setSize ? Math.max(value.length, placeholder.length) + 1 : undefined,
-  );
   let extractedValue = $derived(
     input && valueExtractor ? valueExtractor(value, input) : value,
   );
@@ -154,6 +151,7 @@
     type="text"
     autocomplete="off"
     role="combobox"
+    class={{ "content-sized": setSize }}
     aria-expanded={expanded}
     aria-controls={autocomple_id}
     bind:value
@@ -172,7 +170,6 @@
     onkeydown={keydown}
     {placeholder}
     {required}
-    {size}
   />
   {#if clearButton && value}
     <button
@@ -222,6 +219,11 @@
 
   input {
     width: 100%;
+  }
+
+  input.content-sized {
+    min-width: calc(8rem + 2px);
+    field-sizing: content;
   }
 
   ul {


### PR DESCRIPTION
Supported in Firefox since the recent 152, Chrome for a couple of years
already and Safari for about half a year.

Fixes #2250 
