### PR TITLE
charts: use separate tooltip instances per chart

### DIFF
--- a/frontend/css/charts.css
+++ b/frontend/css/charts.css
@@ -15,24 +15,24 @@ svg text {
   border: 1px solid var(--border);
   box-shadow: var(--box-shadow-button);
   opacity: 0;
-  transform: translate(-50%, -100%);
-}
+  transform: translate(-50%, calc(-10px - 100%));
 
-.tooltip::before {
-  position: absolute;
-  top: 100%;
-  left: 50%;
-  width: 0;
-  height: 0;
-  margin-left: -15px;
-  content: "";
-  border: 15px solid transparent;
-  border-top-color: var(--border);
-}
+  &::before {
+    position: absolute;
+    top: 100%;
+    left: 50%;
+    width: 0;
+    height: 0;
+    margin-left: -10px;
+    content: "";
+    border: 10px solid transparent;
+    border-top-color: var(--border);
+  }
 
-.tooltip em {
-  display: block;
-  margin-top: 5px;
-  font-family: var(--font-family);
-  color: var(--text-color-lightest);
+  em {
+    display: block;
+    margin-top: 2px;
+    font-family: var(--font-family);
+    color: var(--text-color-lightest);
+  }
 }

--- a/frontend/src/charts/BarChart.svelte
+++ b/frontend/src/charts/BarChart.svelte
@@ -9,6 +9,7 @@
   import Axis from "./Axis.svelte";
   import Brush from "./Brush.svelte";
   import type { BarChart } from "./bar.ts";
+  import { get_chart_tooltip } from "./context.ts";
   import {
     currenciesScale,
     filterTicks,
@@ -17,7 +18,6 @@
     padExtent,
     urlForTimeFilter,
   } from "./helpers.ts";
-  import { followingTooltip } from "./tooltip.ts";
 
   interface Props {
     chart: BarChart;
@@ -27,6 +27,7 @@
   let { chart, width }: Props = $props();
 
   const today = new Date();
+  const tooltip = get_chart_tooltip();
 
   // Constant dimensions
   const max_column_width = 100;
@@ -107,7 +108,7 @@
     {#each bar_groups as group (group.date)}
       <g
         class={["group", group.date > today && "desaturate"]}
-        {@attach followingTooltip(() => chart.tooltipText($ctx, group))}
+        {@attach tooltip.following(() => chart.tooltipText($ctx, group))}
         transform={`translate(${(x0(group.label) ?? 0).toString()},0)`}
       >
         <rect
@@ -161,7 +162,7 @@
                   y={y(Math.max(bar[0], bar[1]))}
                   height={Math.abs(y(bar[1]) - y(bar[0]))}
                   fill={account_color_scale(account)}
-                  {@attach followingTooltip(() =>
+                  {@attach tooltip.following(() =>
                     chart.tooltipTextAccount(
                       $ctx,
                       bar.data,

--- a/frontend/src/charts/Brush.svelte
+++ b/frontend/src/charts/Brush.svelte
@@ -11,7 +11,8 @@
 
   import { router } from "../router.ts";
   import { currentTimeFilterDateFormat } from "../stores/format.ts";
-  import { hide, type TooltipFindNode, tooltip } from "./tooltip.ts";
+  import { get_chart_tooltip } from "./context.ts";
+  import type { TooltipFindNode } from "./tooltip.ts";
 
   /** Ignore tiny drags less than 5px. */
   const DRAG_THRESHOLD = 5;
@@ -27,6 +28,8 @@
   }
 
   let { invert, height, children, find, transform }: Props = $props();
+
+  const tooltip = get_chart_tooltip();
 
   let x_start = $state(0);
   let x_current = $state(0);
@@ -56,16 +59,14 @@
     const [x_pointer, y_pointer] = pointer(event);
     if (find != null) {
       const res = find(x_pointer, y_pointer);
-      const matrix = event.currentTarget.getScreenCTM();
+      const matrix = event.currentTarget.getCTM();
       if (res && matrix) {
         const [x, y, content] = res;
-        const t = tooltip();
-        t.style.opacity = "1";
-        t.replaceChildren(...content);
-        t.style.left = `${(window.scrollX + x + matrix.e).toString()}px`;
-        t.style.top = `${(window.scrollY + y + matrix.f - 15).toString()}px`;
+        const point = new DOMPoint(x, y).matrixTransform(matrix);
+        tooltip.content(content);
+        tooltip.position(point.x, point.y);
       } else {
-        hide();
+        tooltip.hide();
       }
     }
     if (event.pointerId !== active_pointer_id) {
@@ -93,7 +94,7 @@
   function onpointerleave() {
     // Cancel when leaving the container element
     active_pointer_id = undefined;
-    hide();
+    tooltip.hide();
   }
 </script>
 

--- a/frontend/src/charts/Chart.svelte
+++ b/frontend/src/charts/Chart.svelte
@@ -11,11 +11,13 @@
   import { show_charts } from "../stores/url.ts";
   import BarChart from "./BarChart.svelte";
   import ChartLegend from "./ChartLegend.svelte";
+  import { set_chart_tooltip } from "./context.ts";
   import HierarchyContainer from "./HierarchyContainer.svelte";
   import type { FavaChart } from "./index.ts";
   import LineChart from "./LineChart.svelte";
   import ModeSwitch from "./ModeSwitch.svelte";
   import ScatterPlot from "./ScatterPlot.svelte";
+  import { Tooltip } from "./tooltip.ts";
 
   interface Props {
     /** The chart to render. */
@@ -25,6 +27,9 @@
   }
 
   let { chart, children }: Props = $props();
+
+  const tooltip = new Tooltip();
+  set_chart_tooltip(tooltip);
 
   /** Width of the chart. */
   let width = $state<number>();
@@ -73,7 +78,12 @@
     {$show_charts ? "▼" : "◀"}
   </button>
 </div>
-<div hidden={!$show_charts} bind:clientWidth={width}>
+<div
+  class="chart-wrapper"
+  hidden={!$show_charts}
+  bind:clientWidth={width}
+  {@attach tooltip.init.bind(tooltip)}
+>
   {#if width}
     {#if chart.type === "barchart"}
       <BarChart {chart} {width} />
@@ -90,6 +100,10 @@
 <style>
   .flex-row {
     margin-bottom: var(--flex-gap);
+  }
+
+  .chart-wrapper {
+    position: relative;
   }
 
   @media print {

--- a/frontend/src/charts/Icicle.svelte
+++ b/frontend/src/charts/Icicle.svelte
@@ -4,13 +4,14 @@
   import { urlForAccount } from "../helpers.ts";
   import { leaf } from "../lib/account.ts";
   import { ctx } from "../stores/format.ts";
+  import { get_chart_tooltip } from "./context.ts";
   import { sunburstScale } from "./helpers.ts";
   import {
     type AccountHierarchyDatum,
     type AccountHierarchyNode,
     balance_with_percentage,
   } from "./hierarchy.ts";
-  import { domHelpers, followingTooltip } from "./tooltip.ts";
+  import { domHelpers } from "./tooltip.ts";
 
   interface Props {
     data: AccountHierarchyNode;
@@ -20,6 +21,8 @@
   }
 
   let { data, currency, width, height }: Props = $props();
+
+  const tooltip = get_chart_tooltip();
 
   let root = $derived(partition<AccountHierarchyDatum>()(data));
   let nodes = $derived(root.descendants().filter((d) => !d.data.dummy));
@@ -38,7 +41,7 @@
   {#each nodes as d (d.data.account)}
     {@const account = d.data.account}
     <g
-      {@attach followingTooltip(() => [
+      {@attach tooltip.following(() => [
         balance_with_percentage($ctx, d, currency),
         domHelpers.em(account),
       ])}

--- a/frontend/src/charts/Treemap.svelte
+++ b/frontend/src/charts/Treemap.svelte
@@ -4,13 +4,14 @@
   import { urlForAccount } from "../helpers.ts";
   import { leaf } from "../lib/account.ts";
   import { ctx } from "../stores/format.ts";
+  import { get_chart_tooltip } from "./context.ts";
   import { treemapScale } from "./helpers.ts";
   import {
     type AccountHierarchyDatum,
     type AccountHierarchyNode,
     balance_with_percentage,
   } from "./hierarchy.ts";
-  import { domHelpers, followingTooltip } from "./tooltip.ts";
+  import { domHelpers } from "./tooltip.ts";
 
   interface Props {
     data: AccountHierarchyNode;
@@ -20,6 +21,8 @@
   }
 
   let { data, width, height, currency }: Props = $props();
+
+  const tooltip = get_chart_tooltip();
 
   const tree = treemap<AccountHierarchyDatum>().paddingInner(2).round(true);
   let root = $derived(tree.size([width, height])(data.copy()));
@@ -42,7 +45,7 @@
     {@const account = d.data.account}
     <g
       transform={`translate(${d.x0.toString()},${d.y0.toString()})`}
-      {@attach followingTooltip(() => [
+      {@attach tooltip.following(() => [
         balance_with_percentage($ctx, d, currency),
         domHelpers.em(account),
       ])}

--- a/frontend/src/charts/context.ts
+++ b/frontend/src/charts/context.ts
@@ -1,9 +1,11 @@
+import { createContext } from "svelte";
 import { derived } from "svelte/store";
 
 import { currentDateFormat } from "../stores/format.ts";
 import { currencies } from "../stores/index.ts";
 import { operating_currency } from "../stores/options.ts";
 import { conversion } from "../stores/url.ts";
+import type { Tooltip } from "./tooltip.ts";
 
 /** Context data for parsing and rendering of the charts. */
 export interface ChartContext {
@@ -24,6 +26,8 @@ const operatingCurrenciesWithConversion = derived(
       ? [...$operating_currency, $conversion]
       : $operating_currency,
 );
+
+export const [get_chart_tooltip, set_chart_tooltip] = createContext<Tooltip>();
 
 export const chartContext = derived(
   [operatingCurrenciesWithConversion, currentDateFormat],

--- a/frontend/src/charts/tooltip.ts
+++ b/frontend/src/charts/tooltip.ts
@@ -1,23 +1,63 @@
 import type { Attachment } from "svelte/attachments";
 
-/** The tooltip `<div>`, lazily created. */
-export const tooltip = (() => {
-  let value: HTMLDivElement | null = null;
-  return () => {
-    if (value == null) {
-      value = document.createElement("div");
-      value.className = "tooltip";
-      document.body.appendChild(value);
-    }
-    return value;
-  };
-})();
+/** A tooltip, a light wrapper around a `<div>` that's added to the `<body>` */
+export class Tooltip {
+  private div: HTMLDivElement;
 
-/** Hide the tooltip. */
-export const hide = (): void => {
-  const t = tooltip();
-  t.style.opacity = "0";
-};
+  constructor() {
+    this.div = document.createElement("div");
+    this.div.className = "tooltip top";
+  }
+
+  init(node: HTMLElement): void {
+    node.appendChild(this.div);
+  }
+
+  /** Set the tooltip content. */
+  content(nodes: (Node | string)[]): void {
+    this.div.replaceChildren(...nodes);
+  }
+
+  /** Position the tooltip. */
+  position(left: number, top: number): void {
+    this.div.style.opacity = "1";
+    this.div.style.left = `${Math.round(left).toString()}px`;
+    this.div.style.top = `${Math.round(top).toString()}px`;
+  }
+
+  /** Hide the tooltip. */
+  hide(): void {
+    this.div.style.opacity = "0";
+  }
+
+  /**
+   * Svelte attachment to have the given element act on mouse to show a tooltip.
+   *
+   * The tooltip will be positioned at the cursor and is given a tooltip getter
+   * per element.
+   */
+  following(getter: () => (Node | string)[]): Attachment<SVGElement> {
+    return (node) => {
+      const mouseenter = () => {
+        this.content(getter());
+      };
+      const mousemove = (event: MouseEvent) => {
+        this.position(event.offsetX, event.offsetY);
+      };
+      const hide = this.hide.bind(this);
+
+      node.addEventListener("mouseenter", mouseenter);
+      node.addEventListener("mousemove", mousemove);
+      node.addEventListener("mouseleave", hide);
+
+      return () => {
+        node.removeEventListener("mouseenter", mouseenter);
+        node.removeEventListener("mousemove", mousemove);
+        node.removeEventListener("mouseleave", hide);
+      };
+    };
+  }
+}
 
 /** Some small utilities to create tooltip contents. */
 export const domHelpers = {
@@ -32,39 +72,6 @@ export const domHelpers = {
 } satisfies Record<string, (x: string) => HTMLElement>;
 
 export type TooltipContent = (HTMLElement | string)[];
-
-/**
- * Svelte attachment to have the given element act on mouse to show a tooltip.
- *
- * The tooltip will be positioned at the cursor and is given a tooltip getter
- * per element.
- */
-export const followingTooltip = (
-  getter: () => TooltipContent,
-): Attachment<SVGElement> => {
-  return (node) => {
-    const mouseenter = () => {
-      const t = tooltip();
-      t.replaceChildren(...getter());
-    };
-    function mousemove(event: MouseEvent) {
-      const t = tooltip();
-      t.style.opacity = "1";
-      t.style.left = `${event.pageX.toString()}px`;
-      t.style.top = `${(event.pageY - 15).toString()}px`;
-    }
-    node.addEventListener("mouseenter", mouseenter);
-    node.addEventListener("mousemove", mousemove);
-    node.addEventListener("mouseleave", hide);
-
-    return () => {
-      node.removeEventListener("mouseenter", mouseenter);
-      node.removeEventListener("mousemove", mousemove);
-      node.removeEventListener("mouseleave", hide);
-      hide();
-    };
-  };
-};
 
 /** A function to find the closest node and the content to show in the tooltip. */
 export type TooltipFindNode = (


### PR DESCRIPTION
This avoids having tooltips stick around on page move, as they will
properly be removed by Svelte. Also make them relatively positioned, so
that they stay in place when scrolling.

<!--
Hi, thank you for opening a PR!

Please ensure that your change passes tests and the various linters by running
`make test` and `make lint`. If testable, your changes should be covered by
unit tests.

Explain your changes below and link to related issues.
-->
