### PR TITLE
fix: export empty set columns

### DIFF
--- a/src/fava/util/excel.py
+++ b/src/fava/util/excel.py
@@ -91,16 +91,15 @@ def _row_to_pyexcel(row: ResultRow, header: list[Column]) -> list[str | float]:
     result: list[str | float] = []
     for idx, column in enumerate(header):
         value = row[idx]
-        if not value:
-            result.append(value)
-            continue
         type_ = column.datatype
-        if type_ is Decimal:
+        if type_ is set:
+            result.append(" ".join(value))
+        elif not value:
+            result.append(value)
+        elif type_ is Decimal:
             result.append(float(value))
         elif type_ is int:
             result.append(value)
-        elif type_ is set:
-            result.append(" ".join(value))
         elif type_ is datetime.date:
             result.append(str(value))
         else:

--- a/tests/test_util_excel.py
+++ b/tests/test_util_excel.py
@@ -43,6 +43,15 @@ def test_to_csv(example_ledger: FavaLedger) -> None:
 
 
 @pytest.mark.skipif(not excel.HAVE_EXCEL, reason="pyexcel not installed")
+def test_export_set_column(example_ledger: FavaLedger) -> None:
+    types, _ = _run_query(example_ledger, "select tags")
+    rows = [(frozenset(),), (frozenset({"food"}),)]
+
+    assert excel.to_csv(types, rows).getvalue() == b'tags\r\n""\r\nfood\r\n'
+    assert excel.to_excel(types, rows, "xlsx", "select tags").read(2) == b"PK"
+
+
+@pytest.mark.skipif(not excel.HAVE_EXCEL, reason="pyexcel not installed")
 def test_to_excel(example_ledger: FavaLedger) -> None:
     types, rows = _run_query(example_ledger, "balances")
     assert types


### PR DESCRIPTION
## Summary

- serialize set-valued query columns before handling empty values
- export empty tag sets as blank cells instead of `frozenset()`
- add CSV and XLSX regression coverage for empty and populated tag sets

Fixes #1951

## Verification

- `pytest -q tests/test_util_excel.py` — 3 passed
- `PATH="$PWD/.venv/bin:$PATH" pytest -q` — 470 passed
- `ruff check src/fava/util/excel.py tests/test_util_excel.py`
- `ruff format --check src/fava/util/excel.py tests/test_util_excel.py`
- `git diff --check`
