### PR TITLE
income statement: add interval averages to report values

### DIFF
--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -81,6 +81,7 @@ type ApiEndpoint = DeleteEndpoint | GetEndpoint | PutEndpoint;
 type ApiParams = Partial<{
   a: string;
   account: string;
+  average: string;
   conversion: string;
   entry_hash: string;
   filename: string;
@@ -265,7 +266,7 @@ export const get_imports = define_paramless_endpoint(
 export const get_income_statement = define_endpoint(
   "income_statement",
   tree_report_validator,
-  filters_conversion_interval,
+  [...filters_conversion_interval, "average"],
 );
 export const get_journal_page = define_endpoint(
   "journal_page",

--- a/frontend/src/charts/BarChart.svelte
+++ b/frontend/src/charts/BarChart.svelte
@@ -1,11 +1,17 @@
 <script lang="ts">
   import { extent, least } from "d3-array";
   import { axisBottom, axisLeft } from "d3-axis";
+  import type { NumberValue } from "d3-scale";
   import { scaleBand, scaleLinear, scaleOrdinal } from "d3-scale";
 
   import { urlForAccount } from "../helpers.ts";
   import { barChartMode, chartToggledCurrencies } from "../stores/chart.ts";
-  import { ctx, currentTimeFilterDateFormat, short } from "../stores/format.ts";
+  import {
+    ctx,
+    currentTimeFilterDateFormat,
+    plainNum,
+    short,
+  } from "../stores/format.ts";
   import Axis from "./Axis.svelte";
   import Brush from "./Brush.svelte";
   import type { BarChart } from "./bar.ts";
@@ -16,6 +22,7 @@
     hclColorRange,
     includeZero,
     padExtent,
+    separateMarkerPositions,
     urlForTimeFilter,
   } from "./helpers.ts";
 
@@ -34,12 +41,19 @@
   const margin = { top: 10, right: 10, bottom: 30, left: 40 };
   const height = 250;
   const inner_height = height - margin.top - margin.bottom;
+  const min_visible_bar_height = 2;
 
   // Chart data
   let accounts = $derived(chart.accounts);
-  let { currencies, bar_groups, stacks } = $derived(
-    chart.filter($chartToggledCurrencies),
-  );
+  let all_currencies = $derived(chart.currencies);
+  let {
+    currencies: visible_currencies,
+    bar_groups,
+    averages: filtered_averages,
+    stacks,
+  } = $derived(chart.filter($chartToggledCurrencies));
+  let averages = $derived(filtered_averages ?? {});
+  let has_averages = $derived(Object.keys(averages).length > 0);
 
   // Computed dimensions
   let max_width = $derived(bar_groups.length * max_column_width);
@@ -59,19 +73,50 @@
       .domain(bar_groups.map((d) => d.label))
       .padding(0.1),
   );
-  let x1 = $derived(scaleBand([0, x0.bandwidth()]).domain(currencies));
+  let x1 = $derived(scaleBand([0, x0.bandwidth()]).domain(all_currencies));
 
-  let y_extent = $derived(
+  let y_values = $derived(
     show_stacked_bars
-      ? extent(stacks.flatMap(([, s]) => s.flat(2)))
-      : extent(
-          bar_groups.flatMap((d) => d.values),
-          (d) => d.value,
-        ),
+      ? [...stacks.flatMap(([, s]) => s.flat(2)), ...Object.values(averages)]
+      : [
+          ...bar_groups.flatMap((d) => d.values.map((v) => v.value)),
+          ...Object.values(averages),
+        ],
   );
+  let y_extent = $derived(extent(y_values));
   let y = $derived(
     scaleLinear([inner_height, 0]).domain(padExtent(includeZero(y_extent))),
   );
+  let y_tick_format = $derived((value: NumberValue) =>
+    has_averages ? $plainNum(Number(value)) : $short(value),
+  );
+  let average_markers = $derived.by(() => {
+    const entries = visible_currencies
+      .map((currency) => ({
+        currency,
+        value: averages[currency],
+      }))
+      .filter(
+        (
+          entry,
+        ): entry is {
+          currency: string;
+          value: number;
+        } => entry.value != null,
+      );
+    const marker_positions = separateMarkerPositions(
+      entries.map(({ value }) => y(value)),
+      8,
+      0,
+      inner_height,
+    );
+    return entries.map(({ currency, value }, index) => ({
+      currency,
+      value,
+      line_y: y(value),
+      marker_y: marker_positions[index] ?? y(value),
+    }));
+  });
 
   let account_color_scale = $derived(
     scaleOrdinal(hclColorRange(accounts.length)).domain(accounts),
@@ -84,7 +129,7 @@
       .tickValues(filterTicks(x0.domain(), inner_width / 70)),
   );
   let y_axis = $derived(
-    axisLeft(y).tickPadding(6).tickSize(-inner_width).tickFormat($short),
+    axisLeft(y).tickPadding(6).tickSize(-inner_width).tickFormat(y_tick_format),
   );
 
   /** Invert a pixel x position to the date of the nearest bar group. */
@@ -95,7 +140,38 @@
     );
     return closest?.date ?? new Date();
   }
+
+  function barHeight(start: number, end = 0): number {
+    const height = Math.abs(y(start) - y(end));
+    return start !== end && height < min_visible_bar_height
+      ? min_visible_bar_height
+      : height;
+  }
+
+  function isTinyBar(value: number): boolean {
+    return value !== 0 && Math.abs(y(value) - y(0)) < min_visible_bar_height;
+  }
 </script>
+
+{#if has_averages}
+  <div class="averages">
+    {#each visible_currencies as currency (currency)}
+      {#if averages[currency] != null}
+        <span
+          class="average"
+          style={`--average-color:${$currenciesScale(currency)};`}
+          title={currency}
+        >
+          <span class="dot"></span>
+          <span class="label">{currency}</span>
+          <span class="value"
+            >{$ctx.amount(averages[currency] ?? 0, currency)}</span
+          >
+        </span>
+      {/if}
+    {/each}
+  </div>
+{/if}
 
 <svg viewBox={`0 0 ${width.toString()} ${height.toString()}`}>
   <Brush
@@ -105,6 +181,31 @@
   >
     <Axis x axis={x_axis} {inner_height} />
     <Axis y axis={y_axis} line_at_zero={y(0)} />
+    {#if has_averages}
+      <g class="average-lines">
+        {#each average_markers as { currency, line_y, marker_y } (currency)}
+          <g transform={`translate(0,${line_y.toString()})`}>
+            <line
+              class="average-line"
+              x2={inner_width}
+              stroke={$currenciesScale(currency)}
+            />
+          </g>
+          <path
+            class="average-marker-connector"
+            d={`M ${Math.max(inner_width - 14, 0).toString()} ${line_y.toString()} L ${(inner_width + 4).toString()} ${marker_y.toString()}`}
+            stroke={$currenciesScale(currency)}
+          />
+          <circle
+            class="average-marker"
+            cx={inner_width + 4}
+            cy={marker_y}
+            r="3"
+            fill={$currenciesScale(currency)}
+          />
+        {/each}
+      </g>
+    {/if}
     {#each bar_groups as group (group.date)}
       <g
         class={["group", group.date > today && "desaturate"]}
@@ -135,14 +236,14 @@
               width={x1.bandwidth()}
               x={x1(currency)}
               y={y(Math.max(0, value))}
-              height={Math.abs(y(value) - y(0))}
+              height={barHeight(value)}
             />
             <rect
               class="budget"
               width={x1.bandwidth()}
               x={x1(currency)}
               y={y(Math.max(0, budget))}
-              height={Math.abs(y(budget) - y(0))}
+              height={barHeight(budget)}
             />
           {/each}
         {/if}
@@ -160,7 +261,7 @@
                   width={x1.bandwidth()}
                   x={(x0(bar.data.label) ?? 0) + (x1(currency) ?? 0)}
                   y={y(Math.max(bar[0], bar[1]))}
-                  height={Math.abs(y(bar[1]) - y(bar[0]))}
+                  height={barHeight(bar[1], bar[0])}
                   fill={account_color_scale(account)}
                   {@attach tooltip.following(() =>
                     chart.tooltipTextAccount(
@@ -173,6 +274,22 @@
                 />
               {/each}
             </a>
+          {/each}
+        {/each}
+      </g>
+      <g class="tiny-bar-markers">
+        {#each bar_groups as group (group.date)}
+          {#each group.values as { currency, value } (currency)}
+            {#if isTinyBar(value)}
+              <rect
+                class="tiny-bar-marker"
+                width={x1.bandwidth()}
+                x={(x0(group.label) ?? 0) + (x1(currency) ?? 0)}
+                y={y(Math.max(0, value))}
+                height={min_visible_bar_height}
+                fill={$currenciesScale(currency)}
+              />
+            {/if}
           {/each}
         {/each}
       </g>
@@ -196,6 +313,74 @@
 
   .budget {
     opacity: 0.3;
+  }
+
+  .averages {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5em;
+    margin: 0 0 0.5em;
+  }
+
+  .average {
+    display: inline-flex;
+    gap: 0.35em;
+    align-items: center;
+    padding: 0.2em 0.45em;
+    font-size: 0.85em;
+    color: var(--text-color);
+    background: var(--background);
+    border: 1px solid var(--border-darker);
+    border-radius: 0.25em;
+  }
+
+  .average .dot {
+    flex: 0 0 auto;
+    width: 0.6em;
+    height: 0.6em;
+    background: var(--average-color);
+    border-radius: 999px;
+  }
+
+  .average .label {
+    font-weight: 600;
+  }
+
+  .average .value {
+    color: var(--text-color-lightest);
+  }
+
+  .average-lines {
+    pointer-events: none;
+  }
+
+  .average-line {
+    opacity: 0.9;
+    stroke-width: 1.5px;
+    stroke-dasharray: 4 4;
+  }
+
+  .average-marker-connector,
+  .average-marker {
+    opacity: 0.9;
+    stroke-width: 1.5px;
+  }
+
+  .average-marker-connector {
+    fill: none;
+  }
+
+  .average-marker {
+    stroke: var(--background);
+    stroke-width: 1px;
+  }
+
+  .tiny-bar-markers {
+    pointer-events: none;
+  }
+
+  .tiny-bar-marker {
+    opacity: 0.9;
   }
 
   .desaturate {

--- a/frontend/src/charts/bar.ts
+++ b/frontend/src/charts/bar.ts
@@ -9,6 +9,7 @@ import {
   date,
   number,
   object,
+  optional,
   record,
   string,
 } from "../lib/validation.ts";
@@ -49,15 +50,19 @@ export class BarChart {
   readonly currencies: readonly string[];
   /** The data for the (single) bars for all the intervals in this chart. */
   private readonly bar_groups: BarChartDatum[];
+  /** Optional average values for the visible currencies. */
+  readonly averages: Record<string, number> | null;
 
   constructor(
     label: string | null,
     currencies: readonly string[],
     bar_groups: BarChartDatum[],
+    averages: Record<string, number> | null = null,
   ) {
     this.label = label;
     this.currencies = currencies;
     this.bar_groups = bar_groups;
+    this.averages = averages;
     this.accounts = Array.from(
       new Set(bar_groups.map((d) => Object.keys(d.account_balances)).flat(2)),
     ).sort();
@@ -75,6 +80,7 @@ export class BarChart {
   filter(hidden_names: string[]): {
     currencies: string[];
     bar_groups: BarChartDatum[];
+    averages: Record<string, number> | null;
     stacks: [currency: string, stacks: Series<BarChartDatum, string>[]][];
   } {
     const hidden_names_set = new Set(hidden_names);
@@ -86,7 +92,14 @@ export class BarChart {
       values: b.values.filter((v) => currencies.has(v.currency)),
     }));
     const stacks = this.stacks.filter((s) => currencies.has(s[0]));
-    return { currencies: [...currencies], bar_groups, stacks };
+    const averages = this.averages
+      ? Object.fromEntries(
+          Object.entries(this.averages).filter(([currency]) =>
+            currencies.has(currency),
+          ),
+        )
+      : null;
+    return { currencies: [...currencies], bar_groups, averages, stacks };
   }
 
   /** Whether this chart contains any stacks (or is just a single account). */
@@ -170,20 +183,31 @@ const bar_validator = array(
 
 type ParsedBarChartData = ValidationT<typeof bar_validator>;
 
-const bar_chart_validator = object({ label: string, data: bar_validator });
+const bar_chart_validator = object({
+  label: string,
+  data: bar_validator,
+  averages: optional(record(number)),
+});
 
 export class ParsedBarChart implements ParsedFavaChart {
   readonly label: string | null;
   readonly data: ParsedBarChartData;
+  readonly averages: Record<string, number> | null;
 
-  constructor(label: string | null, data: ParsedBarChartData) {
+  constructor(
+    label: string | null,
+    data: ParsedBarChartData,
+    averages: Record<string, number> | null,
+  ) {
     this.label = label;
     this.data = data;
+    this.averages = averages;
   }
 
   static validator: Validator<ParsedBarChart> = (json) =>
     bar_chart_validator(json).map(
-      ({ label, data }) => new ParsedBarChart(label, data),
+      ({ label, data, averages }) =>
+        new ParsedBarChart(label, data, averages ?? null),
     );
 
   with_context($chartContext: ChartContext): BarChart {
@@ -200,6 +224,6 @@ export class ParsedBarChart implements ParsedFavaChart {
       account_balances: interval.account_balances,
     }));
 
-    return new BarChart(this.label, currencies, bar_groups);
+    return new BarChart(this.label, currencies, bar_groups, this.averages);
   }
 }

--- a/frontend/src/charts/helpers.ts
+++ b/frontend/src/charts/helpers.ts
@@ -47,6 +47,70 @@ export function padExtent([from, to]:
 }
 
 /**
+ * Separate marker positions so overlapping markers stay visible.
+ * @param positions - The original marker positions.
+ * @param min_gap - The minimum distance between adjacent markers.
+ * @param min_y - The smallest allowed marker position.
+ * @param max_y - The largest allowed marker position.
+ */
+export function separateMarkerPositions(
+  positions: readonly number[],
+  min_gap: number,
+  min_y: number,
+  max_y: number,
+): number[] {
+  if (positions.length <= 1) {
+    return [...positions];
+  }
+
+  const indexed = positions
+    .map((position, index) => ({ index, position }))
+    .sort((a, b) => a.position - b.position);
+
+  const adjusted = indexed.map((marker, index) => ({
+    ...marker,
+    position: index === 0 ? Math.max(min_y, marker.position) : marker.position,
+  }));
+
+  for (let index = 1; index < adjusted.length; index += 1) {
+    const current = adjusted[index];
+    const previous = adjusted[index - 1];
+    if (!current || !previous) {
+      continue;
+    }
+    current.position = Math.max(current.position, previous.position + min_gap);
+  }
+
+  const last = adjusted[adjusted.length - 1];
+  if (!last) {
+    return [];
+  }
+
+  const overflow = last.position - max_y;
+  if (overflow > 0) {
+    for (const marker of adjusted) {
+      marker.position -= overflow;
+    }
+  }
+
+  const first = adjusted[0];
+  if (!first) {
+    return [];
+  }
+
+  const underflow = min_y - first.position;
+  if (underflow > 0) {
+    for (const marker of adjusted) {
+      marker.position += underflow;
+    }
+  }
+
+  return adjusted
+    .sort((a, b) => a.index - b.index)
+    .map((marker) => marker.position);
+}
+
+/**
  * Filter ticks to have them not overlap.
  * @param domain - The domain of values to filter.
  * @param count - The number of ticks that should be returned.

--- a/frontend/src/format.ts
+++ b/frontend/src/format.ts
@@ -46,6 +46,13 @@ export interface FormatterContext {
   percentage: (num: number) => string;
 }
 
+const extra_precision_digits = 2;
+
+function isRepresentableWithPrecision(num: number, precision: number): boolean {
+  const factor = 10 ** precision;
+  return Math.abs(num * factor - Math.round(num * factor)) < 1e-8;
+}
+
 /** Build the formatter context for the given configuration */
 export function formatter_context(
   incognito: boolean,
@@ -59,8 +66,25 @@ export function formatter_context(
       localeFormatter(locale, prec),
     ]),
   );
-  const num_raw = (n: number, c: string) =>
-    (currencyFormatters[c] ?? formatter)(n);
+  const formatterCache = new Map<number, (num: number) => string>();
+
+  const getFormatter = (precision: number) => {
+    const cached = formatterCache.get(precision);
+    if (cached) {
+      return cached;
+    }
+    const next = localeFormatter(locale, precision);
+    formatterCache.set(precision, next);
+    return next;
+  };
+
+  const num_raw = (n: number, c: string) => {
+    const precision = precisions[c];
+    if (precision == null || isRepresentableWithPrecision(n, precision)) {
+      return (currencyFormatters[c] ?? formatter)(n);
+    }
+    return getFormatter(Math.max(precision, extra_precision_digits))(n);
+  };
 
   const num = incognito
     ? (n: number, c: string) => replaceNumbers(num_raw(n, c))

--- a/frontend/src/reports/tree_reports/IncomeStatement.svelte
+++ b/frontend/src/reports/tree_reports/IncomeStatement.svelte
@@ -1,11 +1,38 @@
 <script lang="ts">
   import ChartSwitcher from "../../charts/ChartSwitcher.svelte";
+  import SelectCombobox from "../../charts/SelectCombobox.svelte";
+  import { _, format } from "../../i18n.ts";
+  import { getInterval, intervalLabel } from "../../lib/interval.ts";
+  import { router } from "../../router.ts";
+  import { average } from "../../stores/url.ts";
   import TreeTable from "../../tree-table/TreeTable.svelte";
   import type { TreeReportProps } from "./index.ts";
 
+  const AVERAGES = ["", "day", "week", "month", "quarter", "year"] as const;
+
   let { charts, trees, date_range }: TreeReportProps = $props();
   let end = $derived(date_range?.end ?? null);
+
+  const average_description = (option: string) => {
+    if (option === "") {
+      return _("No Average");
+    }
+    return format(_("%(interval)s average"), {
+      interval: intervalLabel(getInterval(option)),
+    });
+  };
 </script>
+
+<SelectCombobox
+  bind:value={
+    () => $average,
+    (value: string) => {
+      router.set_search_param("average", value);
+    }
+  }
+  options={AVERAGES}
+  description={average_description}
+/>
 
 <ChartSwitcher {charts} />
 

--- a/frontend/src/router.ts
+++ b/frontend/src/router.ts
@@ -45,6 +45,7 @@ const navigation_api = "navigation" in globalThis ? navigation : null;
 type FavaQueryParameters =
   | "account"
   | "charts"
+  | "average"
   | "conversion"
   | "extract_filename"
   | "extract_importer"
@@ -377,6 +378,7 @@ class Router {
   set_search_param(
     key:
       | "account"
+      | "average"
       | "conversion"
       | "filter"
       | "interval"

--- a/frontend/src/stores/filters.ts
+++ b/frontend/src/stores/filters.ts
@@ -25,8 +25,9 @@ export interface Filters extends Record<string, string> {
   time: string;
 }
 
-/** The three filters as well as conversion and interval. */
+/** The three filters as well as average, conversion and interval. */
 export interface FiltersConversionInterval extends Filters {
+  average: string;
   conversion: string;
   interval: string;
 }
@@ -44,6 +45,7 @@ export const filter_params = derived(
 export function getURLFilters(url: URL): FiltersConversionInterval {
   return {
     account: url.searchParams.get("account") ?? "",
+    average: url.searchParams.get("average") ?? "",
     filter: url.searchParams.get("filter") ?? "",
     time: url.searchParams.get("time") ?? "",
     conversion: url.searchParams.get("conversion") ?? "",

--- a/frontend/src/stores/format.ts
+++ b/frontend/src/stores/format.ts
@@ -23,6 +23,17 @@ export const short = derived(incognito, ($incognito) =>
     : short_format,
 );
 
+/** Render a number without SI prefixes when the currency is not known. */
+export const plainNum = derived(
+  [incognito, locale],
+  ([$incognito, $locale]) => {
+    const formatter = localeFormatter($locale);
+    return $incognito
+      ? (n: NumberValue) => replaceNumbers(formatter(Number(n)))
+      : formatter;
+  },
+);
+
 /** Format a number for which the currency is not known. */
 export const num = derived(locale, ($locale) => localeFormatter($locale));
 

--- a/frontend/src/stores/url.ts
+++ b/frontend/src/stores/url.ts
@@ -37,10 +37,27 @@ export const interval = derived(searchParams, ($searchParams) =>
   getInterval($searchParams.get("interval")),
 );
 
+const AVERAGE_INTERVALS = ["day", "week", "month", "quarter", "year"] as const;
+type AverageInterval = (typeof AVERAGE_INTERVALS)[number];
+
+function isAverageInterval(s: string | null): s is AverageInterval {
+  return s != null && AVERAGE_INTERVALS.includes(s as AverageInterval);
+}
+
+export function getAverage(s: string | null): string {
+  return isAverageInterval(s) ? s : "";
+}
+
+/** The current average used for income statements. */
+export const average = derived(searchParams, ($searchParams) =>
+  getAverage($searchParams.get("average")),
+);
+
 /** These URL parameters for filters and conversion / interval are synced for most links. */
 const synced_search_param_names = [
   "account",
   "charts",
+  "average",
   "conversion",
   "filter",
   "interval",

--- a/frontend/test/charts.test.ts
+++ b/frontend/test/charts.test.ts
@@ -8,6 +8,7 @@ import {
   filterTicks,
   includeZero,
   padExtent,
+  separateMarkerPositions,
 } from "../src/charts/helpers.ts";
 import { ParsedHierarchyChart } from "../src/charts/hierarchy.ts";
 import { charts_validator } from "../src/charts/index.ts";
@@ -35,6 +36,18 @@ test("chart helpers (include zero in extent)", () => {
 test("chart helpers (pad extent)", () => {
   deepEqual(padExtent([0, 1]), [-0.03, 1.03]);
   deepEqual(padExtent([undefined, undefined]), [0, 1]);
+});
+
+test("chart helpers (separate marker positions)", () => {
+  deepEqual(
+    separateMarkerPositions([100, 101, 102], 8, 0, 210),
+    [100, 108, 116],
+  );
+  deepEqual(separateMarkerPositions([2, 3], 8, 0, 210), [2, 10]);
+  deepEqual(
+    separateMarkerPositions([205, 206, 207], 8, 0, 210),
+    [194, 202, 210],
+  );
 });
 
 test("handle data for hierarchical chart", async () => {
@@ -275,7 +288,11 @@ test("handle data for bar chart without stacked data", () => {
   ];
   // even without the operating currencies, the two most popular ones will be selected
   const ctx = { currencies: [], dateFormat: () => "DATE" };
-  const chart = ParsedBarChart.validator({ label: "name", data })
+  const chart = ParsedBarChart.validator({
+    label: "name",
+    data,
+    averages: { EUR: 55, USD: 5 },
+  })
     .unwrap()
     .with_context(ctx);
   equal(false, chart.hasStackedData);
@@ -283,8 +300,10 @@ test("handle data for bar chart without stacked data", () => {
     ["EUR", []],
     ["USD", []],
   ]);
+  deepEqual(chart.filter([]).averages, { EUR: 55, USD: 5 });
   const without_usd = chart.filter(["USD"]);
   deepEqual(without_usd.stacks, [["EUR", []]]);
+  deepEqual(without_usd.averages, { EUR: 55 });
   deepEqual(without_usd.bar_groups, [
     {
       date: new Date("2000-01-01"),

--- a/frontend/test/format.test.ts
+++ b/frontend/test/format.test.ts
@@ -42,6 +42,10 @@ test("formatter context", () => {
   const incognito_ctx = formatter_context(true, null, { USD: 4 });
   equal(incognito_ctx.num(10, "EUR"), "XX.XX");
   equal(incognito_ctx.num(10, "USD"), "XX.XXXX");
+
+  const average_ctx = formatter_context(false, null, { VACHR: 0 });
+  equal(average_ctx.num(-0.5, "VACHR"), "−0.50");
+  equal(average_ctx.amount(-0.5, "VACHR"), "−0.50 VACHR");
 });
 
 test("time filter date formatting", () => {

--- a/src/fava/internal_api.py
+++ b/src/fava/internal_api.py
@@ -18,7 +18,9 @@ from fava.context import g
 from fava.util.excel import HAVE_EXCEL
 
 if TYPE_CHECKING:  # pragma: no cover
+    from collections.abc import Mapping
     from collections.abc import Sequence
+    from decimal import Decimal
     from typing import Literal
 
     from fava.beans.abc import Meta
@@ -145,6 +147,7 @@ class BarChart:
 
     label: str
     data: Sequence[DateAndBalanceWithBudget]
+    averages: Mapping[str, Decimal] | None = None
     type: Literal["bar"] = "bar"
 
 

--- a/src/fava/json_api.py
+++ b/src/fava/json_api.py
@@ -11,6 +11,8 @@ import shutil
 from abc import abstractmethod
 from dataclasses import dataclass
 from dataclasses import fields
+from dataclasses import replace
+from decimal import Decimal
 from functools import wraps
 from http import HTTPStatus
 from inspect import Parameter
@@ -38,31 +40,38 @@ from fava.core.file import get_entry_slice
 from fava.core.filters import FilterError
 from fava.core.group_entries import group_entries_by_type
 from fava.core.ingest import filepath_in_primary_imports_folder
+from fava.core.inventory import SimpleCounterInventory
 from fava.core.misc import align
 from fava.helpers import FavaAPIError
+from fava.internal_api import BalancesChart
+from fava.internal_api import BarChart
 from fava.internal_api import ChartApi
 from fava.internal_api import get_errors
 from fava.internal_api import get_ledger_data
+from fava.internal_api import HierarchyChart
 from fava.serialisation import deserialise
 from fava.serialisation import serialise
+from fava.util.date import DateRange
+from fava.util.date import dateranges
+from fava.util.date import INTERVALS
 
 if TYPE_CHECKING:  # pragma: no cover
     from collections.abc import Callable
     from collections.abc import Mapping
     from collections.abc import Sequence
     from datetime import date
-    from decimal import Decimal
 
     from flask.wrappers import Response
 
     from fava.beans.abc import Directive
+    from fava.core import FilteredLedger
+    from fava.core.charts import DateAndBalance
+    from fava.core.charts import DateAndBalanceWithBudget
     from fava.core.ingest import FileImporters
-    from fava.core.inventory import SimpleCounterInventory
     from fava.core.query import QueryResultTable
     from fava.core.query import QueryResultText
     from fava.core.tree import SerialisedTreeNode
     from fava.internal_api import ChartData
-    from fava.util.date import DateRange
 
 
 json_api = Blueprint("json_api", __name__)
@@ -108,6 +117,131 @@ def json_success(data: Any) -> Response:
     return jsonify(
         {"data": data, "mtime": str(g.ledger.mtime)},
     )
+
+
+def _average_range(filtered: FilteredLedger) -> DateRange | None:
+    """Get the date range used for average calculations."""
+    if filtered.date_range is not None:
+        return filtered.date_range
+    if filtered._date_first is None or filtered._date_last is None:  # noqa: SLF001
+        return None
+    return DateRange(filtered._date_first, filtered._date_last)  # noqa: SLF001
+
+
+def _average_divisor(
+    filtered: FilteredLedger,
+    average: str | None,
+) -> Decimal | None:
+    """Get the divisor for the selected average interval."""
+    if not average:
+        return None
+    interval = INTERVALS.get(average)
+    if interval is None:
+        raise InvalidAverageError(average)
+    date_range = _average_range(filtered)
+    if date_range is None:
+        return None
+    divisor = len(
+        dateranges(
+            date_range.begin,
+            date_range.end,
+            interval,
+            complete=False,
+        ),
+    )
+    return Decimal(divisor) if divisor else None
+
+
+def _scale_inventory(
+    inventory: SimpleCounterInventory,
+    divisor: Decimal,
+) -> SimpleCounterInventory:
+    return SimpleCounterInventory(
+        {currency: number / divisor for currency, number in inventory.items()},
+    )
+
+
+def _scale_optional_inventory(
+    inventory: SimpleCounterInventory | None,
+    divisor: Decimal,
+) -> SimpleCounterInventory | None:
+    if inventory is None:
+        return None
+    return _scale_inventory(inventory, divisor)
+
+
+def _scale_date_and_balance(
+    item: DateAndBalance,
+    divisor: Decimal,
+) -> DateAndBalance:
+    return replace(item, balance=_scale_inventory(item.balance, divisor))
+
+
+def _scale_date_and_balance_with_budget(
+    item: DateAndBalanceWithBudget,
+    divisor: Decimal,
+) -> DateAndBalanceWithBudget:
+    return replace(
+        item,
+        balance=_scale_inventory(item.balance, divisor),
+        account_balances={
+            account: _scale_inventory(balance, divisor)
+            for account, balance in item.account_balances.items()
+        },
+        budgets={
+            currency: amount / divisor
+            for currency, amount in item.budgets.items()
+        },
+    )
+
+
+def _scale_tree(
+    node: SerialisedTreeNode,
+    divisor: Decimal,
+) -> SerialisedTreeNode:
+    return replace(
+        node,
+        balance=_scale_inventory(node.balance, divisor),
+        balance_children=_scale_inventory(node.balance_children, divisor),
+        cost=_scale_optional_inventory(node.cost, divisor),
+        cost_children=_scale_optional_inventory(node.cost_children, divisor),
+        children=tuple(_scale_tree(child, divisor) for child in node.children),
+    )
+
+
+def _scale_chart(chart: ChartData, divisor: Decimal) -> ChartData:
+    if isinstance(chart, BalancesChart):
+        return replace(
+            chart,
+            data=[
+                _scale_date_and_balance(item, divisor) for item in chart.data
+            ],
+        )
+    if isinstance(chart, BarChart):
+        return replace(
+            chart,
+            data=[
+                _scale_date_and_balance_with_budget(item, divisor)
+                for item in chart.data
+            ],
+        )
+    if isinstance(chart, HierarchyChart):
+        return replace(chart, data=_scale_tree(chart.data, divisor))
+    return chart
+
+
+def _average_bar_chart(chart: BarChart, divisor: Decimal) -> BarChart:
+    """Compute average values for a bar chart."""
+    if not chart.data:
+        return replace(chart, averages=None)
+    totals: dict[str, Decimal] = {}
+    for item in chart.data:
+        for currency, value in item.balance.items():
+            totals[currency] = totals.get(currency, Decimal()) + value
+    averages = {
+        currency: total / divisor for currency, total in totals.items()
+    }
+    return replace(chart, averages=averages)
 
 
 class FavaJSONAPIError(FavaAPIError):
@@ -180,6 +314,15 @@ class NotAFileError(FavaJSONAPIError):
 
     def __init__(self, filename: str) -> None:
         super().__init__(f"Not a file: '{filename}'")
+
+
+class InvalidAverageError(FavaJSONAPIError):
+    """Invalid average interval."""
+
+    status = HTTPStatus.BAD_REQUEST
+
+    def __init__(self, average: str) -> None:
+        super().__init__(f"Invalid average interval: '{average}'.")
 
 
 @json_api.errorhandler(FavaAPIError)
@@ -675,6 +818,7 @@ def get_income_statement() -> TreeReport:
     g.ledger.changed()
     options = g.ledger.options
     invert = g.ledger.fava_options.invert_income_liabilities_equity
+    divisor = _average_divisor(g.filtered, request.args.get("average"))
 
     charts = [
         ChartApi.interval_totals(
@@ -702,10 +846,22 @@ def get_income_statement() -> TreeReport:
         root_tree.get(options["name_expenses"]),
     ]
 
-    return TreeReport(
+    report = TreeReport(
         g.filtered.date_range,
         charts,
         trees=[tree.serialise_with_context() for tree in trees],
+    )
+    if divisor is None:
+        return report
+    return TreeReport(
+        report.date_range,
+        [
+            _average_bar_chart(chart, divisor)
+            if isinstance(chart, BarChart)
+            else _scale_chart(chart, divisor)
+            for chart in report.charts
+        ],
+        [_scale_tree(tree, divisor) for tree in report.trees],
     )
 
 

--- a/src/fava/translations/messages.pot
+++ b/src/fava/translations/messages.pot
@@ -227,7 +227,7 @@ msgstr ""
 
 #: frontend/src/reports/accounts/AccountReport.svelte:66
 #: frontend/src/reports/accounts/AccountReport.svelte:69
-#: src/fava/json_api.py:786
+#: src/fava/json_api.py:935
 msgid "Changes"
 msgstr ""
 
@@ -550,6 +550,15 @@ msgstr ""
 msgid "Statistics"
 msgstr ""
 
+#: frontend/src/reports/tree_reports/IncomeStatement.svelte:18
+msgid "No Average"
+msgstr ""
+
+#: frontend/src/reports/tree_reports/IncomeStatement.svelte:20
+#, python-format
+msgid "%(interval)s average"
+msgstr ""
+
 #: frontend/src/reports/tree_reports/index.ts:38
 #: frontend/src/sidebar/AsideContents.svelte:27
 msgid "Income Statement"
@@ -585,8 +594,8 @@ msgstr ""
 msgid "Filter by tag, payee, …"
 msgstr ""
 
-#: frontend/src/stores/accounts.ts:113 src/fava/json_api.py:683
-#: src/fava/json_api.py:701
+#: frontend/src/stores/accounts.ts:113 src/fava/json_api.py:820
+#: src/fava/json_api.py:838
 msgid "Net Profit"
 msgstr ""
 
@@ -648,19 +657,19 @@ msgstr ""
 msgid "Other"
 msgstr ""
 
-#: src/fava/internal_api.py:171
+#: src/fava/internal_api.py:174
 msgid "Account Balance"
 msgstr ""
 
-#: src/fava/internal_api.py:219
+#: src/fava/internal_api.py:222
 msgid "Net Worth"
 msgstr ""
 
-#: src/fava/json_api.py:689
+#: src/fava/json_api.py:826
 msgid "Income"
 msgstr ""
 
-#: src/fava/json_api.py:695
+#: src/fava/json_api.py:832
 msgid "Expenses"
 msgstr ""
 

--- a/tests/__snapshots__/test_internal_api-test_chart_api.json
+++ b/tests/__snapshots__/test_internal_api-test_chart_api.json
@@ -573,6 +573,7 @@
     "type": "balances"
   },
   {
+    "averages": null,
     "data": [
       {
         "account_balances": {},

--- a/tests/__snapshots__/test_json_api-test_api-account_report_off_by_one.json
+++ b/tests/__snapshots__/test_json_api-test_api-account_report_off_by_one.json
@@ -26,6 +26,7 @@
       "type": "balances"
     },
     {
+      "averages": null,
       "data": [
         {
           "account_balances": {

--- a/tests/__snapshots__/test_json_api-test_api-account_report_off_by_one_journal.json
+++ b/tests/__snapshots__/test_json_api-test_api-account_report_off_by_one_journal.json
@@ -6,6 +6,7 @@
       "type": "balances"
     },
     {
+      "averages": null,
       "data": [
         {
           "account_balances": {

--- a/tests/__snapshots__/test_json_api-test_api-income_statement_average.json
+++ b/tests/__snapshots__/test_json_api-test_api-income_statement_average.json
@@ -1,7 +1,11 @@
 {
   "charts": [
     {
-      "averages": null,
+      "averages": {
+        "IRAUSD": 0.0,
+        "USD": -98.23901369863013,
+        "VACHR": -0.3561643835616438
+      },
       "data": [
         {
           "account_balances": {
@@ -365,7 +369,11 @@
       "type": "bar"
     },
     {
-      "averages": null,
+      "averages": {
+        "IRAUSD": -47.945205479452056,
+        "USD": -354.3445479452055,
+        "VACHR": -0.3561643835616438
+      },
       "data": [
         {
           "account_balances": {
@@ -503,7 +511,7 @@
       "type": "bar"
     },
     {
-      "averages": null,
+      "averages": { "IRAUSD": 47.945205479452056, "USD": 256.10553424657536 },
       "data": [
         {
           "account_balances": {
@@ -826,29 +834,32 @@
       "account": "Income",
       "balance": {},
       "balance_children": {
-        "IRAUSD": -17500,
-        "USD": -129335.76,
-        "VACHR": -130
+        "IRAUSD": -47.945205479452056,
+        "USD": -354.3445479452055,
+        "VACHR": -0.3561643835616438
       },
       "children": [
         {
           "account": "Income:US",
           "balance": {},
           "balance_children": {
-            "IRAUSD": -17500,
-            "USD": -129335.76,
-            "VACHR": -130
+            "IRAUSD": -47.945205479452056,
+            "USD": -354.3445479452055,
+            "VACHR": -0.3561643835616438
           },
           "children": [
             {
               "account": "Income:US:BayBook",
               "balance": {},
-              "balance_children": { "USD": -129382.2, "VACHR": -130 },
+              "balance_children": {
+                "USD": -354.47178082191783,
+                "VACHR": -0.3561643835616438
+              },
               "children": [
                 {
                   "account": "Income:US:BayBook:GroupTermLife",
-                  "balance": { "USD": -632.32 },
-                  "balance_children": { "USD": -632.32 },
+                  "balance": { "USD": -1.7323835616438357 },
+                  "balance_children": { "USD": -1.7323835616438357 },
                   "children": [],
                   "cost": null,
                   "cost_children": null,
@@ -856,8 +867,8 @@
                 },
                 {
                   "account": "Income:US:BayBook:Match401k",
-                  "balance": { "USD": -8750.0 },
-                  "balance_children": { "USD": -8750.0 },
+                  "balance": { "USD": -23.972602739726028 },
+                  "balance_children": { "USD": -23.972602739726028 },
                   "children": [],
                   "cost": null,
                   "cost_children": null,
@@ -865,8 +876,8 @@
                 },
                 {
                   "account": "Income:US:BayBook:Salary",
-                  "balance": { "USD": -119999.88 },
-                  "balance_children": { "USD": -119999.88 },
+                  "balance": { "USD": -328.76679452054793 },
+                  "balance_children": { "USD": -328.76679452054793 },
                   "children": [],
                   "cost": null,
                   "cost_children": null,
@@ -874,8 +885,8 @@
                 },
                 {
                   "account": "Income:US:BayBook:Vacation",
-                  "balance": { "VACHR": -130 },
-                  "balance_children": { "VACHR": -130 },
+                  "balance": { "VACHR": -0.3561643835616438 },
+                  "balance_children": { "VACHR": -0.3561643835616438 },
                   "children": [],
                   "cost": null,
                   "cost_children": null,
@@ -889,12 +900,12 @@
             {
               "account": "Income:US:ETrade",
               "balance": {},
-              "balance_children": { "USD": 46.44 },
+              "balance_children": { "USD": 0.12723287671232877 },
               "children": [
                 {
                   "account": "Income:US:ETrade:Dividends",
-                  "balance": { "USD": -51.68 },
-                  "balance_children": { "USD": -51.68 },
+                  "balance": { "USD": -0.1415890410958904 },
+                  "balance_children": { "USD": -0.1415890410958904 },
                   "children": [],
                   "cost": null,
                   "cost_children": null,
@@ -902,8 +913,8 @@
                 },
                 {
                   "account": "Income:US:ETrade:Gains",
-                  "balance": { "USD": 98.12 },
-                  "balance_children": { "USD": 98.12 },
+                  "balance": { "USD": 0.2688219178082192 },
+                  "balance_children": { "USD": 0.2688219178082192 },
                   "children": [],
                   "cost": null,
                   "cost_children": null,
@@ -917,12 +928,12 @@
             {
               "account": "Income:US:Federal",
               "balance": {},
-              "balance_children": { "IRAUSD": -17500 },
+              "balance_children": { "IRAUSD": -47.945205479452056 },
               "children": [
                 {
                   "account": "Income:US:Federal:PreTax401k",
-                  "balance": { "IRAUSD": -17500 },
-                  "balance_children": { "IRAUSD": -17500 },
+                  "balance": { "IRAUSD": -47.945205479452056 },
+                  "balance_children": { "IRAUSD": -47.945205479452056 },
                   "children": [],
                   "cost": null,
                   "cost_children": null,
@@ -945,8 +956,11 @@
     },
     {
       "account": "Net Profit",
-      "balance": { "USD": -35857.24, "VACHR": -130 },
-      "balance_children": { "USD": -35857.24, "VACHR": -130 },
+      "balance": { "USD": -98.23901369863013, "VACHR": -0.3561643835616438 },
+      "balance_children": {
+        "USD": -98.23901369863013,
+        "VACHR": -0.3561643835616438
+      },
       "children": [],
       "cost": null,
       "cost_children": null,
@@ -955,17 +969,20 @@
     {
       "account": "Expenses",
       "balance": {},
-      "balance_children": { "IRAUSD": 17500.0, "USD": 93478.52 },
+      "balance_children": {
+        "IRAUSD": 47.945205479452056,
+        "USD": 256.10553424657536
+      },
       "children": [
         {
           "account": "Expenses:Financial",
           "balance": {},
-          "balance_children": { "USD": 137.5 },
+          "balance_children": { "USD": 0.3767123287671233 },
           "children": [
             {
               "account": "Expenses:Financial:Commissions",
-              "balance": { "USD": 89.5 },
-              "balance_children": { "USD": 89.5 },
+              "balance": { "USD": 0.2452054794520548 },
+              "balance_children": { "USD": 0.2452054794520548 },
               "children": [],
               "cost": null,
               "cost_children": null,
@@ -973,8 +990,8 @@
             },
             {
               "account": "Expenses:Financial:Fees",
-              "balance": { "USD": 48.0 },
-              "balance_children": { "USD": 48.0 },
+              "balance": { "USD": 0.13150684931506848 },
+              "balance_children": { "USD": 0.13150684931506848 },
               "children": [],
               "cost": null,
               "cost_children": null,
@@ -988,7 +1005,7 @@
         {
           "account": "Expenses:Food",
           "balance": {},
-          "balance_children": { "USD": 6601.98 },
+          "balance_children": { "USD": 18.087616438356164 },
           "children": [
             {
               "account": "Expenses:Food:Alcohol",
@@ -1010,8 +1027,8 @@
             },
             {
               "account": "Expenses:Food:Groceries",
-              "balance": { "USD": 2424.91 },
-              "balance_children": { "USD": 2424.91 },
+              "balance": { "USD": 6.643589041095891 },
+              "balance_children": { "USD": 6.643589041095891 },
               "children": [],
               "cost": null,
               "cost_children": null,
@@ -1019,8 +1036,8 @@
             },
             {
               "account": "Expenses:Food:Restaurant",
-              "balance": { "USD": 4177.07 },
-              "balance_children": { "USD": 4177.07 },
+              "balance": { "USD": 11.444027397260275 },
+              "balance_children": { "USD": 11.444027397260275 },
               "children": [],
               "cost": null,
               "cost_children": null,
@@ -1034,17 +1051,17 @@
         {
           "account": "Expenses:Health",
           "balance": {},
-          "balance_children": { "USD": 2519.4 },
+          "balance_children": { "USD": 6.902465753424657 },
           "children": [
             {
               "account": "Expenses:Health:Dental",
               "balance": {},
-              "balance_children": { "USD": 75.4 },
+              "balance_children": { "USD": 0.20657534246575343 },
               "children": [
                 {
                   "account": "Expenses:Health:Dental:Insurance",
-                  "balance": { "USD": 75.4 },
-                  "balance_children": { "USD": 75.4 },
+                  "balance": { "USD": 0.20657534246575343 },
+                  "balance_children": { "USD": 0.20657534246575343 },
                   "children": [],
                   "cost": null,
                   "cost_children": null,
@@ -1058,12 +1075,12 @@
             {
               "account": "Expenses:Health:Life",
               "balance": {},
-              "balance_children": { "USD": 632.32 },
+              "balance_children": { "USD": 1.7323835616438357 },
               "children": [
                 {
                   "account": "Expenses:Health:Life:GroupTermLife",
-                  "balance": { "USD": 632.32 },
-                  "balance_children": { "USD": 632.32 },
+                  "balance": { "USD": 1.7323835616438357 },
+                  "balance_children": { "USD": 1.7323835616438357 },
                   "children": [],
                   "cost": null,
                   "cost_children": null,
@@ -1077,12 +1094,12 @@
             {
               "account": "Expenses:Health:Medical",
               "balance": {},
-              "balance_children": { "USD": 711.88 },
+              "balance_children": { "USD": 1.9503561643835616 },
               "children": [
                 {
                   "account": "Expenses:Health:Medical:Insurance",
-                  "balance": { "USD": 711.88 },
-                  "balance_children": { "USD": 711.88 },
+                  "balance": { "USD": 1.9503561643835616 },
+                  "balance_children": { "USD": 1.9503561643835616 },
                   "children": [],
                   "cost": null,
                   "cost_children": null,
@@ -1096,12 +1113,12 @@
             {
               "account": "Expenses:Health:Vision",
               "balance": {},
-              "balance_children": { "USD": 1099.8 },
+              "balance_children": { "USD": 3.013150684931507 },
               "children": [
                 {
                   "account": "Expenses:Health:Vision:Insurance",
-                  "balance": { "USD": 1099.8 },
-                  "balance_children": { "USD": 1099.8 },
+                  "balance": { "USD": 3.013150684931507 },
+                  "balance_children": { "USD": 3.013150684931507 },
                   "children": [],
                   "cost": null,
                   "cost_children": null,
@@ -1120,12 +1137,12 @@
         {
           "account": "Expenses:Home",
           "balance": {},
-          "balance_children": { "USD": 31302.44 },
+          "balance_children": { "USD": 85.7601095890411 },
           "children": [
             {
               "account": "Expenses:Home:Electricity",
-              "balance": { "USD": 780.0 },
-              "balance_children": { "USD": 780.0 },
+              "balance": { "USD": 2.136986301369863 },
+              "balance_children": { "USD": 2.136986301369863 },
               "children": [],
               "cost": null,
               "cost_children": null,
@@ -1133,8 +1150,8 @@
             },
             {
               "account": "Expenses:Home:Internet",
-              "balance": { "USD": 959.79 },
-              "balance_children": { "USD": 959.79 },
+              "balance": { "USD": 2.6295616438356166 },
+              "balance_children": { "USD": 2.6295616438356166 },
               "children": [],
               "cost": null,
               "cost_children": null,
@@ -1142,8 +1159,8 @@
             },
             {
               "account": "Expenses:Home:Phone",
-              "balance": { "USD": 762.65 },
-              "balance_children": { "USD": 762.65 },
+              "balance": { "USD": 2.0894520547945206 },
+              "balance_children": { "USD": 2.0894520547945206 },
               "children": [],
               "cost": null,
               "cost_children": null,
@@ -1151,8 +1168,8 @@
             },
             {
               "account": "Expenses:Home:Rent",
-              "balance": { "USD": 28800.0 },
-              "balance_children": { "USD": 28800.0 },
+              "balance": { "USD": 78.9041095890411 },
+              "balance_children": { "USD": 78.9041095890411 },
               "children": [],
               "cost": null,
               "cost_children": null,
@@ -1166,22 +1183,31 @@
         {
           "account": "Expenses:Taxes",
           "balance": {},
-          "balance_children": { "IRAUSD": 17500.0, "USD": 51477.2 },
+          "balance_children": {
+            "IRAUSD": 47.945205479452056,
+            "USD": 141.03342465753425
+          },
           "children": [
             {
               "account": "Expenses:Taxes:Y2014",
               "balance": {},
-              "balance_children": { "IRAUSD": 17500.0, "USD": 51477.2 },
+              "balance_children": {
+                "IRAUSD": 47.945205479452056,
+                "USD": 141.03342465753425
+              },
               "children": [
                 {
                   "account": "Expenses:Taxes:Y2014:US",
                   "balance": {},
-                  "balance_children": { "IRAUSD": 17500.0, "USD": 51477.2 },
+                  "balance_children": {
+                    "IRAUSD": 47.945205479452056,
+                    "USD": 141.03342465753425
+                  },
                   "children": [
                     {
                       "account": "Expenses:Taxes:Y2014:US:CityNYC",
-                      "balance": { "USD": 4547.92 },
-                      "balance_children": { "USD": 4547.92 },
+                      "balance": { "USD": 12.460054794520548 },
+                      "balance_children": { "USD": 12.460054794520548 },
                       "children": [],
                       "cost": null,
                       "cost_children": null,
@@ -1189,16 +1215,16 @@
                     },
                     {
                       "account": "Expenses:Taxes:Y2014:US:Federal",
-                      "balance": { "USD": 27635.92 },
+                      "balance": { "USD": 75.71484931506849 },
                       "balance_children": {
-                        "IRAUSD": 17500.0,
-                        "USD": 27635.92
+                        "IRAUSD": 47.945205479452056,
+                        "USD": 75.71484931506849
                       },
                       "children": [
                         {
                           "account": "Expenses:Taxes:Y2014:US:Federal:PreTax401k",
-                          "balance": { "IRAUSD": 17500.0 },
-                          "balance_children": { "IRAUSD": 17500.0 },
+                          "balance": { "IRAUSD": 47.945205479452056 },
+                          "balance_children": { "IRAUSD": 47.945205479452056 },
                           "children": [],
                           "cost": null,
                           "cost_children": null,
@@ -1211,8 +1237,8 @@
                     },
                     {
                       "account": "Expenses:Taxes:Y2014:US:Medicare",
-                      "balance": { "USD": 2772.12 },
-                      "balance_children": { "USD": 2772.12 },
+                      "balance": { "USD": 7.594849315068493 },
+                      "balance_children": { "USD": 7.594849315068493 },
                       "children": [],
                       "cost": null,
                       "cost_children": null,
@@ -1220,8 +1246,8 @@
                     },
                     {
                       "account": "Expenses:Taxes:Y2014:US:SDI",
-                      "balance": { "USD": 29.12 },
-                      "balance_children": { "USD": 29.12 },
+                      "balance": { "USD": 0.07978082191780822 },
+                      "balance_children": { "USD": 0.07978082191780822 },
                       "children": [],
                       "cost": null,
                       "cost_children": null,
@@ -1229,8 +1255,8 @@
                     },
                     {
                       "account": "Expenses:Taxes:Y2014:US:SocSec",
-                      "balance": { "USD": 7000.04 },
-                      "balance_children": { "USD": 7000.04 },
+                      "balance": { "USD": 19.17819178082192 },
+                      "balance_children": { "USD": 19.17819178082192 },
                       "children": [],
                       "cost": null,
                       "cost_children": null,
@@ -1238,8 +1264,8 @@
                     },
                     {
                       "account": "Expenses:Taxes:Y2014:US:State",
-                      "balance": { "USD": 9492.08 },
-                      "balance_children": { "USD": 9492.08 },
+                      "balance": { "USD": 26.005698630136987 },
+                      "balance_children": { "USD": 26.005698630136987 },
                       "children": [],
                       "cost": null,
                       "cost_children": null,
@@ -1263,12 +1289,12 @@
         {
           "account": "Expenses:Transport",
           "balance": {},
-          "balance_children": { "USD": 1440.0 },
+          "balance_children": { "USD": 3.9452054794520546 },
           "children": [
             {
               "account": "Expenses:Transport:Tram",
-              "balance": { "USD": 1440.0 },
-              "balance_children": { "USD": 1440.0 },
+              "balance": { "USD": 3.9452054794520546 },
+              "balance_children": { "USD": 3.9452054794520546 },
               "children": [],
               "cost": null,
               "cost_children": null,

--- a/tests/test_json_api.py
+++ b/tests/test_json_api.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import datetime
+from decimal import Decimal
 from difflib import Differ
 from http import HTTPStatus
 from io import BytesIO
@@ -12,11 +13,24 @@ import pytest
 
 from fava.beans.funcs import hash_entry
 from fava.context import g
+from fava.core import FilteredLedger
+from fava.core.charts import DateAndBalance
+from fava.core.charts import DateAndBalanceWithBudget
 from fava.core.file import _sha256_str
 from fava.core.file import get_entry_slice
+from fava.core.inventory import SimpleCounterInventory
 from fava.core.misc import align
+from fava.core.tree import SerialisedTreeNode
+from fava.internal_api import BalancesChart
+from fava.internal_api import BarChart
+from fava.internal_api import HierarchyChart
+from fava.json_api import _average_bar_chart
+from fava.json_api import _average_divisor
+from fava.json_api import _average_range
+from fava.json_api import _scale_chart
 from fava.json_api import validate_func_arguments
 from fava.json_api import ValidationError
+from fava.util.date import DateRange
 
 if TYPE_CHECKING:  # pragma: no cover
     from flask import Flask
@@ -27,6 +41,10 @@ if TYPE_CHECKING:  # pragma: no cover
 
     from .conftest import GetFavaLedger
     from .conftest import SnapshotFunc
+
+
+def _simple_inv(**amounts: Decimal) -> SimpleCounterInventory:
+    return SimpleCounterInventory(amounts)
 
 
 def diff_strings(a: str, b: str) -> list[str]:
@@ -808,6 +826,207 @@ def test_api_commodities_empty(
     assert not data
 
 
+def test_api_income_statement_average(
+    test_client: FlaskClient,
+) -> None:
+    baseline = assert_api_success(
+        test_client.get("/long-example/api/income_statement?time=2014"),
+    )
+    averaged = assert_api_success(
+        test_client.get(
+            "/long-example/api/income_statement?time=2014&average=day",
+        ),
+    )
+
+    tree = next(tree for tree in baseline["trees"] if tree["balance_children"])
+    currency = next(iter(tree["balance_children"]))
+    baseline_tree_value = tree["balance_children"][currency]
+    averaged_tree_value = next(
+        tree for tree in averaged["trees"] if tree["balance_children"]
+    )["balance_children"][currency]
+    assert averaged_tree_value == pytest.approx(baseline_tree_value / 365)
+
+    baseline_chart_value = next(
+        item
+        for chart in baseline["charts"]
+        for item in chart["data"]
+        if item["balance"]
+    )["balance"][currency]
+    averaged_chart_value = next(
+        item
+        for chart in averaged["charts"]
+        for item in chart["data"]
+        if item["balance"]
+    )["balance"][currency]
+    assert averaged_chart_value == pytest.approx(baseline_chart_value)
+
+    average_chart = next(
+        chart for chart in averaged["charts"] if chart["averages"]
+    )
+    average_currency = next(iter(average_chart["averages"]))
+    average_values = [
+        item["balance"].get(average_currency, 0)
+        for item in average_chart["data"]
+    ]
+    assert average_chart["averages"][average_currency] == pytest.approx(
+        sum(average_values) / 365,
+    )
+
+
+def test_api_income_statement_average_uses_filter_window(
+    test_client: FlaskClient,
+) -> None:
+    baseline = assert_api_success(
+        test_client.get(
+            "/long-example/api/income_statement"
+            "?time=2016&account=Expenses:Food:Groceries",
+        ),
+    )
+    averaged = assert_api_success(
+        test_client.get(
+            "/long-example/api/income_statement"
+            "?time=2016&account=Expenses:Food:Groceries&average=month",
+        ),
+    )
+
+    tree = next(tree for tree in baseline["trees"] if tree["balance_children"])
+    currency = next(iter(tree["balance_children"]))
+    baseline_tree_value = tree["balance_children"][currency]
+    averaged_tree_value = next(
+        tree for tree in averaged["trees"] if tree["balance_children"]
+    )["balance_children"][currency]
+    assert averaged_tree_value == pytest.approx(baseline_tree_value / 12)
+
+    baseline_chart = next(
+        chart for chart in baseline["charts"] if chart["type"] == "bar"
+    )
+    averaged_chart = next(
+        chart for chart in averaged["charts"] if chart["type"] == "bar"
+    )
+    baseline_chart_value = next(
+        item["balance"][currency]
+        for item in baseline_chart["data"]
+        if item["balance"]
+    )
+    averaged_chart_value = next(
+        item["balance"][currency]
+        for item in averaged_chart["data"]
+        if item["balance"]
+    )
+    assert averaged_chart_value == pytest.approx(baseline_chart_value)
+    assert averaged_chart["averages"][currency] == pytest.approx(
+        baseline_tree_value / 12,
+    )
+
+
+def test_api_income_statement_average_invalid(
+    test_client: FlaskClient,
+) -> None:
+    response = test_client.get(
+        "/long-example/api/income_statement?time=2014&average=century",
+    )
+    assert_api_error(response, status=HTTPStatus.BAD_REQUEST)
+
+
+def test_average_range_uses_filtered_bounds(
+    small_example_ledger: FavaLedger,
+) -> None:
+    filtered = FilteredLedger(small_example_ledger)
+    filtered.date_range = None
+    filtered._date_first = datetime.date(2014, 1, 1)
+    filtered._date_last = datetime.date(2015, 1, 1)
+
+    assert _average_range(filtered) == DateRange(
+        datetime.date(2014, 1, 1),
+        datetime.date(2015, 1, 1),
+    )
+    assert _average_divisor(filtered, "year") == Decimal(1)
+
+
+def test_average_divisor_without_dates(
+    small_example_ledger: FavaLedger,
+) -> None:
+    filtered = FilteredLedger(small_example_ledger)
+    filtered.date_range = None
+    filtered._date_first = None
+    filtered._date_last = None
+
+    assert _average_divisor(filtered, "month") is None
+
+
+def test_scale_chart_scales_all_chart_types() -> None:
+    divisor = Decimal(2)
+    day = datetime.date(2024, 1, 1)
+
+    balances = BalancesChart(
+        "Balances",
+        [DateAndBalance(day, _simple_inv(USD=Decimal(6)))],
+    )
+    scaled_balances = _scale_chart(balances, divisor)
+    assert isinstance(scaled_balances, BalancesChart)
+    assert scaled_balances.data[0].balance == _simple_inv(USD=Decimal(3))
+
+    bar = BarChart(
+        "Changes",
+        [
+            DateAndBalanceWithBudget(
+                day,
+                _simple_inv(USD=Decimal(8)),
+                {
+                    "Assets:Cash": _simple_inv(USD=Decimal(6)),
+                    "Assets:Empty": _simple_inv(),
+                },
+                {"USD": Decimal(4)},
+            )
+        ],
+    )
+    scaled_bar = _scale_chart(bar, divisor)
+    assert isinstance(scaled_bar, BarChart)
+    assert scaled_bar.data[0].balance == _simple_inv(USD=Decimal(4))
+    assert scaled_bar.data[0].account_balances == {
+        "Assets:Cash": _simple_inv(USD=Decimal(3)),
+        "Assets:Empty": _simple_inv(),
+    }
+    assert scaled_bar.data[0].budgets == {"USD": Decimal(2)}
+
+    tree = HierarchyChart(
+        "Assets",
+        SerialisedTreeNode(
+            "Assets",
+            _simple_inv(USD=Decimal(10)),
+            _simple_inv(USD=Decimal(12)),
+            (
+                SerialisedTreeNode(
+                    "Assets:Cash",
+                    _simple_inv(USD=Decimal(4)),
+                    _simple_inv(USD=Decimal(4)),
+                    (),
+                    has_txns=True,
+                ),
+            ),
+            has_txns=True,
+            cost=_simple_inv(USD=Decimal(14)),
+            cost_children=_simple_inv(USD=Decimal(16)),
+        ),
+    )
+    scaled_tree = _scale_chart(tree, divisor)
+    assert isinstance(scaled_tree, HierarchyChart)
+    assert scaled_tree.data.balance == _simple_inv(USD=Decimal(5))
+    assert scaled_tree.data.balance_children == _simple_inv(USD=Decimal(6))
+    assert scaled_tree.data.cost == _simple_inv(USD=Decimal(7))
+    assert scaled_tree.data.cost_children == _simple_inv(USD=Decimal(8))
+    assert scaled_tree.data.children[0].balance == _simple_inv(USD=Decimal(2))
+
+    other: Any = object()
+    assert _scale_chart(other, divisor) is other
+
+
+def test_average_bar_chart_empty_data() -> None:
+    chart = BarChart("Changes", [])
+
+    assert _average_bar_chart(chart, Decimal(3)).averages is None
+
+
 def test_api_journal_page_not_found(
     test_client: FlaskClient,
 ) -> None:
@@ -834,6 +1053,10 @@ def test_api_filter_error(
         ("events", "/long-example/api/events"),
         ("journal", "/example/api/journal"),
         ("income_statement", "/long-example/api/income_statement?time=2014"),
+        (
+            "income_statement_average",
+            "/long-example/api/income_statement?time=2014&average=day",
+        ),
         ("narrations", "/long-example/api/narrations"),
         ("trial_balance", "/long-example/api/trial_balance?time=2014"),
         ("balance_sheet", "/long-example/api/balance_sheet"),


### PR DESCRIPTION
Implement the average view requested in #2148 by adding an `average` query parameter (day/week/month/quarter/year) and applying the computed divisor across income statement trees and charts.

Add frontend support for selecting and syncing the average interval in the URL, include per-currency bar chart averages in the API payload, and adjust number formatting to preserve useful precision for averaged values.

Update API/frontend tests and snapshots for the new behavior.

Fix issue, #2148 