### PR TITLE
Allow emoji/Unicode characters in filter search strings

### DIFF
--- a/src/fava/core/filters.py
+++ b/src/fava/core/filters.py
@@ -104,7 +104,7 @@ class FilterSyntaxLexer:
         ("EQ_OP", r":"),
         ("CMP_OP", r"(=|>=|<=|<|>)"),
         ("NUMBER", r"\d*\.?\d+"),
-        ("STRING", r"""\w[-\w]*|"[^"]*"|'[^']*'"""),
+        ("STRING", r"""\w[-\w]*|"[^"]*"|'[^']*'|[^\s\-(),#^:="']+"""),
     )
 
     regex = re.compile(

--- a/tests/test_core_filters.py
+++ b/tests/test_core_filters.py
@@ -87,6 +87,24 @@ def test_lexer_emoji() -> None:
     ]
 
 
+def test_emoji_search_in_narration() -> None:
+    txn = create.transaction(
+        {},
+        datetime.date(2026, 6, 24),
+        "*",
+        "Cafe ☕",
+        "Coffee",
+        frozenset(),
+        frozenset(),
+        [create.posting("Expenses:Food:Coffee", "5.00 AUD")],
+    )
+    filter_ = AdvancedFilter("☕")
+    assert filter_.apply([txn]) == [txn]
+
+    filter_no_match = AdvancedFilter("⛽")
+    assert filter_no_match.apply([txn]) == []
+
+
 def test_lexer_literals_in_string() -> None:
     lex = FilterSyntaxLexer().lex
     data = "string-2-2 string"

--- a/tests/test_core_filters.py
+++ b/tests/test_core_filters.py
@@ -75,7 +75,16 @@ def test_lexer_basic() -> None:
         ("STRING", "string"),
     ]
     with pytest.raises(FilterError):
-        list(lex("|"))
+        list(lex('"'))
+
+
+def test_lexer_emoji() -> None:
+    lex = FilterSyntaxLexer().lex
+    data = "☕ ⛽️"
+    assert [(tok.type, tok.value) for tok in lex(data)] == [
+        ("STRING", "☕"),
+        ("STRING", "⛽️"),
+    ]
 
 
 def test_lexer_literals_in_string() -> None:


### PR DESCRIPTION
The `STRING` token regex in `FilterSyntaxLexer` only matched ASCII word characters (`\w`), so emoji like ☕ fell through to the illegal-character error handler.

Added a catch-all pattern `[^\s\-(),#^:="\']+` as the last alternative in the STRING regex, so emoji and other Unicode characters are now valid search terms. This only matches after all other token patterns (TAG, LINK, KEY, quoted strings, numbers, operators) have been tried.

Fixes #2302