### PR TITLE
fix: return JSON error for extension endpoint exceptions

### DIFF
--- a/src/fava/application.py
+++ b/src/fava/application.py
@@ -359,7 +359,16 @@ def _setup_routes(fava_app: Flask) -> None:  # noqa: PLR0915
         try:
             response = ext.endpoints[key](ext)
         except Exception as e:
-            return jsonify({"error": str(e), "extension": extension_name, "endpoint": endpoint}), 500
+            log.exception("Extension endpoint error")
+            response = jsonify(
+                {
+                    "error": str(e),
+                    "extension": extension_name,
+                    "endpoint": endpoint,
+                }
+            )
+            response.status_code = 500
+            return response
 
         return (
             fava_app.make_response(response)

--- a/src/fava/application.py
+++ b/src/fava/application.py
@@ -30,6 +30,7 @@ from urllib.parse import urlunparse
 from flask import abort
 from flask import current_app
 from flask import Flask
+from flask import jsonify
 from flask import redirect
 from flask import render_template
 from flask import render_template_string
@@ -355,7 +356,10 @@ def _setup_routes(fava_app: Flask) -> None:  # noqa: PLR0915
         key = (endpoint, request.method)
         if ext is None or key not in ext.endpoints:
             return abort(404)
-        response = ext.endpoints[key](ext)
+        try:
+            response = ext.endpoints[key](ext)
+        except Exception as e:
+            return jsonify({"error": str(e), "extension": extension_name, "endpoint": endpoint}), 500
 
         return (
             fava_app.make_response(response)

--- a/src/fava/ext/fava_ext_test/__init__.py
+++ b/src/fava/ext/fava_ext_test/__init__.py
@@ -184,6 +184,12 @@ class FavaExtTest(FavaExtensionBase):
         """Return some data with a GET endpoint."""
         return jsonify(["some data"])
 
+    @extension_endpoint
+    def example_error(self) -> Response:
+        """Raise an exception for testing error handling."""
+        msg = "example error"
+        raise RuntimeError(msg)
+
     def chart_data(self) -> list[BalancesChart]:
         """Return some chart data."""
         return [

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -347,3 +347,15 @@ def test_load_extension_endpoint(test_client: FlaskClient) -> None:
     response = test_client.get(url)
     assert assert_success(response)
     assert response.json == ["some data"]
+
+
+def test_load_extension_endpoint_error(test_client: FlaskClient) -> None:
+    """Exceptions in extension endpoints return JSON with a 500 status."""
+    url = "/extension-report/extension/FavaExtTest/example_error"
+    response = test_client.get(url)
+    assert response.status_code == HTTPStatus.INTERNAL_SERVER_ERROR.value
+    assert response.json == {
+        "error": "example error",
+        "extension": "FavaExtTest",
+        "endpoint": "example_error",
+    }


### PR DESCRIPTION
Previously an exception in an extension endpoint bubbled up to Flask's default HTML 500 page, making it hard for extension UIs to show a friendly message. Wrap endpoint handler calls and return a JSON object with error details.

This is a small, focused change that makes the extension system more usable for JS-heavy extensions (like those using Preact/htm) that can't easily parse an HTML error page.