### PR TITLE
feat: add Elasticsearch/Grafana date-math syntax to time filter

### DIFF
--- a/docs/time-filter-syntax.md
+++ b/docs/time-filter-syntax.md
@@ -1,0 +1,218 @@
+# Fava Time Filter Syntax
+
+The Time search box at the top of the Fava UI accepts a custom date expression language. The input is sent as the `?time=` URL parameter and parsed server-side by `parse_date()` in `src/fava/util/date.py`.
+
+## How it works
+
+1. The frontend (`FilterForm.svelte`) sends the raw string as the `time` query parameter.
+2. The backend (`TimeFilter` in `filters.py`) calls `parse_date(value, fiscal_year_end)`.
+3. If parsing returns `(None, None)`, a `TimeFilterParseError` is raised and shown to the user.
+4. Otherwise, the returned `(begin, end)` tuple is used to clamp entries via `clamp_opt()`.
+
+All dates are **inclusive on the start, exclusive on the end**. A range `2024` means Jan 1, 2024 through Jan 1, 2025 (all of 2024).
+
+---
+
+## 1. Single-date formats
+
+| Format | Example | Start | End | Notes |
+|---|---|---|---|---|
+| `YYYY` | `2024` | 2024-01-01 | 2025-01-01 | Full calendar year |
+| `YYYY-MM` | `2024-03` | 2024-03-01 | 2024-04-01 | Calendar month |
+| `YYYY-MM-DD` | `2024-03-15` | 2024-03-15 | 2024-03-16 | Single day |
+| `YYYY-Www` | `2024-W03` | 2024-01-15 | 2024-01-22 | ISO week (Monday start) |
+| `YYYY-Qn` | `2024-Q1` | 2024-01-01 | 2024-04-01 | Calendar quarter (Q1-Q4) |
+| `FYYYYY` | `FY2024` | 2023-07-01 | 2024-07-01 | Fiscal year (depends on `fiscal-year-end` option; shown with FYE=06-30) |
+| `FYYYYY-Qn` | `FY2024-Q2` | 2023-10-01 | 2024-01-01 | Fiscal quarter (depends on `fiscal-year-end`; FYE must start on 1st of a month) |
+
+---
+
+## 2. Range formats
+
+Two dates separated by ` - ` or ` to `:
+
+| Example | Start | End |
+|---|---|---|
+| `2024 - 2025` | 2024-01-01 | 2026-01-01 |
+| `2024 to 2025` | 2024-01-01 | 2026-01-01 |
+| `2024-03 - 2025` | 2024-03-01 | 2026-01-01 |
+| `2024-01-15 - 2024-03` | 2024-01-15 | 2024-04-01 |
+| `FY2019 - FY2020` | 2018-07-01 | 2020-07-01 |
+| `FY2019 - 2020` | 2018-07-01 | 2021-01-01 |
+| `2011 to FY2015` | 2011-01-01 | 2015-07-01 |
+
+Each side of the range can be any single-date format. The range regex matches `-` or `to` only when followed by whitespace and a year-like pattern (`fyYYYY` or `YYYY`).
+
+---
+
+## 3. Relative keywords
+
+These resolve against **today's date**. They can appear anywhere a date is expected (single or range).
+
+| Keyword | Today=2016-06-24 | Start | End |
+|---|---|---|---|
+| `year` | 2016 | 2016-01-01 | 2017-01-01 |
+| `year-1` | 2015 | 2015-01-01 | 2016-01-01 |
+| `year+3` | 2019 | 2019-01-01 | 2020-01-01 |
+| `month` | 2016-06 | 2016-06-01 | 2016-07-01 |
+| `month-1` | 2016-05 | 2016-05-01 | 2016-06-01 |
+| `month+6` | 2016-12 | 2016-12-01 | 2017-01-01 |
+| `quarter` | 2016-Q2 | 2016-04-01 | 2016-07-01 |
+| `quarter+2` | 2016-Q4 | 2016-10-01 | 2017-01-01 |
+| `week` | 2016-W25 | 2016-06-20 | 2016-06-27 |
+| `week+20` | 2016-W45 | 2016-11-07 | 2016-11-14 |
+| `day` | 2016-06-24 | 2016-06-24 | 2016-06-25 |
+| `day+20` | 2016-07-14 | 2016-07-14 | 2016-07-15 |
+| `fiscal_year` | FY2018 | 2017-07-01 | 2018-07-01 |
+| `fiscal_year-1` | FY2017 | 2016-07-01 | 2017-07-01 |
+| `fiscal_quarter` | FY2018-Q3 | 2018-01-01 | 2018-04-01 |
+
+Keywords can be **parenthesized**: `(year)`, `(year+3)`. Parentheses are optional but can help disambiguate in ranges.
+
+### Fiscal year details
+
+`fiscal_year` and `fiscal_quarter` depend on the `fiscal-year-end` option (format `MM-DD`, default `12-31`). The offset from the end of the fiscal year determines which FY label applies:
+
+- With FYE=06-30: a date in Feb 2018 is in FY2018 (before June 30); a date in Aug 2018 is in FY2019 (after July 1).
+- With FYE=04-05 (UK-style): a date in Feb 2018 is in FY2017; a date in May 2018 is in FY2018.
+- With FYE=15-31 (offset fiscal year, e.g. Japan): month 15 = March of the next calendar year.
+
+Fiscal quarters are only available when the fiscal year starts on the first of a month (e.g. FYE=06-30 works; FYE=04-05 does not).
+
+---
+
+## 4. Relative ranges
+
+Both sides of a range can use relative keywords:
+
+| Example (today=2016-06-24, FYE=06-30) | Start | End |
+|---|---|---|
+| `year-2 - day+2` | 2014-01-01 | 2016-06-27 |
+| `year - day` | 2016-01-01 | 2016-06-25 |
+| `2015 - year` | 2015-01-01 | 2017-01-01 |
+| `quarter-1` | 2016-01-01 | 2016-04-01 |
+| `fiscal_year-2` | 2013-07-01 | 2014-07-01 |
+
+---
+
+## 5. Date-math syntax (Elasticsearch/Grafana style)
+
+Fava supports the Elasticsearch/Grafana date-math syntax:
+
+```
+now[+/-Nunit][/snap]
+```
+
+This is resolved against today's date.
+
+### Units
+
+| Unit | Meaning | Example |
+|---|---|---|
+| `d` | Days | `now-30d` = 30 days ago |
+| `w` | Weeks | `now-1w` = 1 week ago |
+| `M` | Months | `now-1M` = 1 month ago |
+| `y` | Years | `now-1y` = 1 year ago |
+
+### Snaps: what they are and why they matter
+
+A **snap** rounds a date down to the start of a period. This is the key concept that makes date-math useful for financial reporting.
+
+Without a snap, `now-1y` means "exactly 1 year ago" -- a single point in time (2025-07-26). That's rarely what you want in a ledger. With a snap, `now-1y/y` means "the start of the year that was 1 year ago" (2025-01-01), giving you the full calendar year.
+
+The snap is applied **after** the offset. So `now-1y/y` is: take today, subtract 1 year, then snap to the start of that year.
+
+| Snap | Rounds down to | Example |
+|---|---|---|
+| `/d` | Start of day (identity for date-only) | `now/d` = today at midnight |
+| `/w` | Monday of the week | `now/w` = this Monday |
+| `/M` | First of the month | `now/M` = first of this month |
+| `/y` | First of the year | `now/y` = first of this year |
+| `/fy` | Start of the fiscal year | `now/fy` = start of current fiscal year |
+| `/fQ` | Start of the fiscal quarter | `now/fQ` = start of current fiscal quarter |
+
+**Without an explicit snap, the unit determines the period.** For example, `now-1M` is equivalent to `now-1M/M` -- it snaps to the month boundary automatically. This matches the intuitive reading: "last month" means the calendar month, not a single day 30 days ago.
+
+### Examples (today=2026-07-26)
+
+| Expression | Start | End | Meaning |
+|---|---|---|---|
+| `now` | 2026-07-26 | 2026-07-27 | Today |
+| `now-1d` | 2026-07-25 | 2026-07-26 | Yesterday |
+| `now-7d` | 2026-07-19 | 2026-07-20 | 7 days ago |
+| `now-1w` | 2026-07-13 | 2026-07-20 | Last week (Mon-Mon) |
+| `now-1M` | 2026-06-01 | 2026-07-01 | Last month |
+| `now-1y` | 2025-01-01 | 2026-01-01 | Last calendar year |
+| `now+1M` | 2026-08-01 | 2026-09-01 | Next month |
+| `now/d` | 2026-07-26 | 2026-07-27 | Start of today |
+| `now/M` | 2026-07-01 | 2026-08-01 | This month |
+| `now/y` | 2026-01-01 | 2027-01-01 | This year |
+| `now-1y/y` | 2025-01-01 | 2026-01-01 | Last calendar year (explicit snap) |
+| `now-1M/M` | 2026-06-01 | 2026-07-01 | Last month (explicit snap) |
+| `now-1d/d` | 2026-07-25 | 2026-07-26 | Yesterday (explicit snap) |
+| `now/w` | 2026-07-20 | 2026-07-27 | This week |
+| `now-1w/w` | 2026-07-13 | 2026-07-20 | Last week (explicit snap) |
+
+### Fiscal snaps (FYE=06-30)
+
+| Expression | Start | End | Meaning |
+|---|---|---|---|
+| `now/fy` | 2026-07-01 | 2027-07-01 | Current fiscal year |
+| `now-1y/fy` | 2025-07-01 | 2026-07-01 | Last fiscal year |
+| `now/fQ` | 2026-07-01 | 2026-10-01 | Current fiscal quarter |
+
+### Date-math ranges
+
+| Expression | Start | End | Meaning |
+|---|---|---|---|
+| `now-30d - now` | 2026-06-26 | 2026-07-26 | Last 30 days |
+| `now-1y - now` | 2025-07-26 | 2026-07-26 | Last 365 days |
+| `now/M - now` | 2026-07-01 | 2026-07-26 | Month to date |
+| `now-1y/y - now/y` | 2025-01-01 | 2026-01-01 | Last calendar year (range form) |
+| `now-7d - now-1d` | 2026-07-19 | 2026-07-25 | 7 days ago through yesterday |
+
+### How snaps work step by step
+
+`now-1y/y` with today=2026-07-26:
+
+1. Start with `now` = 2026-07-26
+2. Apply offset `-1y` = 2025-07-26
+3. Apply snap `/y` = round down to start of year = 2025-01-01
+4. End = start of next year = 2026-01-01
+5. Result: 2025-01-01 to 2026-01-01 (all of 2025)
+
+`now-1y` (no explicit snap, unit=y implies snap to year):
+
+1. Start with `now` = 2026-07-26
+2. Apply offset `-1y` = 2025-07-26
+3. Implicit snap to year = 2025-01-01
+4. End = start of next year = 2026-01-01
+5. Result: 2025-01-01 to 2026-01-01 (same as `now-1y/y`)
+
+`now-30d - now` (range, no snap on either side):
+
+1. Left: `now-30d` = 2026-06-26 (no snap, just offset)
+2. Right: `now` = 2026-07-26 (no snap)
+3. Result: 2026-06-26 to 2026-07-26 (rolling 30-day window)
+
+---
+
+## 6. Edge cases
+
+| Input | Result |
+|---|---|
+| Empty or whitespace-only | `(None, None)` -- no filter applied |
+| `   2000   ` | Whitespace is stripped; parses as year 2000 |
+| Unparseable string (e.g. `abc`) | `(None, None)` -- raises `TimeFilterParseError` |
+
+---
+
+## 7. Implementation reference
+
+- **Frontend input**: `frontend/src/sidebar/FilterForm.svelte` -- `AutocompleteInput` with `suggestions={$years}`
+- **Brush widget**: `frontend/src/charts/Brush.svelte` -- drag-select sets `time` param as `"start - end"`
+- **URL store**: `frontend/src/stores/filters.ts` -- reads `?time=` from URL
+- **Date format for brush output**: `frontend/src/format.ts` -- `timeFilterDateFormat` maps interval to format string
+- **Backend parser**: `src/fava/util/date.py` -- `parse_date()`, `substitute()`, `_parse_datemath()`
+- **Filter application**: `src/fava/core/filters.py` -- `TimeFilter` class
+- **Tests**: `tests/test_util_date.py` -- comprehensive parametrized test suite

--- a/src/fava/util/date.py
+++ b/src/fava/util/date.py
@@ -55,6 +55,16 @@ VARIABLE_RE = re.compile(
     r"|month|week|day)(?:([-+])(\d+))?\)?",
 )
 
+# Elasticsearch/Grafana date-math: now[+/-Nunit][/snap]
+# Units: y, M, w, d (date-only, no h/m/s for beancount)
+# Snaps: y, M, w, d, fy, fQ
+DATEMATH_RE = re.compile(
+    r"now"
+    r"(?:\s*([+-])\s*(\d+)\s*([yMwWd]))?"
+    r"(?:\s*/\s*(fy|fq|[yMwWd]))?",
+    re.IGNORECASE,
+)
+
 
 @dataclass(frozen=True)
 class FiscalYearEnd:
@@ -340,6 +350,123 @@ def local_today() -> datetime.date:
     return datetime.date.today()  # noqa: DTZ011
 
 
+def _snap_date(
+    date: datetime.date,
+    snap: str,
+    fye: FiscalYearEnd,
+) -> datetime.date:
+    """Snap a date to the start of the given period.
+
+    Supports: y, M, w, d, fy (fiscal year), fQ (fiscal quarter).
+    """
+    snap_lower = snap.lower()
+    if snap_lower == "d":
+        return date
+    if snap_lower == "w":
+        return date - timedelta(date.weekday())
+    if snap_lower == "m":
+        return datetime.date(date.year, date.month, 1)
+    if snap_lower == "y":
+        return datetime.date(date.year, 1, 1)
+    if snap_lower == "fy":
+        after_fye = (date.month, date.day) > (fye.month_of_year, fye.day)
+        year = date.year + (1 if after_fye else 0) - fye.year_offset
+        start, _ = get_fiscal_period(year, fye)
+        return start if start is not None else datetime.date.min
+    if snap_lower == "fq":
+        if not fye.has_quarters():
+            raise FyeHasNoQuartersError
+        after_fye = (date.month, date.day) > (fye.month_of_year, fye.day)
+        year = date.year + (1 if after_fye else 0) - fye.year_offset
+        # find which fiscal quarter the date falls into
+        start_year, _ = get_fiscal_period(year, fye)
+        if start_year is None:
+            return datetime.date.min
+        # how many months since fiscal year start
+        months_since = (date.year - start_year.year) * 12 + date.month - start_year.month
+        quarter = max(1, min(4, months_since // 3 + 1))
+        start, _ = get_fiscal_period(year, fye, quarter)
+        return start if start is not None else datetime.date.min
+    msg = f"Unknown date math snap: {snap}"
+    raise ValueError(msg)
+
+
+def _period_end_from_snap(date: datetime.date, snap: str, fye: FiscalYearEnd) -> datetime.date:
+    """Given a snapped start date, return the (exclusive) end date."""
+    snap_lower = snap.lower()
+    if snap_lower == "d":
+        return Day.get_next(date)
+    if snap_lower == "w":
+        return Week.get_next(date)
+    if snap_lower == "m":
+        return Month.get_next(date)
+    if snap_lower == "y":
+        return Year.get_next(date)
+    if snap_lower == "fy":
+        # determine the fiscal year label for this start date
+        after_fye = (date.month, date.day) > (fye.month_of_year, fye.day)
+        year = date.year + (1 if after_fye else 0) - fye.year_offset
+        _, end = get_fiscal_period(year, fye)
+        return end if end is not None else datetime.date.max
+    if snap_lower == "fq":
+        # determine fiscal year/quarter for this start date
+        after_fye = (date.month, date.day) > (fye.month_of_year, fye.day)
+        year = date.year + (1 if after_fye else 0) - fye.year_offset
+        if not fye.has_quarters():
+            raise FyeHasNoQuartersError
+        start_year, _ = get_fiscal_period(year, fye)
+        if start_year is None:
+            return datetime.date.max
+        months_since = (date.year - start_year.year) * 12 + date.month - start_year.month
+        quarter = max(1, min(4, months_since // 3 + 1))
+        _, end = get_fiscal_period(year, fye, quarter)
+        return end if end is not None else datetime.date.max
+    msg = f"Unknown date math snap: {snap}"
+    raise ValueError(msg)
+
+
+def _unit_from_match(match: re.Match[str]) -> str:
+    """Extract the unit from a DATEMATH_RE match, defaulting to 'd'."""
+    return match.group(3) or "d"
+
+
+def _eval_datemath(
+    string: str,
+    fye: FiscalYearEnd,
+) -> datetime.date | None:
+    """Evaluate a single date-math expression like 'now-1y' or 'now/M'.
+
+    Returns the (possibly snapped) anchor date, or None if the string is
+    not date math.  Without an explicit snap, the offset is applied as a
+    simple shift (no period snapping).  With a snap (/d, /M, /y, /fy, /fQ),
+    the result is rounded down to the start of that period.
+    """
+    match = DATEMATH_RE.match(string.strip())
+    if not match:
+        return None
+    today = local_today()
+    plusminus, amount_str, unit, snap = match.group(1, 2, 3, 4)
+    date = today
+    if amount_str:
+        amount = int(amount_str)
+        unit_lower = (unit or "d").lower()
+        delta: int = amount if plusminus == "+" else -amount
+        if unit_lower == "d":
+            date += timedelta(days=delta)
+        elif unit_lower == "w":
+            date += timedelta(weeks=delta)
+        elif unit_lower == "m":
+            date = month_offset(date.replace(day=1), delta)
+        elif unit_lower == "y":
+            try:
+                date = date.replace(year=date.year + delta)
+            except ValueError:
+                return None  # pragma: no cover
+    if snap:
+        return _snap_date(date, snap, fye)
+    return date
+
+
 def substitute(
     string: str,
     fye: FiscalYearEnd | None = None,
@@ -398,6 +525,53 @@ def substitute(
     return string
 
 
+# Date-math range: "now-30d - now", "now/M - now/d", etc.
+DATEMATH_RANGE_RE = re.compile(
+    r"(now\S*)\s*(?:-|to)\s*(now\S*)",
+    re.IGNORECASE,
+)
+
+
+def _parse_datemath(
+    string: str,
+    fye: FiscalYearEnd,
+) -> tuple[datetime.date | None, datetime.date | None]:
+    """Try to parse a date-math expression (now-1y, now/M, etc.).
+
+    Returns (begin, end) or (None, None) if not a date-math expression.
+    """
+    s = string.strip().lower()
+    if not s.startswith("now"):
+        return None, None
+
+    # Check for range: now-30d - now, now/M - now/d, etc.
+    range_match = DATEMATH_RANGE_RE.match(s)
+    if range_match:
+        start = _eval_datemath(range_match.group(1), fye)
+        end = _eval_datemath(range_match.group(2), fye)
+        if start is not None and end is not None:
+            return start, end
+        return None, None
+
+    # Single date-math expression
+    start = _eval_datemath(s, fye)
+    if start is None:
+        return None, None
+
+    # Determine end from the snap or unit.
+    # Without an explicit snap, the unit determines both the snap and the
+    # period length, e.g. now-1M means "the calendar month one month ago".
+    match = DATEMATH_RE.match(s)
+    if match:
+        snap = match.group(4)
+        period = snap or _unit_from_match(match) or "d"
+        start = _snap_date(start, period, fye)
+        end = _period_end_from_snap(start, period, fye)
+        return start, end
+
+    return start, Day.get_next(start)
+
+
 def parse_date(  # noqa: PLR0911
     string: str,
     fye: FiscalYearEnd | None = None,
@@ -409,6 +583,7 @@ def parse_date(  # noqa: PLR0911
     - 2010-03-15, 2010-03, 2010
     - 2010-W01, 2010-Q3
     - FY2012, FY2012-Q2
+    - now, now-1y, now/M, now-1y/y, now-1M - now
 
     Ranges of dates can be expressed in the following forms:
 
@@ -427,6 +602,13 @@ def parse_date(  # noqa: PLR0911
     string = string.strip().lower()
     if not string:
         return None, None
+
+    fye = fye or END_OF_YEAR
+
+    # Try date-math first (now-1y, now/M, etc.)
+    datemath_result = _parse_datemath(string, fye)
+    if datemath_result != (None, None):
+        return datemath_result
 
     string = substitute(string, fye).lower()
 
@@ -485,6 +667,22 @@ def parse_date(  # noqa: PLR0911
         return get_fiscal_period(year, fye, quarter)
 
     return None, None
+
+
+def parse_date_resolved(
+    string: str,
+    fye: FiscalYearEnd | None = None,
+) -> tuple[datetime.date | None, datetime.date | None, str]:
+    """Like parse_date but also returns a human-readable description.
+
+    Returns:
+        A tuple (start, end, description) where description is something
+        like "2024-01-01 to 2024-12-31" showing the resolved range.
+    """
+    begin, end = parse_date(string, fye)
+    if begin is None or end is None:
+        return None, None, ""
+    return begin, end, f"{begin.isoformat()} to {(end - ONE_DAY).isoformat()}"
 
 
 def month_offset(date: datetime.date, months: int) -> datetime.date:

--- a/tests/test_util_date.py
+++ b/tests/test_util_date.py
@@ -17,6 +17,7 @@ from fava.util.date import InvalidDateRangeError
 from fava.util.date import Month
 from fava.util.date import month_offset
 from fava.util.date import parse_date
+from fava.util.date import parse_date_resolved
 from fava.util.date import parse_fye_string
 from fava.util.date import Quarter
 from fava.util.date import substitute
@@ -464,3 +465,83 @@ def test_parse_fye_string(fye_str: str, month: int, day: int) -> None:
 )
 def test_parse_fye_invalid_string(fye_str: str) -> None:
     assert parse_fye_string(fye_str) is None
+
+
+@pytest.mark.parametrize(
+    ("expect_start", "expect_end", "text"),
+    [
+        ("2026-07-26", "2026-07-27", "now"),
+        ("2026-07-25", "2026-07-26", "now-1d"),
+        ("2026-07-19", "2026-07-20", "now-7d"),
+        ("2026-07-13", "2026-07-20", "now-1w"),
+        ("2026-06-01", "2026-07-01", "now-1M"),
+        ("2025-01-01", "2026-01-01", "now-1y"),
+        ("2026-08-01", "2026-09-01", "now+1M"),
+        ("2026-07-26", "2026-07-27", "now/d"),
+        ("2026-07-01", "2026-08-01", "now/M"),
+        ("2026-01-01", "2027-01-01", "now/y"),
+        ("2025-01-01", "2026-01-01", "now-1y/y"),
+        ("2026-06-01", "2026-07-01", "now-1M/M"),
+        ("2026-07-25", "2026-07-26", "now-1d/d"),
+        ("2026-07-20", "2026-07-27", "now/w"),
+        ("2026-07-13", "2026-07-20", "now-1w/w"),
+    ],
+)
+def test_parse_date_datemath(
+    expect_start: str,
+    expect_end: str,
+    text: str,
+) -> None:
+    start, end = fromisoformat(expect_start), fromisoformat(expect_end)
+    with mock.patch("fava.util.date.local_today", return_value=fromisoformat("2026-07-26")):
+        assert parse_date(text) == (start, end)
+
+
+@pytest.mark.parametrize(
+    ("expect_start", "expect_end", "text"),
+    [
+        ("2026-07-01", "2027-07-01", "now/fy"),
+        ("2025-07-01", "2026-07-01", "now-1y/fy"),
+        ("2026-07-01", "2026-10-01", "now/fQ"),
+    ],
+)
+def test_parse_date_datemath_fiscal(
+    expect_start: str,
+    expect_end: str,
+    text: str,
+) -> None:
+    start, end = fromisoformat(expect_start), fromisoformat(expect_end)
+    with mock.patch("fava.util.date.local_today", return_value=fromisoformat("2026-07-26")):
+        assert parse_date(text, FiscalYearEnd(6, 30)) == (start, end)
+
+
+@pytest.mark.parametrize(
+    ("expect_start", "expect_end", "text"),
+    [
+        ("2026-06-26", "2026-07-26", "now-30d - now"),
+        ("2025-07-26", "2026-07-26", "now-1y - now"),
+        ("2026-07-01", "2026-07-26", "now/M - now"),
+        ("2025-01-01", "2026-01-01", "now-1y/y - now/y"),
+        ("2026-07-19", "2026-07-25", "now-7d - now-1d"),
+    ],
+)
+def test_parse_date_datemath_range(
+    expect_start: str,
+    expect_end: str,
+    text: str,
+) -> None:
+    start, end = fromisoformat(expect_start), fromisoformat(expect_end)
+    with mock.patch("fava.util.date.local_today", return_value=fromisoformat("2026-07-26")):
+        assert parse_date(text) == (start, end)
+
+
+def test_parse_date_resolved() -> None:
+    with mock.patch("fava.util.date.local_today", return_value=fromisoformat("2026-07-26")):
+        _, _, desc = parse_date_resolved("now-1y")
+        assert desc == "2025-01-01 to 2025-12-31"
+        _, _, desc = parse_date_resolved("now/M")
+        assert desc == "2026-07-01 to 2026-07-31"
+        _, _, desc = parse_date_resolved("2024")
+        assert desc == "2024-01-01 to 2024-12-31"
+        _, _, desc = parse_date_resolved("")
+        assert desc == ""


### PR DESCRIPTION
## Summary

Adds Elasticsearch/Grafana-style date-math expressions (`now-1y`, `now/M`, `now-1y/y`, etc.) to the Fava time filter, with an explicit snap concept for period boundaries.

## New syntax

```
now[+/-Nunit][/snap]
```

- **Units**: `d` (days), `w` (weeks), `M` (months), `y` (years)
- **Snaps**: `/d`, `/w`, `/M`, `/y`, `/fy` (fiscal year), `/fQ` (fiscal quarter)
- **Ranges**: `now-30d - now`, `now/M - now`, `now-1y/y - now/y`

Without an explicit snap, the unit determines the period (e.g. `now-1M` = last calendar month, equivalent to `now-1M/M`).

## Changes

### Backend (`src/fava/util/date.py`)
- `DATEMATH_RE` — regex for `now[+/-N][unit][/snap]`
- `_snap_date()` — snaps to `d/w/M/y/fy/fQ` boundaries
- `_period_end_from_snap()` — computes exclusive end from a snapped start
- `_eval_datemath()` — evaluates a single date-math expression
- `_parse_datemath()` — handles single and range date-math, tried before legacy parser
- `parse_date_resolved()` — returns `(begin, end, "YYYY-MM-DD to YYYY-MM-DD")` for UI/API use
- All legacy syntax (`2024`, `year-1`, `FY2024`, `2024 - 2025`) preserved

### Tests (`tests/test_util_date.py`)
- 24 new parametrized tests: date-math singles, fiscal snaps, ranges, resolved descriptions
- All 169 tests pass

### Docs (`docs/time-filter-syntax.md`)
- Full date-math section with snap explanation and step-by-step walkthroughs

## Backward compatibility

All existing syntax continues to work unchanged. Date-math is tried first, then falls through to the legacy parser.

## Snap concept

A snap rounds a date down to the start of a period. Without a snap, `now-1y` means "exactly 1 year ago" (a single point). With a snap, `now-1y/y` means "the start of the year that was 1 year ago" (the full calendar year). Without an explicit snap, the unit implies the snap — `now-1M` is equivalent to `now-1M/M`.