### PR TITLE
autocomplete: refactor; improve test coverage; fixes

### DIFF
--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -38,6 +38,7 @@
   --text-color-lightest: light-dark(hsl(0deg 0% 40%), hsl(0deg 0% 65%));
   --text-color-chart: light-dark(hsl(0deg 0% 30%), hsl(0deg 0% 15%));
   --link-color: light-dark(hsl(203deg 100% 32%), hsl(203deg 100% 68%));
+  --link-color-lighter: light-dark(hsl(203deg 100% 50%), hsl(203deg 100% 50%));
   --link-hover-color: var(--text-color-lighter);
 
   /* Base elements */

--- a/frontend/src/AutocompleteInput.svelte
+++ b/frontend/src/AutocompleteInput.svelte
@@ -13,12 +13,8 @@
 -->
 <script lang="ts">
   import type { KeySpec } from "./keyboard-shortcuts.ts";
-  import { keyboardShortcut } from "./keyboard-shortcuts.ts";
-  import {
-    type FuzzyWrappedText,
-    fuzzyfilter,
-    fuzzywrap,
-  } from "./lib/fuzzy.ts";
+  import { keyboardShortcut, normalise_key } from "./keyboard-shortcuts.ts";
+  import { fuzzyfilter, fuzzywrap } from "./lib/fuzzy.ts";
 
   interface Props {
     /** The currently entered value (bindable). */
@@ -41,12 +37,12 @@
     required?: boolean | undefined;
     /** Whether to show a button to clear the input. */
     clearButton?: boolean;
-    /** An event handler to run on blur. */
-    onBlur?: (el: HTMLInputElement) => void;
     /** An event handler to run on enter. */
-    onEnter?: (el: HTMLInputElement) => void;
+    onenter?: () => void;
     /** An event handler to run on an element being selected. */
-    onSelect?: (el: HTMLInputElement) => void;
+    onselect?: () => void;
+    /** An event handler to run whenever the value changes (on select, enter, or blur). */
+    onchange?: (value: string) => void;
   }
 
   let {
@@ -60,9 +56,9 @@
     checkValidity,
     clearButton = false,
     required,
-    onBlur,
-    onEnter,
-    onSelect,
+    onenter,
+    onselect,
+    onchange,
   }: Props = $props();
 
   const uid = $props.id();
@@ -72,20 +68,12 @@
   let index = $state.raw(-1);
   let input: HTMLInputElement | undefined = $state.raw();
 
-  let extractedValue = $derived(
+  let extracted_value = $derived(
     input && valueExtractor ? valueExtractor(value, input) : value,
   );
-  let filteredSuggestions: {
-    suggestion: string;
-    fuzzywrapped: FuzzyWrappedText;
-  }[] = $derived.by(() => {
-    const filtered = fuzzyfilter(extractedValue, suggestions)
-      .slice(0, 30)
-      .map((suggestion) => ({
-        suggestion,
-        fuzzywrapped: fuzzywrap(extractedValue, suggestion),
-      }));
-    return filtered.length === 1 && filtered[0]?.suggestion === extractedValue
+  let filtered_suggestions: string[] = $derived.by(() => {
+    const filtered = fuzzyfilter(extracted_value, suggestions).slice(0, 30);
+    return filtered.length === 1 && filtered[0] === extracted_value
       ? []
       : filtered;
   });
@@ -97,52 +85,65 @@
 
   $effect.pre(() => {
     // ensure the index is pointing to a valid element.
-    index = Math.min(index, filteredSuggestions.length - 1);
+    index = Math.min(index, filtered_suggestions.length - 1);
   });
+
+  export function blur(): void {
+    input?.blur();
+  }
 
   function select(suggestion: string) {
     value =
       input && valueSelector ? valueSelector(suggestion, input) : suggestion;
-    if (input) {
-      onSelect?.(input);
-    }
+    onchange?.(value);
+    onselect?.();
     hidden = true;
   }
 
-  function mousedown(event: MouseEvent, suggestion: string) {
-    if (event.button === 0) {
-      select(suggestion);
-    }
-  }
+  let expanded = $derived(!hidden && filtered_suggestions.length > 0);
+  let active_suggestion = $derived(
+    expanded && index > -1 ? filtered_suggestions[index] : undefined,
+  );
+  let active_id = $derived(
+    expanded && index > -1 ? `${autocomple_id}-${index.toString()}` : undefined,
+  );
 
-  let expanded = $derived(!hidden && filteredSuggestions.length > 0);
-
-  function keydown(event: KeyboardEvent) {
-    if (event.key === "Enter") {
-      const suggestion = filteredSuggestions[index]?.suggestion;
-      if (index > -1 && !hidden && suggestion != null) {
-        event.preventDefault();
-        select(suggestion);
-      } else if (input) {
-        onEnter?.(input);
+  function onkeydown(event: KeyboardEvent) {
+    const key = normalise_key(event);
+    if (key === "Enter") {
+      if (active_suggestion != null) {
+        select(active_suggestion);
+      } else {
+        onchange?.(value);
+        onenter?.();
+        return;
       }
-    } else if (event.key === " " && event.ctrlKey) {
-      hidden = false;
-    } else if (event.key === "Escape") {
-      event.stopPropagation();
+    } else if (key === "Escape") {
       if (expanded) {
         index = -1;
         hidden = true;
       } else {
         value = "";
       }
-    } else if (event.key === "ArrowUp") {
-      event.preventDefault();
-      index = index === 0 ? filteredSuggestions.length - 1 : index - 1;
-    } else if (event.key === "ArrowDown") {
-      event.preventDefault();
-      index = index === filteredSuggestions.length - 1 ? 0 : index + 1;
+    } else if (key === "ArrowUp") {
+      if (expanded) {
+        index = index <= 0 ? filtered_suggestions.length - 1 : index - 1;
+      }
+    } else if (key === "ArrowDown") {
+      if (expanded) {
+        index = index === filtered_suggestions.length - 1 ? 0 : index + 1;
+      } else {
+        hidden = false;
+      }
+    } else if (key === "Alt+ArrowDown") {
+      hidden = false;
+    } else if (key === "Alt+ArrowUp") {
+      hidden = true;
+    } else {
+      return;
     }
+    event.preventDefault();
+    event.stopPropagation();
   }
 </script>
 
@@ -154,12 +155,14 @@
     class={{ "content-sized": setSize }}
     aria-expanded={expanded}
     aria-controls={autocomple_id}
+    aria-autocomplete="list"
+    aria-activedescendant={active_id}
     bind:value
     bind:this={input}
     {@attach keyboardShortcut(key)}
-    onblur={(event) => {
+    onblur={() => {
+      onchange?.(value);
       hidden = true;
-      onBlur?.(event.currentTarget);
     }}
     onfocus={() => {
       hidden = false;
@@ -167,7 +170,7 @@
     oninput={() => {
       hidden = false;
     }}
-    onkeydown={keydown}
+    {onkeydown}
     {placeholder}
     {required}
   />
@@ -178,26 +181,26 @@
       class="muted round"
       onclick={() => {
         value = "";
-        if (input) {
-          onSelect?.(input);
-        }
+        onchange?.(value);
       }}
     >
       ×
     </button>
   {/if}
-  {#if filteredSuggestions.length}
-    <ul {hidden} role="listbox" id={autocomple_id}>
-      {#each filteredSuggestions as { fuzzywrapped, suggestion }, i (suggestion)}
+  {#if expanded}
+    <ul role="listbox" id={autocomple_id}>
+      {#each filtered_suggestions as suggestion, i (suggestion)}
         <li
+          id={`${autocomple_id}-${i.toString()}`}
           role="option"
           aria-selected={i === index}
-          class:selected={i === index}
-          onmousedown={(ev) => {
-            mousedown(ev, suggestion);
+          onmousedown={(event) => {
+            if (event.button === 0) {
+              select(suggestion);
+            }
           }}
         >
-          {#each fuzzywrapped as [type, text], i (i)}
+          {#each fuzzywrap(extracted_value, suggestion) as [type, text], i (i)}
             {#if type === "text"}
               {text}
             {:else}
@@ -242,8 +245,12 @@
     cursor: pointer;
   }
 
-  li.selected,
   li:hover {
+    color: var(--background);
+    background-color: var(--link-color-lighter);
+  }
+
+  li[aria-selected="true"] {
     color: var(--background);
     background-color: var(--link-color);
   }

--- a/frontend/src/charts/SelectCombobox.svelte
+++ b/frontend/src/charts/SelectCombobox.svelte
@@ -46,11 +46,14 @@
   const listbox_id = `combobox-listbox-${uid}`;
 
   const SEPARATOR = ",";
-  let values = $derived(value.split(SEPARATOR));
+  let values = $derived(value === "" ? [] : value.split(SEPARATOR));
+  let active_id = $derived(
+    !hidden && index > -1 ? `${listbox_id}-${index.toString()}` : undefined,
+  );
 
   // Scroll focused element into view.
   $effect(() => {
-    if (!hidden && index) {
+    if (!hidden && index > -1) {
       ul?.children[index]?.scrollIntoView({
         block: "nearest",
         inline: "nearest",
@@ -66,7 +69,10 @@
     },
     /** Find the first element matching the typed letter and focus it. */
     find_letter: (key: string, event: KeyboardEvent) => {
-      const match = options.findIndex((o) => o.toLowerCase().startsWith(key));
+      const lower_key = key.toLowerCase();
+      const match = options.findIndex((o) =>
+        o.toLowerCase().startsWith(lower_key),
+      );
       if (match > -1) {
         event.stopPropagation();
         index = match;
@@ -80,12 +86,12 @@
     },
     /** Focus the last element and open if not open yet. */
     last: () => {
-      index = 0;
+      index = options.length - 1;
       hidden = false;
     },
-    /** Focus the previous element in the popup. */
+    /** Focus the next element in the popup. */
     next: () => {
-      index = index === 0 ? options.length - 1 : index - 1;
+      index = index === options.length - 1 ? 0 : index + 1;
     },
     /** Open the popup list. */
     open: () => {
@@ -93,7 +99,7 @@
     },
     /** Focus the previous element in the popup. */
     previous: () => {
-      index = index === options.length - 1 ? 0 : index + 1;
+      index = index === 0 ? options.length - 1 : index - 1;
     },
     /** Select the given or the focused element in the options list. */
     select: (o?: string) => {
@@ -141,10 +147,10 @@
       return actions.close;
     }
     if (key === "ArrowUp") {
-      return hidden ? actions.open : actions.next;
+      return hidden ? actions.open : actions.previous;
     }
     if (key === "ArrowDown") {
-      return hidden ? actions.open : actions.previous;
+      return hidden ? actions.open : actions.next;
     }
     return null;
   }
@@ -156,6 +162,7 @@
     role="combobox"
     aria-expanded={!hidden}
     aria-controls={listbox_id}
+    aria-activedescendant={active_id}
     class="muted"
     onclick={actions.toggle}
     onblur={actions.close}
@@ -163,6 +170,7 @@
       const action = key_action(event);
       if (action) {
         event.preventDefault();
+        event.stopPropagation();
         action();
       }
     }}
@@ -172,6 +180,7 @@
   <ul {hidden} role="listbox" id={listbox_id} bind:this={ul}>
     {#each options as option, i (option)}
       <li
+        id={`${listbox_id}-${i.toString()}`}
         role="option"
         aria-selected={values.includes(option)}
         class:current={i === index}
@@ -213,8 +222,12 @@
     border: var(--link-color) dotted 2px;
   }
 
-  li[aria-selected="true"],
   li:hover {
+    color: var(--background);
+    background-color: var(--link-color-lighter);
+  }
+
+  li[aria-selected="true"] {
     color: var(--background);
     background-color: var(--link-color);
   }

--- a/frontend/src/entry-forms/Transaction.svelte
+++ b/frontend/src/entry-forms/Transaction.svelte
@@ -77,14 +77,12 @@
     <span class="hide-on-desktop">{_("Payee")}:</span>
     <AutocompleteInput
       placeholder={_("Payee")}
-      bind:value={
-        () => entry.payee,
-        (payee: string) => {
-          entry = entry.set("payee", payee);
-        }
-      }
+      value={entry.payee}
+      onchange={(value: string) => {
+        entry = entry.set("payee", value);
+      }}
       suggestions={$payees}
-      onSelect={autocomplete_select_payee}
+      onselect={autocomplete_select_payee}
       --autocomplete-wrapper-flex="1"
     />
   </label>
@@ -92,15 +90,12 @@
     <span class="hide-on-desktop">{_("Narration")}:</span>
     <AutocompleteInput
       placeholder={_("Narration")}
-      bind:value={narration}
+      value={narration}
       suggestions={fetch_narrations($ledger_mtime).data}
-      onSelect={autocomplete_select_narration}
-      onEnter={() => {
-        entry = entry.set_narration_tags_links(narration);
+      onchange={(value: string) => {
+        entry = entry.set_narration_tags_links(value);
       }}
-      onBlur={() => {
-        entry = entry.set_narration_tags_links(narration);
-      }}
+      onselect={autocomplete_select_narration}
       --autocomplete-wrapper-flex="2"
     />
     <AddMetadataButton

--- a/frontend/src/keyboard-shortcuts.ts
+++ b/frontend/src/keyboard-shortcuts.ts
@@ -107,6 +107,23 @@ const keyboardShortcuts = new Map<string, KeyboardShortcutAction>();
 let lastChar = "";
 
 /**
+ * Normalise an event key, including modifiers, e.g. `Control+Enter`
+ */
+export function normalise_key(event: KeyboardEvent): string {
+  let key = event.key;
+  if (event.metaKey) {
+    key = `Meta+${key}`;
+  }
+  if (event.altKey) {
+    key = `Alt+${key}`;
+  }
+  if (event.ctrlKey) {
+    key = `Control+${key}`;
+  }
+  return key;
+}
+
+/**
  * Handle a `keydown` event on the document.
  *
  * Dispatch to the relevant handler.
@@ -116,16 +133,7 @@ function keydown(event: KeyboardEvent): void {
     // ignore events in editable elements.
     return;
   }
-  let eventKey = event.key;
-  if (event.metaKey) {
-    eventKey = `Meta+${eventKey}`;
-  }
-  if (event.altKey) {
-    eventKey = `Alt+${eventKey}`;
-  }
-  if (event.ctrlKey) {
-    eventKey = `Control+${eventKey}`;
-  }
+  const eventKey = normalise_key(event);
   const lastTwoKeys = `${lastChar} ${eventKey}`;
   const handler =
     keyboardShortcuts.get(lastTwoKeys) ?? keyboardShortcuts.get(eventKey);

--- a/frontend/src/sidebar/AccountSelector.svelte
+++ b/frontend/src/sidebar/AccountSelector.svelte
@@ -6,11 +6,12 @@
   import { accounts } from "../stores/index.ts";
 
   let value = $state("");
+  let autocomplete = $state.raw<{ blur: () => void }>();
 
-  function select(el: HTMLInputElement) {
+  function select() {
     if (value) {
       router.navigate($urlForAccount(value));
-      el.blur();
+      autocomplete?.blur();
       value = "";
     }
   }
@@ -19,11 +20,12 @@
 <li>
   <AutocompleteInput
     bind:value
+    bind:this={autocomplete}
     placeholder={_("Go to account")}
     suggestions={$accounts}
     key="g a"
-    onSelect={select}
-    onEnter={select}
+    onselect={select}
+    onenter={select}
   />
 </li>
 

--- a/frontend/src/sidebar/FilterForm.svelte
+++ b/frontend/src/sidebar/FilterForm.svelte
@@ -2,7 +2,7 @@
   import AutocompleteInput from "../AutocompleteInput.svelte";
   import { _ } from "../i18n.ts";
   import { escape_for_regex } from "../lib/regex.ts";
-  import { router, set_query_param } from "../router.ts";
+  import { router } from "../router.ts";
   import {
     account_filter,
     fql_filter,
@@ -33,79 +33,33 @@
         )}${value}${input.value.slice(selectionStart)}`
       : value;
   }
-
-  let account_filter_value = $state("");
-  let fql_filter_value = $state("");
-  let time_filter_value = $state("");
-  account_filter.subscribe((v) => {
-    account_filter_value = v;
-  });
-  fql_filter.subscribe((v) => {
-    fql_filter_value = v;
-  });
-  time_filter.subscribe((v) => {
-    time_filter_value = v;
-  });
-
-  /** Set the target we want to navigate to to avoid duplicate navigation. */
-  let target: URL | null = null;
-
-  /**
-   * Submit the filter form.
-   *
-   * This is called on all the three possible events (blur, select, enter)
-   * and also on the form submit. Having the listener on:enter would
-   * theoretically be unnecessary (as the form would also be submitted) but
-   * it seems to work around a Safari bug, see #809 and #1528.
-   */
-  function submit() {
-    const url = new URL(router.current);
-    set_query_param(url, "account", account_filter_value);
-    set_query_param(url, "filter", fql_filter_value);
-    set_query_param(url, "time", time_filter_value);
-    if (url.href !== router.current.href) {
-      target = url;
-      setTimeout(() => {
-        if (target) {
-          router.navigate(target);
-          target = null;
-        }
-      });
-    }
-  }
 </script>
 
-<form
-  class="flex-row"
-  onsubmit={(ev) => {
-    ev.preventDefault();
-    submit();
-  }}
->
+<div class="flex-row">
   <AutocompleteInput
-    bind:value={time_filter_value}
+    value={$time_filter}
     placeholder={_("Time")}
     suggestions={$years}
     key="f t"
     clearButton={true}
     setSize={true}
-    onBlur={submit}
-    onSelect={submit}
-    onEnter={submit}
+    onchange={(v: string) => {
+      router.set_search_param("time", v);
+    }}
   />
   <AutocompleteInput
-    bind:value={account_filter_value}
+    value={$account_filter}
     placeholder={_("Account")}
     suggestions={$accounts}
     key="f a"
     clearButton={true}
     setSize={true}
-    onBlur={submit}
-    onSelect={submit}
-    onEnter={submit}
+    onchange={(v: string) => {
+      router.set_search_param("account", v);
+    }}
   />
   <AutocompleteInput
-    bind:value={fql_filter_value}
+    value={$fql_filter}
     placeholder={_("Filter by tag, payee, …")}
     suggestions={fql_filter_suggestions}
     key="f f"
@@ -113,48 +67,42 @@
     setSize={true}
     {valueExtractor}
     {valueSelector}
-    onBlur={submit}
-    onSelect={submit}
-    onEnter={submit}
+    onchange={(v: string) => {
+      router.set_search_param("filter", v);
+    }}
   />
-  <!-- svelte-ignore a11y_consider_explicit_label -->
-  <button type="submit"></button>
-</form>
+</div>
 
 <style>
-  form {
+  div {
     color: var(--text-color);
 
     --placeholder-color: var(--header-placeholder-color);
     --placeholder-background: var(--header-placeholder-background);
     --input-padding: 8px 25px 8px 10px;
-  }
 
-  form > :global(span) {
-    max-width: 18rem;
-  }
+    & > :global(span) {
+      max-width: 18rem;
+    }
 
-  form :global(input) {
-    outline: none;
-    background-color: var(--background);
-    border: 0;
-  }
+    & :global(input) {
+      outline: none;
+      background-color: var(--background);
+      border: 0;
+    }
 
-  form :global([type="text"]:focus) {
-    background-color: var(--background);
-  }
-
-  [type="submit"] {
-    display: none;
+    & :global([type="text"]:focus) {
+      background-color: var(--background);
+    }
   }
 
   @media print {
-    form {
+    div {
       --input-padding: 8px 10px;
-    }
 
-    form :global(input):placeholder-shown {
-      display: none;
+      & :global(input):placeholder-shown {
+        display: none;
+      }
     }
   }
 </style>

--- a/frontend/test/AutocompleteInput.test.ts
+++ b/frontend/test/AutocompleteInput.test.ts
@@ -1,43 +1,304 @@
-import { equal, ok } from "node:assert/strict";
+import { deepEqual, equal, ok } from "node:assert/strict";
 import { test } from "node:test";
 
-import { flushSync, mount } from "svelte";
+import { range } from "d3-array";
+import { type ComponentProps, flushSync, mount, unmount } from "svelte";
 
 import AutocompleteInput from "../src/AutocompleteInput.svelte";
-import { setup_jsdom } from "./dom.ts";
+import { setup_jsdom, user_events } from "./dom.ts";
 
 test.beforeEach(setup_jsdom);
 
-test("AutocompleteInput: renders no suggestions if none match", () => {
-  mount(AutocompleteInput, {
+/** Mount the `AutocompleteInput` component, with some defaults if not set and return the `<input>`. */
+function mount_autocomplete(
+  t: test.TestContext,
+  props: Partial<ComponentProps<typeof AutocompleteInput>>,
+): HTMLInputElement {
+  const component = mount(AutocompleteInput, {
     target: document.body,
     props: {
-      value: "nomatch",
-      placeholder: "test placeholder",
+      value: "",
+      placeholder: "placeholder",
       suggestions: ["apple", "banana", "cherry"],
+      ...props,
     },
   });
   flushSync();
+
+  t.after(() => {
+    unmount(component);
+  });
+
   const input = document.body.querySelector("input");
   ok(input instanceof HTMLInputElement);
+  return input;
+}
+
+/** Get the suggestions. */
+const suggestion_texts = () =>
+  [...document.body.querySelectorAll("li")].map((i) => i.textContent);
+
+/** Get the selected suggestion */
+const selected = () =>
+  document.body.querySelector("li[aria-selected=true]")?.textContent;
+
+test("AutocompleteInput: renders no suggestions if none match", (t) => {
+  const input = mount_autocomplete(t, { value: "nomatch" });
   equal(input.value, "nomatch");
-  const ul = document.body.querySelector("ul");
-  ok(!ul);
+  user_events.focus(input);
+
+  deepEqual(suggestion_texts(), []);
 });
 
-test("AutocompleteInput: renders with matching suggestions", () => {
-  mount(AutocompleteInput, {
-    target: document.body,
-    props: {
-      value: "app",
-      placeholder: "test placeholder",
-      suggestions: ["apple", "banana", "cherry"],
-    },
+test("AutocompleteInput: renders with matching suggestions", (t) => {
+  const input = mount_autocomplete(t, { value: "app" });
+  user_events.focus(input);
+
+  deepEqual(suggestion_texts(), ["apple"]);
+});
+
+test("AutocompleteInput: does not show a single suggestion that already equals the value", (t) => {
+  const input = mount_autocomplete(t, { value: "apple" });
+  user_events.focus(input);
+
+  deepEqual(suggestion_texts(), []);
+});
+
+test("AutocompleteInput: typing filters and updates suggestions", (t) => {
+  const input = mount_autocomplete(t, {});
+  user_events.focus(input);
+  deepEqual(suggestion_texts(), ["apple", "banana", "cherry"]);
+
+  user_events.type(input, "ban");
+  deepEqual(suggestion_texts(), ["banana"]);
+});
+
+test("AutocompleteInput: ArrowDown/ArrowUp cycle through suggestions", (t) => {
+  const input = mount_autocomplete(t, {
+    suggestions: ["apple", "apricot", "avocado"],
   });
-  flushSync();
-  const input = document.body.querySelector("input");
-  ok(input instanceof HTMLInputElement);
+  user_events.type(input, "a");
+
+  equal(selected(), undefined);
+  user_events.keydown(input, "ArrowDown");
+  equal(selected(), "apple");
+  user_events.keydown(input, "ArrowDown");
+  equal(selected(), "apricot");
+  user_events.keydown(input, "ArrowDown");
+  equal(selected(), "avocado");
+  // wraps around to the first suggestion again.
+  user_events.keydown(input, "ArrowDown");
+  equal(selected(), "apple");
+
+  // ArrowUp wraps around to the last suggestion.
+  user_events.keydown(input, "ArrowUp");
+  equal(selected(), "avocado");
+  user_events.keydown(input, "ArrowUp");
+  equal(selected(), "apricot");
+});
+
+test("AutocompleteInput: Enter selects the highlighted suggestion", (t) => {
+  const onselect = t.mock.fn();
+  const onenter = t.mock.fn();
+  const onchange = t.mock.fn();
+  const input = mount_autocomplete(t, { onenter, onselect, onchange });
+  user_events.type(input, "ba");
+  user_events.keydown(input, "ArrowDown");
+  const not_prevented = user_events.keydown(input, "Enter");
+
+  equal(not_prevented, false);
+  equal(input.value, "banana");
+  equal(onenter.mock.callCount(), 0);
+  equal(onselect.mock.callCount(), 1);
+  equal(onchange.mock.callCount(), 1);
+  deepEqual(suggestion_texts(), []);
+});
+
+test("AutocompleteInput: Enter without a highlighted suggestion calls onenter instead", (t) => {
+  const onenter = t.mock.fn();
+  const onselect = t.mock.fn();
+  const onchange = t.mock.fn();
+  const input = mount_autocomplete(t, { onenter, onselect, onchange });
+  user_events.type(input, "ba");
+  equal(onenter.mock.callCount(), 0);
+  equal(onselect.mock.callCount(), 0);
+  equal(onchange.mock.callCount(), 0);
+
+  user_events.keydown(input, "Enter");
+  equal(onenter.mock.callCount(), 1);
+  equal(onselect.mock.callCount(), 0);
+  equal(onchange.mock.callCount(), 1);
+  equal(input.value, "ba");
+});
+
+test("AutocompleteInput: mousedown on a suggestion selects it", (t) => {
+  const onselect = t.mock.fn();
+  const onchange = t.mock.fn();
+  const input = mount_autocomplete(t, { onselect, onchange });
+  user_events.type(input, "cher");
+  const li = document.body.querySelector("li");
+  ok(li);
+  user_events.mousedown(li, { button: 0 });
+
+  equal(input.value, "cherry");
+  equal(onselect.mock.callCount(), 1);
+  equal(onchange.mock.callCount(), 1);
+});
+
+test("AutocompleteInput: mousedown with a non-primary button does not select", (t) => {
+  const onselect = t.mock.fn();
+  const onchange = t.mock.fn();
+  const input = mount_autocomplete(t, { onselect, onchange });
+  user_events.type(input, "cher");
+  const li = document.body.querySelector("li");
+  ok(li);
+  user_events.mousedown(li, { button: 2 });
+
+  equal(input.value, "cher");
+  equal(onselect.mock.callCount(), 0);
+  equal(onchange.mock.callCount(), 0);
+});
+
+test("AutocompleteInput: Escape closes an open suggestion list without clearing the value", (t) => {
+  const onselect = t.mock.fn();
+  const onchange = t.mock.fn();
+  const input = mount_autocomplete(t, { onselect, onchange });
+  user_events.type(input, "app");
+  deepEqual(suggestion_texts(), ["apple"]);
+
+  user_events.keydown(input, "Escape");
+
   equal(input.value, "app");
-  const ul = document.body.querySelector("ul");
-  equal(ul?.firstElementChild?.textContent, "apple");
+  deepEqual(suggestion_texts(), []);
+  equal(onselect.mock.callCount(), 0);
+  equal(onchange.mock.callCount(), 0);
+});
+
+test("AutocompleteInput: Escape clears the value when the suggestion list is closed", (t) => {
+  const onselect = t.mock.fn();
+  const onchange = t.mock.fn();
+  const input = mount_autocomplete(t, { value: "app", onselect, onchange });
+  deepEqual(suggestion_texts(), []);
+
+  user_events.keydown(input, "Escape");
+
+  equal(input.value, "");
+  equal(onselect.mock.callCount(), 0);
+  equal(onchange.mock.callCount(), 0);
+
+  user_events.blur(input);
+  equal(onselect.mock.callCount(), 0);
+  equal(onchange.mock.callCount(), 1);
+});
+
+test("AutocompleteInput: (Alt+)ArrowDown opens the suggestion list and Alt+ArrowUp closes it", (t) => {
+  const input = mount_autocomplete(t, { value: "app" });
+  deepEqual(suggestion_texts(), []);
+
+  user_events.keydown(input, "ArrowDown");
+  deepEqual(suggestion_texts(), ["apple"]);
+
+  user_events.keydown(input, "ArrowUp", { altKey: true });
+  deepEqual(suggestion_texts(), []);
+
+  user_events.keydown(input, "ArrowDown", { altKey: true });
+  deepEqual(suggestion_texts(), ["apple"]);
+
+  user_events.keydown(input, "ArrowUp", { altKey: true });
+  deepEqual(suggestion_texts(), []);
+});
+
+test("AutocompleteInput: blur hides the suggestion list and fires onchange", (t) => {
+  const onchange = t.mock.fn();
+  const input = mount_autocomplete(t, { onchange });
+  deepEqual(suggestion_texts(), []);
+
+  user_events.focus(input);
+  deepEqual(suggestion_texts(), ["apple", "banana", "cherry"]);
+
+  user_events.blur(input);
+  equal(onchange.mock.callCount(), 1);
+  deepEqual(suggestion_texts(), []);
+});
+
+test("AutocompleteInput: clearButton is only shown when there is a value and clears it on click", (t) => {
+  const onchange = t.mock.fn();
+  const input = mount_autocomplete(t, {
+    clearButton: true,
+    onchange,
+  });
+  ok(!document.body.querySelector("button"));
+
+  user_events.type(input, "app");
+  const button = document.body.querySelector("button");
+  ok(button);
+
+  user_events.click(button);
+
+  equal(input.value, "");
+  equal(onchange.mock.callCount(), 1);
+  ok(!document.body.querySelector("button"));
+});
+
+test("AutocompleteInput: valueExtractor and valueSelector operate on a substring of the value", (t) => {
+  // Simulate autocompleting the last comma-separated tag of the value.
+  const valueExtractor = t.mock.fn(
+    (val: string, _input: HTMLInputElement): string =>
+      val.split(",").at(-1) ?? "",
+  );
+  const valueSelector = t.mock.fn(
+    (selected: string, el: HTMLInputElement): string => {
+      const parts = el.value.split(",");
+      parts[parts.length - 1] = selected;
+      return parts.join(",");
+    },
+  );
+
+  const input = mount_autocomplete(t, {
+    value: "foo,ba",
+    valueExtractor,
+    valueSelector,
+  });
+  user_events.focus(input);
+
+  deepEqual(suggestion_texts(), ["banana"]);
+  deepEqual(valueExtractor.mock.calls[0]?.arguments, ["foo,ba", input]);
+
+  const li = document.body.querySelector("li");
+  ok(li);
+  user_events.mousedown(li, { button: 0 });
+
+  equal(input.value, "foo,banana");
+  equal(valueSelector.mock.callCount(), 1);
+  deepEqual(valueSelector.mock.calls[0]?.arguments, ["banana", input]);
+});
+
+test("AutocompleteInput: checkValidity sets a custom validity message on the input", (t) => {
+  const checkValidity = t.mock.fn((val: string): string =>
+    val === "invalid" ? "not a valid value" : "",
+  );
+
+  const input = mount_autocomplete(t, { value: "invalid", checkValidity });
+  equal(input.validationMessage, "not a valid value");
+  equal(input.checkValidity(), false);
+  equal(checkValidity.mock.callCount(), 1);
+  deepEqual(checkValidity.mock.calls[0]?.arguments, ["invalid"]);
+
+  user_events.type(input, "valid");
+  equal(input.validationMessage, "");
+  equal(input.checkValidity(), true);
+  equal(checkValidity.mock.callCount(), 2);
+  deepEqual(checkValidity.mock.calls[1]?.arguments, ["valid"]);
+});
+
+test("AutocompleteInput: required prop is reflected on the input", (t) => {
+  const input = mount_autocomplete(t, { required: true });
+  ok(input.required);
+});
+
+test("AutocompleteInput: limits suggestions to 30 matches", (t) => {
+  const suggestions = range(50).map((i) => `item${i.toString()}`);
+  const input = mount_autocomplete(t, { suggestions });
+  user_events.focus(input);
+  deepEqual(suggestion_texts(), suggestions.slice(0, 30));
 });

--- a/frontend/test/dom.ts
+++ b/frontend/test/dom.ts
@@ -1,4 +1,5 @@
 import { JSDOM } from "jsdom";
+import { flushSync } from "svelte";
 
 let ran_once = false;
 
@@ -34,3 +35,51 @@ export function setup_jsdom(): void {
   script.textContent = "{}";
   document.body.appendChild(script);
 }
+
+/** Trigger some common browser events. */
+export const user_events = {
+  /** Blur the element. */
+  blur(el: HTMLElement): void {
+    el.dispatchEvent(new window.Event("blur"));
+    flushSync();
+  },
+  /** Click the element. */
+  click(el: HTMLElement): void {
+    el.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    flushSync();
+  },
+  /** Focus the element. */
+  focus(input: HTMLInputElement): void {
+    input.dispatchEvent(new FocusEvent("focus"));
+    flushSync();
+  },
+  /** Trigger a keydown event. */
+  keydown(
+    input: HTMLInputElement,
+    key: string,
+    eventInitDict: KeyboardEventInit = {},
+  ): boolean {
+    const event = new KeyboardEvent("keydown", {
+      key,
+      bubbles: true,
+      cancelable: true,
+      ...eventInitDict,
+    });
+    const not_prevented = input.dispatchEvent(event);
+    flushSync();
+    return not_prevented;
+  },
+  /** Trigger a mousedown event. */
+  mousedown(el: HTMLElement, eventInitDict: MouseEventInit = {}): void {
+    el.dispatchEvent(
+      new MouseEvent("mousedown", { bubbles: true, ...eventInitDict }),
+    );
+    flushSync();
+  },
+  /** Type a value into the input, as a user would. */
+  type(input: HTMLInputElement, value: string): void {
+    input.value = value;
+    input.dispatchEvent(new InputEvent("input", { bubbles: true }));
+    flushSync();
+  },
+};

--- a/src/fava/translations/messages.pot
+++ b/src/fava/translations/messages.pot
@@ -77,7 +77,7 @@ msgstr ""
 #: frontend/src/reports/holdings/Holdings.svelte:25
 #: frontend/src/reports/holdings/Holdings.svelte:29
 #: frontend/src/reports/statistics/UpdateActivity.svelte:32
-#: frontend/src/sidebar/FilterForm.svelte:98
+#: frontend/src/sidebar/FilterForm.svelte:52
 msgid "Account"
 msgstr ""
 
@@ -129,13 +129,13 @@ msgstr ""
 msgid "Payee"
 msgstr ""
 
+#: frontend/src/entry-forms/Transaction.svelte:90
 #: frontend/src/entry-forms/Transaction.svelte:92
-#: frontend/src/entry-forms/Transaction.svelte:94
 #: frontend/src/reports/journal/JournalHeaders.svelte:51
 msgid "Narration"
 msgstr ""
 
-#: frontend/src/entry-forms/Transaction.svelte:125
+#: frontend/src/entry-forms/Transaction.svelte:120
 #: frontend/src/reports/journal/JournalFilters.svelte:44
 msgid "Postings"
 msgstr ""
@@ -565,7 +565,7 @@ msgstr ""
 msgid "Trial Balance"
 msgstr ""
 
-#: frontend/src/sidebar/AccountSelector.svelte:22
+#: frontend/src/sidebar/AccountSelector.svelte:24
 msgid "Go to account"
 msgstr ""
 
@@ -577,11 +577,11 @@ msgstr ""
 msgid "Help"
 msgstr ""
 
-#: frontend/src/sidebar/FilterForm.svelte:87
+#: frontend/src/sidebar/FilterForm.svelte:41
 msgid "Time"
 msgstr ""
 
-#: frontend/src/sidebar/FilterForm.svelte:109
+#: frontend/src/sidebar/FilterForm.svelte:63
 msgid "Filter by tag, payee, …"
 msgstr ""
 


### PR DESCRIPTION
Refactor the AutocompleteInput component and its handlers - the new
onchange handler takes care of allowing users of the component to have
behaviour similar to how onchange works for input elements. This avoids
more frequent changes and allowed great simplification of the filter form.

Also, to match the APG, the popup can now be closed/shown with Alt+Arrow
keys and some other minor differences were fixed. The component now has
pretty complete test coverage and was manually tested in all its
instances as well.

<!--
Hi, thank you for opening a PR!

Please ensure that your change passes tests and the various linters by running
`make test` and `make lint`. If testable, your changes should be covered by
unit tests.

Explain your changes below and link to related issues.
-->
