### PR TITLE
documents: fix path containment check

### DIFF
--- a/src/fava/core/documents.py
+++ b/src/fava/core/documents.py
@@ -43,7 +43,7 @@ def is_document_or_import_file(filename: str, ledger: FavaLedger) -> bool:
         return True
     file_path = Path(filename).resolve()
     return any(
-        str(file_path).startswith(str(ledger.join_path(d)))
+        file_path.is_relative_to(ledger.join_path(d))
         for d in ledger.fava_options.import_dirs
     )
 

--- a/tests/test_core_documents.py
+++ b/tests/test_core_documents.py
@@ -34,6 +34,8 @@ def test_is_document_or_import_file(
     assert is_document_or_import_file(path, example_ledger)
     assert is_document_or_import_file("/test/err/../err", example_ledger)
     assert is_document_or_import_file("/test/err/../err", example_ledger)
+    assert not is_document_or_import_file("/test_private/err", example_ledger)
+    assert not is_document_or_import_file("/test.bak/err", example_ledger)
 
 
 def test_filepath_in_documents_folder(


### PR DESCRIPTION
Previously, just a string comparison was done, so sibling directories of
import directories would have been considered included as well.

Thanks to @mohammedix88 for reporting this.

<!--
Hi, thank you for opening a PR!

Please ensure that your change passes tests and the various linters by running
`make test` and `make lint`. If testable, your changes should be covered by
unit tests.

Explain your changes below and link to related issues.

If you used AI tools, please describe how they were used.
-->
