### PR TITLE
budgets: add a fortnightly period

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -9,7 +9,8 @@ a regex-based implementation to a proper lexer/parser, fixing several edge-case
 bugs. As part of this, the undocumented `to` range separator (e.g. `2010 to
 2012-10`) is no longer supported - use `-` instead (e.g. `2010 - 2012-10`).
 `Decimal` and `Amount` can now be added as metadata values to entries and
-are also roundtripped correctly when set by importers.
+are also roundtripped correctly when set by importers. Budget directives
+accept a `fortnightly` period, spread over fixed 14-day blocks.
 
 v1.30.13 (2026-05-19)
 ---------------------

--- a/src/fava/core/budgets.py
+++ b/src/fava/core/budgets.py
@@ -13,8 +13,8 @@ from beancount.core.amount import Amount
 
 from fava.core.module_base import FavaModule
 from fava.helpers import BeancountError
+from fava.util.date import BUDGET_INTERVALS
 from fava.util.date import days_in_daterange
-from fava.util.date import INTERVALS
 
 if TYPE_CHECKING:  # pragma: no cover
     import datetime
@@ -85,7 +85,7 @@ def _parse_budget(entry: Custom) -> Budget:
     values = msgspec.convert(
         tuple(v.value for v in entry.values), tuple[str, str, Amount]
     )
-    interval = INTERVALS.get(str(values[1]).lower())
+    interval = BUDGET_INTERVALS.get(str(values[1]).lower())
     if not interval:
         msg = "Invalid interval for budget entry"
         raise TypeError(msg)

--- a/src/fava/help/budgets.md
+++ b/src/fava/help/budgets.md
@@ -4,6 +4,7 @@ Beancount file:
 ```beancount
 2012-01-01 custom "budget" Expenses:Coffee       "daily"         4.00 EUR
 2013-01-01 custom "budget" Expenses:Books        "weekly"       20.00 EUR
+2013-07-01 custom "budget" Expenses:Gym          "fortnightly"  29.00 EUR
 2014-02-10 custom "budget" Expenses:Groceries    "monthly"      40.00 EUR
 2015-05-01 custom "budget" Expenses:Electricity  "quarterly"    85.00 EUR
 2016-06-01 custom "budget" Expenses:Holiday      "yearly"     2500.00 EUR
@@ -12,10 +13,12 @@ Beancount file:
 If budgets are specified, Fava's reports and charts will display remaining
 budgets and related information.
 
-The budget directives can be specified `daily`, `weekly`, `monthly`, `quarterly`
-and `yearly`. The specified budget is valid until another budget directive for
-the account is specified. The budget is broken down to a daily budget, and
-summed up for a range of dates as needed.
+The budget directives can be specified `daily`, `weekly`, `fortnightly`,
+`monthly`, `quarterly` and `yearly`. The specified budget is valid until another
+budget directive for the account is specified. The budget is broken down to a
+daily budget, and summed up for a range of dates as needed. A `fortnightly`
+budget is spread over fixed 14-day blocks that start on a Monday, so it is
+always one fourteenth of the amount per day.
 
 This makes the budgets very flexible, allowing for a monthly budget, being taken
 over by a weekly budget, and so on.

--- a/src/fava/util/date.py
+++ b/src/fava/util/date.py
@@ -183,6 +183,37 @@ class _IntervalWeek(Interval):
         return 7
 
 
+class _IntervalFortnight(Interval):
+    """A fortnight interval: fixed 14-day blocks starting on a Monday.
+
+    The blocks are counted from a fixed Monday, so they never overlap and
+    never shrink to one week in a 53-week year, which pairs of ISO weeks
+    would. Only budgets use this interval; it is not a report interval.
+    """
+
+    _epoch = datetime.date(1970, 1, 5)  # a Monday
+
+    @property
+    def label(self) -> str:
+        return gettext("Fortnightly")
+
+    def format_date(self, date: datetime.date) -> str:
+        return self.get_prev(date).strftime("%Y-%m-%d")
+
+    def get_prev(self, date: datetime.date) -> datetime.date:
+        return date - timedelta((date - self._epoch).days % 14)
+
+    def get_next(self, date: datetime.date) -> datetime.date:
+        try:
+            return self.get_prev(date) + timedelta(14)
+        except OverflowError:
+            return datetime.date.max
+
+    @override
+    def number_of_days(self, date: datetime.date) -> int:
+        return 14
+
+
 class _IntervalDay(Interval):
     """A day interval."""
 
@@ -211,8 +242,10 @@ Year = _IntervalYear()
 Quarter = _IntervalQuarter()
 Month = _IntervalMonth()
 Week = _IntervalWeek()
+Fortnight = _IntervalFortnight()
 Day = _IntervalDay()
 
+#: The intervals that reports and charts can be grouped by.
 INTERVALS = {
     "year": Year,
     "yearly": Year,
@@ -224,6 +257,13 @@ INTERVALS = {
     "weekly": Week,
     "day": Day,
     "daily": Day,
+}
+
+#: The intervals that a budget directive can use.
+BUDGET_INTERVALS = {
+    **INTERVALS,
+    "fortnight": Fortnight,
+    "fortnightly": Fortnight,
 }
 
 

--- a/tests/test_core_budgets.py
+++ b/tests/test_core_budgets.py
@@ -79,6 +79,19 @@ def test_budgets_weekly(budgets_doc: BudgetDict) -> None:
         assert budget["EUR"] == num
 
 
+def test_budgets_fortnightly(budgets_doc: BudgetDict) -> None:
+    """
+    2016-05-01 custom "budget" Expenses:Books "fortnightly" 42 EUR"""
+
+    for start, end, num in [
+        (date(2016, 5, 1), date(2016, 5, 2), Decimal(42) / 14),
+        (date(2016, 9, 1), date(2016, 9, 2), Decimal(42) / 14),
+        (date(2020, 12, 21), date(2021, 1, 18), Decimal(42) * 2),
+    ]:
+        budget = calculate_budget(budgets_doc, "Expenses:Books", start, end)
+        assert budget["EUR"] == num
+
+
 def test_budgets_monthly(budgets_doc: BudgetDict) -> None:
     """
     2014-05-01 custom "budget" Expenses:Books "monthly" 100 EUR"""

--- a/tests/test_util_date.py
+++ b/tests/test_util_date.py
@@ -1,14 +1,17 @@
 from __future__ import annotations
 
 from datetime import date
+from datetime import timedelta
 from typing import TYPE_CHECKING
 
 import pytest
 
+from fava.util.date import BUDGET_INTERVALS
 from fava.util.date import DateRange
 from fava.util.date import dateranges
 from fava.util.date import Day
 from fava.util.date import END_OF_YEAR
+from fava.util.date import Fortnight
 from fava.util.date import get_fiscal_period
 from fava.util.date import interval_ends
 from fava.util.date import INTERVALS
@@ -38,11 +41,37 @@ def test_interval() -> None:
     assert Day.label
 
 
+def test_fortnight_is_budget_only() -> None:
+    assert INTERVALS.get("fortnightly") is None
+    assert BUDGET_INTERVALS.get("fortnightly") is Fortnight
+    assert BUDGET_INTERVALS.get("fortnight") is Fortnight
+    assert BUDGET_INTERVALS.get("weekly") is Week
+    assert Fortnight.label
+
+
+def test_fortnight_blocks_are_fixed_14_days() -> None:
+    # 2020 has 53 ISO weeks; fortnights must stay contiguous and 14 days
+    # long across it rather than shrinking to a single week.
+    start = Fortnight.get_prev(date(2020, 12, 21))
+    for _ in range(6):
+        end = Fortnight.get_next(start)
+        assert (end - start).days == 14
+        assert start.weekday() == 0
+        for offset in range(14):
+            day = start + timedelta(offset)
+            assert Fortnight.get_prev(day) == start
+            assert Fortnight.number_of_days(day) == 14
+        start = end
+    assert Fortnight.get_next(date.max) == date.max
+
+
 @pytest.mark.parametrize(
     ("input_date_string", "interval", "expect"),
     [
         ("2016-01-01", Day, "2016-01-01"),
         ("2016-01-04", Week, "2016-W01"),
+        ("2016-01-04", Fortnight, "2016-01-04"),
+        ("2016-01-10", Fortnight, "2016-01-04"),
         ("2016-01-04", Month, "2016-01"),
         ("2016-01-04", Quarter, "2016-Q1"),
         ("2016-01-04", Year, "2016"),
@@ -61,6 +90,8 @@ def test_interval_format(
     [
         ("2016-01-01", Day, "2016-01-02"),
         ("2016-01-01", Week, "2016-01-04"),
+        ("2016-01-01", Fortnight, "2016-01-04"),
+        ("2016-12-31", Fortnight, "2017-01-02"),
         ("2016-01-01", Month, "2016-02-01"),
         ("2016-01-01", Quarter, "2016-04-01"),
         ("2016-01-01", Year, "2017-01-01"),
@@ -90,6 +121,8 @@ def test_get_next_interval_max() -> None:
     [
         ("2016-01-01", Day, "2016-01-01"),
         ("2016-01-01", Week, "2015-12-28"),
+        ("2016-01-01", Fortnight, "2015-12-21"),
+        ("2016-12-31", Fortnight, "2016-12-19"),
         ("2016-01-01", Month, "2016-01-01"),
         ("2016-01-01", Quarter, "2016-01-01"),
         ("2016-01-01", Year, "2016-01-01"),


### PR DESCRIPTION
Closes #1939.

Fortnightly pay and direct debits are common in Australia and New Zealand, so a budget of 29 AUD per fortnight is easier to state than 29 / 2 per week.

#1955 tried this as a report interval made of ISO week pairs and ran into 53-week years. This PR takes the narrower route the issue asked for: a fortnight is a fixed 14-day block starting on a Monday, counted from a fixed epoch, so consecutive fortnights never overlap and never shrink to one week, and the daily budget is always one fourteenth of the amount. It is exposed through a budget-only `BUDGET_INTERVALS` map and kept out of `INTERVALS`, so reports, charts, the time filter and the frontend are unchanged. If a fortnight report interval is wanted later, this class already has non-overlapping semantics to build on.

Tests cover the 53-week year 2020 (contiguous 14-day blocks), `date.max`, `format_date`, prev and next, and the budget calculation. Help page and CHANGES updated. No translation files touched.
