### PR TITLE
fix: don't clobber sidebar strings while truncating

### DIFF
--- a/frontend/src/sidebar/AsideContents.svelte
+++ b/frontend/src/sidebar/AsideContents.svelte
@@ -9,7 +9,7 @@
   import AccountSelector from "./AccountSelector.svelte";
   import Link from "./SidebarLink.svelte";
 
-  const truncate = (s: string) => (s.length < 25 ? s : `${s.slice(25)}…`);
+  const truncate = (s: string) => (s.length <= 25 ? s : `${s.slice(0, 24)}…`);
 
   let user_queries = $derived($ledger_data.user_queries);
   let upcoming_events_count = $derived($ledger_data.upcoming_events_count);


### PR DESCRIPTION
The `slice(25)` call here was turning "very long example string!" into "", and showing only "…" in the sidebar.

`slice(25)` means "everything from index 25 onwards", so it was effectively turning a 25-long string into the empty string. For queries longer than 25, it was taking the tail of the string, then appending an ellipse. For example, "a string that is longer than the other one", would show in the sidebar as "han the other one…"

The fixed version, `slice(0, 24)`, means "everything from index 0 to index 24":

```
> '012345678901234567890123456789'.slice(25)
'56789'
> '012345678901234567890123456789'.slice(0, 24)
'012345678901234567890123'
```

So it produces results like:

- "very long example string…"
- "a string that is longer …"

Note that the condition in the ternary has to be tweaked as well and we also need to do `slice(0, 24)` rather than `slice(0, 25)` in order for it all to make sense. The existing condition, `s.length < 25`, with a `slice(0, 25)`, would mean that:

- We end up taking a string that's 25 long, "trimming" it to 25 characters, and then appending an ellipsis, actually making it longer.
- If the string is 26 long, we trim it to 25 long, and then append an ellipsis, again producing a string that is 26 long, the same as the original string; we threw away one character of information for no benefit.
- If the string is 27 long, we trim it to 25 long, then append the ellipsis.

ie. only at 27 or longer does the trim-plus-ellipsize trick actually produce a shorter string. So, the ternary must be changed to check for `s.length <= 25` instead, and our slice becomes `slice(0, 24)`. This has the intended effect of ensuring we never show a string longer than 25 characters in the sidebar.