### PR TITLE
core: treat only real subaccounts as children of an account

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -11,6 +11,10 @@ bugs. As part of this, the undocumented `to` range separator (e.g. `2010 to
 `Decimal` and `Amount` can now be added as metadata values to entries and
 are also roundtripped correctly when set by importers.
 
+Accounts that merely share a name prefix with the account being viewed (like
+`Expenses:Carpet` and `Expenses:Car`) are no longer counted as its children in
+the account report charts and in budgets.
+
 v1.30.13 (2026-05-19)
 ---------------------
 

--- a/src/fava/beans/account.py
+++ b/src/fava/beans/account.py
@@ -39,6 +39,21 @@ def child_account_tester(account: str) -> Callable[[str], bool]:
     return is_child_account
 
 
+def any_child_account_tester(
+    accounts: str | tuple[str, ...],
+) -> Callable[[str], bool]:
+    """Get a function to check for a descendant of any of the accounts."""
+    if isinstance(accounts, str):
+        return child_account_tester(accounts)
+
+    testers = tuple(child_account_tester(account) for account in accounts)
+
+    def is_child_account(other: str) -> bool:
+        return any(tester(other) for tester in testers)
+
+    return is_child_account
+
+
 def account_tester(
     account: str, *, with_children: bool
 ) -> Callable[[str], bool]:

--- a/src/fava/core/__init__.py
+++ b/src/fava/core/__init__.py
@@ -18,6 +18,7 @@ from fava.beans.abc import Balance
 from fava.beans.abc import Price
 from fava.beans.abc import Transaction
 from fava.beans.account import account_tester
+from fava.beans.account import child_account_tester
 from fava.beans.account import get_entry_accounts
 from fava.beans.funcs import get_position
 from fava.beans.funcs import hash_entry
@@ -542,10 +543,9 @@ class FavaLedger:
         Returns:
             A pair of a list of Tree instances and the intervals.
         """
+        is_child_account = child_account_tester(account_name)
         min_accounts = [
-            account
-            for account in self.accounts
-            if account.startswith(account_name)
+            account for account in self.accounts if is_child_account(account)
         ]
 
         interval_ranges = list(reversed(filtered.interval_ranges(interval)))

--- a/src/fava/core/budgets.py
+++ b/src/fava/core/budgets.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 import msgspec
 from beancount.core.amount import Amount
 
+from fava.beans.account import child_account_tester
 from fava.core.module_base import FavaModule
 from fava.helpers import BeancountError
 from fava.util.date import days_in_daterange
@@ -202,8 +203,9 @@ def calculate_budget_children(
     """
     currency_dict: dict[str, Decimal] = Counter()  # type: ignore[assignment]  # ty:ignore[invalid-assignment]
 
+    is_child_account = child_account_tester(account)
     for child in budgets:
-        if child.startswith(account):
+        if is_child_account(child):
             currency_dict.update(
                 calculate_budget(budgets, child, date_from, date_to),
             )

--- a/src/fava/core/charts.py
+++ b/src/fava/core/charts.py
@@ -15,6 +15,7 @@ from msgspec import Struct
 
 from fava.beans.abc import Transaction
 from fava.beans.account import account_tester
+from fava.beans.account import any_child_account_tester
 from fava.beans.flags import FLAG_UNREALIZED
 from fava.beans.helpers import slice_entry_dates
 from fava.core.conversion import conversion_from_str
@@ -135,6 +136,7 @@ class ChartModule(FavaModule):
         """
         conv = conversion_from_str(conversion)
         prices = self.ledger.prices
+        is_child_account = any_child_account_tester(accounts)
 
         # limit the bar charts to 100 intervals
         intervals = filtered.interval_ranges(interval)[-100:]
@@ -149,7 +151,7 @@ class ChartModule(FavaModule):
             )
             for entry in entries:
                 for posting in getattr(entry, "postings", []):
-                    if posting.account.startswith(accounts):
+                    if is_child_account(posting.account):
                         account_inventories[posting.account].add_position(
                             posting,
                         )

--- a/src/fava/json_api.py
+++ b/src/fava/json_api.py
@@ -31,6 +31,7 @@ from msgspec.structs import astuple
 from fava import _structs  # noqa: TC001 - needed for msgspec
 from fava.beans.abc import Document
 from fava.beans.abc import Event
+from fava.beans.account import child_account_tester
 from fava.context import g
 from fava.core import EntryNotFoundForHashError
 from fava.core.conversion import UNITS
@@ -812,7 +813,10 @@ def get_account_report(
         all_accounts = (
             interval_balances[0].accounts if interval_balances else []
         )
-        budget_accounts = [acc for acc in all_accounts if acc.startswith(a)]
+        is_child_account = child_account_tester(a)
+        budget_accounts = [
+            acc for acc in all_accounts if is_child_account(acc)
+        ]
         budgets_mod = g.ledger.budgets
         first_date_range = dates[-1]
         budgets = {

--- a/tests/test_beans.py
+++ b/tests/test_beans.py
@@ -11,6 +11,7 @@ from fava.beans import create
 from fava.beans.abc import Note
 from fava.beans.abc import Price
 from fava.beans.account import account_tester
+from fava.beans.account import any_child_account_tester
 from fava.beans.account import parent
 from fava.beans.account import root
 from fava.beans.funcs import get_position
@@ -48,6 +49,26 @@ def test_account_tester() -> None:
     assert not is_equal("Assets:CashOther")
     assert is_equal("Assets:Cash")
     assert not is_equal("Assets:Cash:Test")
+
+
+def test_any_child_account_tester() -> None:
+    is_child = any_child_account_tester("Assets:Cash")
+    assert not is_child("Assets")
+    assert not is_child("Assets:CashOther")
+    assert is_child("Assets:Cash")
+    assert is_child("Assets:Cash:Test")
+
+    is_child = any_child_account_tester(("Assets:Cash", "Expenses:Car"))
+    assert not is_child("Assets")
+    assert not is_child("Assets:CashOther")
+    assert not is_child("Expenses:Carpet")
+    assert is_child("Assets:Cash")
+    assert is_child("Assets:Cash:Test")
+    assert is_child("Expenses:Car")
+    assert is_child("Expenses:Car:Fuel")
+
+    is_child = any_child_account_tester(())
+    assert not is_child("Assets:Cash")
 
 
 def test_hash_entry() -> None:

--- a/tests/test_core_budgets.py
+++ b/tests/test_core_budgets.py
@@ -145,3 +145,28 @@ def test_budgets_children(budgets_doc: BudgetDict) -> None:
         date(2017, 1, 2),
     )
     assert budget["USD"] == Decimal("2.00")
+
+
+def test_budgets_children_sibling_with_shared_prefix(
+    budgets_doc: BudgetDict,
+) -> None:
+    """
+    2017-01-01 custom "budget" Expenses:Car "daily" 10.00 USD
+    2017-01-01 custom "budget" Expenses:Car:Fuel "daily" 1.00 USD
+    2017-01-01 custom "budget" Expenses:Carpet "daily" 100.00 USD"""
+
+    budget = calculate_budget_children(
+        budgets_doc,
+        "Expenses:Car",
+        date(2017, 1, 1),
+        date(2017, 1, 2),
+    )
+    assert budget["USD"] == Decimal("11.00")
+
+    budget = calculate_budget_children(
+        budgets_doc,
+        "Expenses:Carpet",
+        date(2017, 1, 1),
+        date(2017, 1, 2),
+    )
+    assert budget["USD"] == Decimal("100.00")

--- a/tests/test_core_charts.py
+++ b/tests/test_core_charts.py
@@ -1,14 +1,16 @@
 from __future__ import annotations
 
 from decimal import Decimal
+from textwrap import dedent
 from typing import TYPE_CHECKING
 
+from fava.core import FavaLedger
 from fava.core.conversion import AT_COST
 from fava.util.date import Day
 from fava.util.date import Month
 
 if TYPE_CHECKING:  # pragma: no cover
-    from fava.core import FavaLedger
+    from pathlib import Path
 
     from .conftest import GetFavaLedger
     from .conftest import SnapshotFunc
@@ -103,3 +105,47 @@ def test_hierarchy(example_ledger: FavaLedger) -> None:
     etrade = data.children[1].children[2]
     assert etrade.account == "Assets:US:ETrade"
     assert etrade.balance_children == {"USD": Decimal("23137.54")}
+
+
+def test_interval_totals_sibling_with_shared_prefix(tmp_path: Path) -> None:
+    """Accounts that merely share a name prefix are not children."""
+    ledger_path = tmp_path / "prefix.beancount"
+    ledger_path.write_text(
+        dedent("""\
+            option "operating_currency" "USD"
+
+            2016-01-01 open Assets:Cash
+            2016-01-01 open Expenses:Car
+            2016-01-01 open Expenses:Car:Fuel
+            2016-01-01 open Expenses:Carpet
+
+            2016-01-05 * "fuel"
+              Expenses:Car:Fuel    1.00 USD
+              Assets:Cash
+
+            2016-01-05 * "repair"
+              Expenses:Car        10.00 USD
+              Assets:Cash
+
+            2016-01-05 * "carpet - not a child of Expenses:Car"
+              Expenses:Carpet    100.00 USD
+              Assets:Cash
+            """),
+        encoding="utf-8",
+    )
+    ledger = FavaLedger(str(ledger_path))
+    filtered = ledger.get_filtered()
+
+    (interval,) = ledger.charts.interval_totals(
+        filtered, Month, "Expenses:Car", "USD"
+    )
+    assert interval.balance["USD"] == Decimal("11.00")
+    assert set(interval.account_balances) == {
+        "Expenses:Car",
+        "Expenses:Car:Fuel",
+    }
+
+    (interval,) = ledger.charts.interval_totals(
+        filtered, Month, "Expenses:Carpet", "USD"
+    )
+    assert interval.balance["USD"] == Decimal("100.00")


### PR DESCRIPTION
Ancestry between accounts is tested with a plain `str.startswith` in a few
places, so an account that merely shares a *name prefix* with the account
being viewed is treated as one of its children.

With a ledger that has both `Expenses:Car` and `Expenses:Carpet`, the account
report for `Expenses:Car` currently adds `Expenses:Carpet` to its own numbers:

```beancount
option "operating_currency" "USD"

2016-01-01 open Assets:Cash
2016-01-01 open Expenses:Car
2016-01-01 open Expenses:Car:Fuel
2016-01-01 open Expenses:Carpet

2016-01-05 * "fuel"
  Expenses:Car:Fuel    1.00 USD
  Assets:Cash

2016-01-05 * "repair"
  Expenses:Car        10.00 USD
  Assets:Cash

2016-01-05 * "carpet - not a child of Expenses:Car"
  Expenses:Carpet    100.00 USD
  Assets:Cash
```

`interval_totals(..., "Expenses:Car", "USD")` reports `111.00 USD` for January
and lists `Expenses:Carpet` in `account_balances`; the correct value is
`11.00 USD`. The same happens to the budget shown next to that chart —
`calculate_budget_children` sums `Expenses:Carpet`'s budget into
`Expenses:Car`'s.

The intended semantics are already spelled out in the test suite
(`test_account_tester` asserts `not is_child("Assets:CashOther")`), and
`fava.beans.account.child_account_tester` already implements them. It is even
used by the neighbouring functions in the same two modules —
`ChartModule.account_balance` and `FavaLedger.account_journal` both go through
`account_tester(..., with_children=True)`. The call sites changed here just
never got switched over.

### Changes

* `fava/core/charts.py` — `interval_totals`: the posting filter. This is the
  user-visible one, it is what produces the wrong chart total above.
* `fava/core/budgets.py` — `calculate_budget_children`: the wrong budget total.
* `fava/json_api.py` — `get_account_report`: the list of accounts budgets get
  computed for.
* `fava/core/__init__.py` — `interval_balances`: same flaw, but as far as I can
  tell not user-visible today, since only the `tree.get(a)` subtree is
  serialised. Changed for consistency — happy to drop this hunk if you'd
  rather keep the diff to the actual defects.

`interval_totals` takes either a single account or a tuple of them, so I added
`any_child_account_tester` next to the existing helpers for that one call site.

`Expenses`/`Income` prefix checks against the account *type* names (e.g. in
`net_worth`) are left alone — Beancount constrains the root component to the
five configured type names, so no collision is possible there.

### Tests

Three regression tests: the helper itself, the budget total, and the chart
total. The chart one builds a small ledger in `tmp_path` rather than adding a
fixture ledger; let me know if you'd prefer it as a file under `tests/data`.

Verified against the test suite — no snapshots move, the only failures are the
three that already fail in my environment for unrelated reasons (missing built
frontend assets and compiled translations). `ruff check`, `ruff format --check`
and `mypy` are clean on the touched files.

---

Disclosure: this patch was written by an AI agent. A human is accountable for
it, and I'll respond to review comments here. Happy to adjust scope, naming or
test placement to whatever you prefer.
